### PR TITLE
KCore/XCore/Envs - modif to Envs for i8, fix i8 install in XCore

### DIFF
--- a/Cassiopee/Envs/sh_Cassiopee_local
+++ b/Cassiopee/Envs/sh_Cassiopee_local
@@ -45,6 +45,16 @@ MAC0=$(echo $KC | grep 'node6.cluster'); if [ "$MAC0" != "" ]; then export MAC="
 MAC0=$(echo $KC | grep 'topaze'); if [ "$MAC0" != "" ]; then export MAC="topaze"; fi
 MAC0=$(echo $KC | grep 'Aryen'); if [ "$MAC0" != "" ]; then export MAC="aryen"; fi
 
+# Detect the type of integer that is used
+INTTYPE=""
+if [[ $MACHINE == *_i8 ]]; then
+    MACHINE=${MACHINE%"_i8"}
+    INTTYPE="_i8"
+elif [ "$MACHINE" == "i8" ]; then
+    MACHINE=""
+    INTTYPE="_i8"
+fi
+
 if [ "$MACHINE" != "" ]; then
     export MAC=$MACHINE
 fi
@@ -54,7 +64,7 @@ echo $MAC0
 
 if [ "$MAC" = "ld_eos8" ]; then
 #------------------------------- ld centos 8 + python 3 -----------------------------------
-    export ELSAPROD=eos8_r8
+    export ELSAPROD=eos8_r8$INTTYPE
     #module unload $(module -t list 2>&1 | grep -i intel)
     #module purge
     module unload intel/19.0.5
@@ -81,7 +91,7 @@ if [ "$MAC" = "ld_eos8" ]; then
 
 elif [ "$MAC" = "ld" ]; then
 #------------------------------- ld centos 8 + python 3 -----------------------------------
-    export ELSAPROD=ld
+    export ELSAPROD=ld$INTTYPE
     module purge
     module load occt/7.6.1-gnu831
     module load python/3.8.14-gnu831
@@ -105,7 +115,7 @@ elif [ "$MAC" = "ld" ]; then
 
 elif [ "$MAC" = "ld_python2" ]; then
 #------------------------------- ld centos 7 -----------------------------------
-    export ELSAPROD=x86_r8
+    export ELSAPROD=x86_r8$INTTYPE
     module unload $(module -t list 2>&1 | grep -i intel)
     module load python/2.7.8
     module load intel/17.0.4
@@ -127,7 +137,7 @@ elif [ "$MAC" = "ld_python2" ]; then
 
 elif [ "$MAC" = "eos" ]; then
 #------------------------------- eos -----------------------------------
-    export ELSAPROD=x86_r8
+    export ELSAPROD=x86_r8$INTTYPE
     module unload $(module -t list 2>&1 | grep -i intel)
     module load python/2.7.8
     module load intel/17.0.4
@@ -149,7 +159,7 @@ elif [ "$MAC" = "eos" ]; then
 
 elif [ "$MAC" = "macosx" ]; then
 #----------------------------- Mac OSX-----------------------------------------
-    export ELSAPROD=macosx_r8
+    export ELSAPROD=macosx_r8$INTTYPE
     export OMP_NUM_THREADS=2
     export PATH=$CASSIOPEE/Dist/bin/"$ELSAPROD":$PATH
     export LD_LIBRARY_PATHL=$CASSIOPEE/Dist/bin/"$ELSAPROD":$CASSIOPEE/Dist/bin/"$ELSAPROD"/lib:/opt/intel/composer_xe_2015/lib
@@ -160,12 +170,12 @@ elif [ "$MAC" = "macosx" ]; then
 
 elif [ "$MAC" = "sgi" ]; then
 #-------------------------------- SGI -----------------------------------------
-    export ELSAPROD=sgi_r8
+    export ELSAPROD=sgi_r8$INTTYPE
     export LD_LIBRARY_PATHL=/tools/py/tmp/local/lib/:$CASSIOPEE/Kernel/lib/$ELSAPROD
 
 elif [ "$MAC" = "mangrove" ]; then
 #-------------------------------- mangrove -------------------------------------
-    export ELSAPROD=man_r8
+    export ELSAPROD=man_r8$INTTYPE
     export OMP_NUM_THREADS=4
     export PATH=$PATH:$CASSIOPEE/Dist/bin
     export PATH=$CASSIOPEE/Dist/bin/$ELSAPROD:$CASSIOPEE/Dist/bin/$ELSAPROD/bin:$PATH
@@ -174,7 +184,7 @@ elif [ "$MAC" = "mangrove" ]; then
 
 elif [ "$MAC" = "ubuntu" ]; then
 #-------------------------------- ubuntu --------------------------------------
-    export ELSAPROD=ub_r8
+    export ELSAPROD=ub_r8$INTTYPE
     export OMP_NUM_THREADS=2
     export PATH=$PATH:$CASSIOPEE/Dist/bin
     export PATH=$CASSIOPEE/Dist/bin/$ELSAPROD:$CASSIOPEE/Dist/bin/$ELSAPROD/bin:$PATH
@@ -183,7 +193,7 @@ elif [ "$MAC" = "ubuntu" ]; then
 
 elif [ "$MAC" = "fulvio" ]; then
 #----------------------------- fulvio -----------------------------------------
-    export ELSAPROD=flv_r8
+    export ELSAPROD=flv_r8$INTTYPE
     module unload $(module -t list 2>&1 | grep -i intel)
     module load gcc/4.8.1
     module load intel/15.0.6
@@ -199,7 +209,7 @@ elif [ "$MAC" = "fulvio" ]; then
 
 elif [ "$MAC" = "visio" ]; then
 #----------------------------- visio -----------------------------------------
-    export ELSAPROD=vis_r8
+    export ELSAPROD=vis_r8$INTTYPE
     . /etc/profile.d/modules-dri.sh
     module load subversion/1.7.6
     module load python/2.7.8
@@ -216,7 +226,7 @@ elif [ "$MAC" = "visio" ]; then
 
 elif [ "$MAC" = "spiro_gcc" ]; then
 #----------------------------- spiro -----------------------------------------
-    export ELSAPROD=spiro_gcc
+    export ELSAPROD=spiro_gcc$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=24
     module purge
@@ -238,7 +248,7 @@ elif [ "$MAC" = "spiro_gcc" ]; then
 
 elif [ "$MAC" = "visung" ]; then
 #----------------------------- visung -----------------------------------------
-    export ELSAPROD=visung_r8
+    export ELSAPROD=visung_r8$INTTYPE
     . /etc/profile.d/modules-onera.sh
     module purge
     module load subversion
@@ -260,7 +270,7 @@ elif [ "$MAC" = "visung" ]; then
 
 elif [ "$MAC" = "visung_el8" ]; then
 #----------------------------- visung -----------------------------------------
-    export ELSAPROD=visung_el8
+    export ELSAPROD=visung_el8$INTTYPE
     #. /etc/profile.d/modules-dri.sh
     module purge
     module load subversion
@@ -281,7 +291,7 @@ elif [ "$MAC" = "visung_el8" ]; then
 
 elif [ "$MAC" = "austri" ]; then
 #----------------------------- austri -----------------------------------------
-    export ELSAPROD=aus_r8
+    export ELSAPROD=aus_r8$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=24
     export KMP_AFFINITY="verbose,granularity=fine,proclist=[0,2,4,6,8,10,12,14,16,18,20,22,1,3,5,7,9,11,13,15,17,19,21,23],explicit"
@@ -302,7 +312,7 @@ elif [ "$MAC" = "austri" ]; then
 
 elif [ "$MAC" = "moloch" ]; then
 #----------------------------- moloch -----------------------------------------
-    export ELSAPROD=mol_r8
+    export ELSAPROD=mol_r8$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=12
     # modules
@@ -317,7 +327,7 @@ elif [ "$MAC" = "moloch" ]; then
 
 elif [ "$MAC" = "giulia" ]; then
 #----------------------------- giulia -----------------------------------------
-    export ELSAPROD=giu_r8
+    export ELSAPROD=giu_r8$INTTYPE
     # Nbre de threads
     ncpu=$(grep processor /proc/cpuinfo |tail -1 |cut -f2 -d: )
     ncpu=$((ncpu + 1 ))
@@ -344,7 +354,7 @@ elif [ "$MAC" = "giulia" ]; then
 
 elif [ "$MAC" = "cobalt" ]; then
 #-------------------------------- cobalt -----------------------------------------
-    export ELSAPROD=cob_r8
+    export ELSAPROD=cob_r8$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=28
 
@@ -365,7 +375,7 @@ elif [ "$MAC" = "cobalt" ]; then
 
 elif [ "$MAC" = "tgcc_irene" ]; then
 #-------------------------------- irene -----------------------------------------
-    export ELSAPROD=irene_r8
+    export ELSAPROD=irene_r8$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=24
     echo 'TGCC_IRENE SH_CASSIOPEE_LOCAL _v2'
@@ -385,7 +395,7 @@ elif [ "$MAC" = "tgcc_irene" ]; then
 
 elif [ "$MAC" = "jean-zay" ]; then
 #-------------------------------- jean-zay -----------------------------------------
-    export ELSAPROD=jz_r8
+    export ELSAPROD=jz_r8$INTTYPE
     module load python/3.8.2
     module load gcc/9.1.0-cuda-openacc
     module load openmpi/4.1.1-cuda
@@ -402,7 +412,7 @@ elif [ "$MAC" = "jean-zay" ]; then
 
 elif [ "$MAC" = "xdaap" ]; then
 #----------------------------- xdaap -----------------------------------------
-    export ELSAPROD=xdaap_r8
+    export ELSAPROD=xdaap_r8$INTTYPE
     . /etc/profile.d/modules-dri.sh
     module unload $(module -t list 2>&1 | grep -i intel)
     module load gcc/5.2
@@ -419,7 +429,7 @@ elif [ "$MAC" = "xdaap" ]; then
 
 elif [ "$MAC" = "spiro" ]; then
 #----------------------------- spiro -----------------------------------------
-    export ELSAPROD=spiro_r8
+    export ELSAPROD=spiro_r8$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=24
     # modules
@@ -443,7 +453,7 @@ elif [ "$MAC" = "spiro" ]; then
 
 elif [ "$MAC" = "spiro_sky" ]; then
 #----------------------------- spiro -----------------------------------------
-    export ELSAPROD=spiro_sky_r8
+    export ELSAPROD=spiro_sky_r8$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=24
     # modules
@@ -466,7 +476,7 @@ elif [ "$MAC" = "spiro_sky" ]; then
 
 elif [ "$MAC" = "spiro_cas" ]; then
 #----------------------------- spiro -----------------------------------------
-    export ELSAPROD=spiro_cas_r8
+    export ELSAPROD=spiro_cas_r8$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=24
     # modules
@@ -489,7 +499,7 @@ elif [ "$MAC" = "spiro_cas" ]; then
 
 elif [ "$MAC" = "spiro_amdRM" ]; then
 #----------------------------- spiro -----------------------------------------
-    export ELSAPROD=spiro_amdrm_r8
+    export ELSAPROD=spiro_amdrm_r8$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=32
     # modules
@@ -513,7 +523,7 @@ elif [ "$MAC" = "spiro_amdRM" ]; then
 
 elif [ "$MAC" = "spiro_amdNP" ]; then
 #----------------------------- spiro -----------------------------------------
-    export ELSAPROD=spiro_amdnp_r8
+    export ELSAPROD=spiro_amdnp_r8$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=32
     # modules
@@ -537,7 +547,7 @@ elif [ "$MAC" = "spiro_amdNP" ]; then
 
 elif [ "$MAC" = "spiro_socle6" ]; then
 #----------------------------- spiro -----------------------------------------
-    export ELSAPROD=spiro_socle_r8
+    export ELSAPROD=spiro_socle_r8$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=24
     # modules
@@ -557,7 +567,7 @@ elif [ "$MAC" = "spiro_socle6" ]; then
 
 elif [ "$MAC" = "spiro_sonics" ]; then
 #----------------------------- spiro sonics -----------------------------------------
-    export ELSAPROD=linux64
+    export ELSAPROD=linux64$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=24
     # modules
@@ -576,7 +586,7 @@ elif [ "$MAC" = "spiro_sonics" ]; then
 
 elif [ "$MAC" = "spiro_python2" ]; then
 #----------------------------- spiro -----------------------------------------
-    export ELSAPROD=spiro_r8
+    export ELSAPROD=spiro_r8$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=24
     # modules
@@ -595,7 +605,7 @@ elif [ "$MAC" = "spiro_python2" ]; then
 
 elif [ "$MAC" = "spiro_anaconda" ]; then
 #----------------------------- spiro -----------------------------------------
-    export ELSAPROD=spiro_acda
+    export ELSAPROD=spiro_acda$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=24
     # modules
@@ -619,7 +629,7 @@ elif [ "$MAC" = "spiro_anaconda" ]; then
 
 elif [ "$MAC" = "spiro_el8" ]; then
 #----------------------------- spiro -----------------------------------------
-    export ELSAPROD=spiro_el8
+    export ELSAPROD=spiro_el8$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=24
     # modules
@@ -651,7 +661,7 @@ elif [ "$MAC" = "spiro_el8" ]; then
 
 elif [ "$MAC" = "spiro_intel" ]; then
 #----------------------------- spiro -----------------------------------------
-    export ELSAPROD=spiro_intel
+    export ELSAPROD=spiro_intel$INTTYPE
     echo $ELSAPROD
     # Nbre de threads
     export OMP_NUM_THREADS=24
@@ -670,7 +680,7 @@ elif [ "$MAC" = "spiro_intel" ]; then
 
 elif [ "$MAC" = "spiro_coda" ]; then
 #----------------------------- spiro -----------------------------------------
-    export ELSAPROD=spiro_coda
+    export ELSAPROD=spiro_coda$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=24
     # modules
@@ -688,7 +698,7 @@ elif [ "$MAC" = "spiro_coda" ]; then
 
 elif [ "$MAC" = "spiro_arm" ]; then
 #----------------------------- spiro -----------------------------------------
-    export ELSAPROD=spiro_arm
+    export ELSAPROD=spiro_arm$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=56
     export PYTHONEXE=python3
@@ -701,7 +711,7 @@ elif [ "$MAC" = "spiro_arm" ]; then
 
 elif [ "$MAC" = "spiro_pgi" ]; then
 #----------------------------- spiro -----------------------------------------
-    export ELSAPROD=spiro_pgi
+    export ELSAPROD=spiro_pgi$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=24
     export PYTHONEXE=python3
@@ -718,7 +728,7 @@ elif [ "$MAC" = "spiro_pgi" ]; then
 
 elif [ "$MAC" = "juno" ]; then
 #----------------------------- juno -----------------------------------------
-    export ELSAPROD=juno
+    export ELSAPROD=juno$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=48
     # modules
@@ -750,7 +760,7 @@ elif [ "$MAC" = "juno" ]; then
 
 elif [ "$MAC" = "juno_gcc" ]; then
 #----------------------------- juno -----------------------------------------
-    export ELSAPROD=juno_gcc
+    export ELSAPROD=juno_gcc$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=48
     # modules
@@ -784,7 +794,7 @@ elif [ "$MAC" = "juno_gcc" ]; then
 
 elif [ "$MAC" = "juno_coda" ]; then
 #----------------------------- juno -----------------------------------------
-    export ELSAPROD=juno_coda
+    export ELSAPROD=juno_coda$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=48
     # modules
@@ -803,7 +813,7 @@ elif [ "$MAC" = "juno_coda" ]; then
 elif [ "$MAC" = "sator_brw" ]; then
 #----------------------------- sator for broadwell -----------------------------------------
     echo 'SATOR - BROADWELL PARTITION'
-    export ELSAPROD=sat_r8
+    export ELSAPROD=sat_r8$INTTYPE
 
     echo "Pour compiler sur skylake, export MACHINE=sator_sky, puis sourcer sh_Cassiopee_r8"
 
@@ -837,7 +847,7 @@ elif [ "$MAC" = "sator_brw" ]; then
 elif [ "$MAC" = "topaze" ]; then
 #----------------------------- topaze ccrt proc amd milan ---------------------------------------
     echo 'topaze - Milan PARTITION'
-    export ELSAPROD=topaze_r8
+    export ELSAPROD=topaze_r8$INTTYPE
     . /etc/profile.d/module.sh
     module purge
     module load intel/20 mpi/openmpi/4 flavor/hdf5/parallel hdf5/1.8.20
@@ -862,7 +872,7 @@ elif [ "$MAC" = "topaze" ]; then
 elif [ "$MAC" = "sator_sky" ]; then
 #----------------------------- sator skylake ---------------------------------------
     echo 'SATOR - SKYLAKE PARTITION'
-    export ELSAPROD=sat_sky_r8
+    export ELSAPROD=sat_sky_r8$INTTYPE
     . /etc/profile.d/module.sh
     module purge
     #module load socle-cfd/5.0-intel2120-impi
@@ -887,7 +897,7 @@ elif [ "$MAC" = "sator_sky" ]; then
 elif [ "$MAC" = "sator_cas" ]; then
     #----------------------------- sator for cascade ---------------------------------------
     echo 'SATOR - CASCADE PARTITION'
-    export ELSAPROD=sat_cas_r8
+    export ELSAPROD=sat_cas_r8$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=48
     export KMP_AFFINITY="compact,1,0,granularity=fine,verbose"
@@ -914,7 +924,7 @@ elif [ "$MAC" = "sator_cas" ]; then
 
 elif [ "$MAC" = "jean-zay" ]; then
 #-----------------------------jean-zay IDRIS  ---------------------------------------
-    export ELSAPROD=jz_r8
+    export ELSAPROD=jz_r8$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=40
     export KMP_AFFINITY="compact,1,0,granularity=fine,verbose"
@@ -937,7 +947,7 @@ elif [ "$MAC" = "jean-zay" ]; then
 
 elif [ "$MAC" = "aryen" ]; then
 #----------------------------- Aryen msys2  ---------------------------------------
-    export ELSAPROD=win64
+    export ELSAPROD=win64$INTTYPE
     # Nbre de threads
     export OMP_NUM_THREADS=2
 

--- a/Cassiopee/KCore/Dist.py
+++ b/Cassiopee/KCore/Dist.py
@@ -82,10 +82,13 @@ def getenv(name):
 # Get name of the Data folder
 #==============================================================================
 def getDataFolderName(name='Data'):
-    prod = os.getenv("ELSAPROD")
-    if prod is not None: prod = prod.split('_')[0]
-    else: prod = 'xx'
-    intType = 'i8' if EDOUBLEINT else 'i4'
+    elsaprod = os.getenv("ELSAPROD")
+    if elsaprod is not None:
+        intType = 'i8' if elsaprod.endswith('_i8') else 'i4'
+        prod = elsaprod.replace('_i8', '')
+    else:
+        prod = 'xx'
+        intType = 'i4'
     if sys.version_info[0] == 2: name += '2'
     if prod not in 'juno': name += '_' + prod
     if intType == 'i8': name += '_' + intType

--- a/Cassiopee/KCore/config.py
+++ b/Cassiopee/KCore/config.py
@@ -29,6 +29,7 @@ dict = installBase.installDict
 key = ''
 # prod est tout d'abord cherche dans le dictionnaire
 if prod is not None:
+    if prod.endswith('_i8'): prod = prod[:-3]
     for i in dict:
         if re.compile(i).search(prod) is not None:
             key = i; break

--- a/Cassiopee/XCore/XCore/intersectMesh/struct.h
+++ b/Cassiopee/XCore/XCore/intersectMesh/struct.h
@@ -148,12 +148,12 @@ struct edge {
 struct segment {
   vertex *p;
   vertex *q;
-  E_Int id;
+  int id;
   hedge *rep;
 
-  segment(hedge *, E_Int);
+  segment(hedge *, int);
   segment(edge *);
-  segment(vertex *, vertex *, E_Int);
+  segment(vertex *, vertex *, int);
   inline int color() { return rep ? rep->color : NO_IDEA; }
 };
 
@@ -164,7 +164,7 @@ struct event {
   event *left;
   event *right;
   
-  event(E_Float x, E_Float y, E_Int i);
+  event(E_Float x, E_Float y, int i);
   event(vertex *);
   void print();
   void inorder(std::vector<vertex *> &);
@@ -189,7 +189,7 @@ struct queue {
   void inorder(std::vector<vertex *> &);
 
   event *insert(vertex *);
-  event *insert(E_Float, E_Float, E_Int);
+  event *insert(E_Float, E_Float, int);
   void erase(event *);
   void erase(vertex *);
   event *min();
@@ -199,7 +199,7 @@ struct queue {
   int empty();
 
   event *_insert(event *&, vertex *);
-  event *_insert(event *&, E_Float, E_Float, E_Int);
+  event *_insert(event *&, E_Float, E_Float, int);
   event *_erase(event *, vertex *);
   event *_locate(event *, E_Float, E_Float);
   event *_lookup(event *, vertex *);

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 Cassiopee 4
 
 -- Under construction --
-
-test imad


### PR DESCRIPTION
- ELSAPROD is appended the "_i8" suffix for i8 installs which can be done by setting the env. var. MACHINE explicitly:
  + If MACHINE is unset, set MAC to `uname -n` (i4 install)
  + If MACHINE is "i8", set MAC to `uname -n` and the "_i8" suffix is added to ELSAPROD
  + If MACHINE is "spiro", MAC="spiro" (i4 install)
  + If MACHINE is "spiro_i8", MAC="spiro" and the "_i8" suffix is added to ELSAPROD

- Cassiopee now compiles in i8