### PR TITLE
KCore: booleans in i8 and notifications

### DIFF
--- a/Cassiopee/Generator/Generator/close.cpp
+++ b/Cassiopee/Generator/Generator/close.cpp
@@ -41,7 +41,7 @@ PyObject* K_GENERATOR::closeMesh(PyObject* self, PyObject* args)
   E_Bool rmDegeneratedFaces = true;
   E_Bool rmDegeneratedElts = true;
   
-  if (!PYPARSETUPLE_(args, O_ R_ II_ IIII_,
+  if (!PYPARSETUPLE_(args, O_ R_ BB_ BBBB_,
                     &array, &eps, &rmOverlappingPts, &rmOrphanPts,
                     &rmDuplicatedFaces, &rmDuplicatedElts,
                     &rmDegeneratedFaces, &rmDegeneratedElts)) return NULL;
@@ -51,7 +51,7 @@ PyObject* K_GENERATOR::closeMesh(PyObject* self, PyObject* args)
   FldArrayF* f; FldArrayI* cn;
   char* varString; char* eltType;
 
-  E_Int res = K_ARRAY::getFromArray(array, varString, f, im, jm, km, cn, eltType);
+  E_Int res = K_ARRAY::getFromArray3(array, varString, f, im, jm, km, cn, eltType);
   E_Int posx = K_ARRAY::isCoordinateXPresent(varString);
   E_Int posy = K_ARRAY::isCoordinateYPresent(varString);
   E_Int posz = K_ARRAY::isCoordinateZPresent(varString);

--- a/Cassiopee/KCore/KCore/Array/Array.h
+++ b/Cassiopee/KCore/KCore/Array/Array.h
@@ -108,6 +108,10 @@
 #define TRRR_ "(fff)"
 #define TRRRR_ "(ffff)"
 #endif
+#define B_ "i"
+#define BB_ "ii"
+#define BBB_ "iii"
+#define BBBB_ "iiii"
 #define O_ "O"
 #define OO_ "OO"
 #define OOO_ "OOO"

--- a/Cassiopee/KCore/installLib.py
+++ b/Cassiopee/KCore/installLib.py
@@ -42,6 +42,7 @@ shutil.copyfile("Dist.py", installPath+"/Dist.py")
 shutil.copyfile("installPath.py", installPath+"/installPath.py")
 shutil.copyfile("installBase.py", installPath+"/installBase.py")
 shutil.copyfile("test/notify.py", installPath+"/notify.py")
+shutil.copyfile("test/notifyInstall.py", installPath+"/notifyInstall.py")
 
 # Ecrit les infos d'install
 Dist.writeBuildInfo()

--- a/Cassiopee/KCore/test/notifyInstall.py
+++ b/Cassiopee/KCore/test/notifyInstall.py
@@ -19,8 +19,7 @@ def parseArgs():
 if __name__ == '__main__':
   script_args = parseArgs()
   recipients = script_args.recipients.split(' ')
-  if not recipients[0]:
-    recipients = ['vincent.casseau@onera.fr', 'christophe.benoit@onera.fr']
+  if not recipients[0]: recipients = []
   
   # Check install status
   log_entries = []


### PR DESCRIPTION
- booleans map to C int in int32 and int64, create B in Array.h
- any user can receive an update listing the machines on which Cassiopee is installed, their date and their status (OK/FAILED)
  + set the env. variable `CASSIOPEE_EMAIL` as `export CASSIOPEE_EMAIL=firstname.lastname@onera.fr`
  + execute the following command: `python $CASSIOPEE/Cassiopee/KCore/test/notifyInstall.py`

Example:

```
Installation of Cassiopee and Fast:
----------------------------------

                  ld |      17/06/24 at 14:54:10      |         OK
        sator_cas_i8 |      17/06/24 at 14:25:15      |         OK
        spiro_el8_i8 |      17/06/24 at 14:05:34      |         OK
           sator_cas |      17/06/24 at 14:00:39      |         OK
           spiro_el8 |      17/06/24 at 14:00:23      |         OK
```