### PR TITLE
Connector.IBM: optimize final distribution operations

### DIFF
--- a/Cassiopee/Connector/Connector/IBM.py
+++ b/Cassiopee/Connector/Connector/IBM.py
@@ -358,11 +358,12 @@ def _redispatch__(t=None, tc=None, tc2=None, twoFronts=False):
     if tc is not None: 
         algo = 'graph'
         tskel = Cmpi.convert2SkeletonTree(tc)
+        Internal._rmNodesByType(tskel, 'ZoneSubRegion_t')
         tcs    = Cmpi.allgatherTree(tskel)
         stats  = D2._distribute(tcs, Cmpi.size, algorithm=algo)
 
         D2._copyDistribution(tc, tcs)
-        D2mpi._redispatch(tc)
+        D2mpi._redispatch(tc, verbose=1)
 
         if t is not None: 
             D2._copyDistribution(t, tcs)
@@ -378,7 +379,7 @@ def _redispatch__(t=None, tc=None, tc2=None, twoFronts=False):
         stats = D2._distribute(ts, Cmpi.size, algorithm=algo)
         D2._copyDistribution(t, ts)
         del ts
-        D2mpi._redispatch(t)
+        D2mpi._redispatch(t, verbose=1)
 
     return None
 

--- a/Cassiopee/Distributor2/Distributor2/Mpi.py
+++ b/Cassiopee/Distributor2/Distributor2/Mpi.py
@@ -8,13 +8,60 @@ from . import PyTree as D2
 # redispatch
 # IN: graph: graph 'proc'
 #==============================================================================
-def redispatch(t, graph=None):
+def redispatch(t, graph=None, verbose=0):
     """Redistribute tree from graph."""
     tp = Internal.copyRef(t)
-    _redispatch(tp, graph)
+    _redispatch(tp, graph, verbose)
     return tp
 
-def _redispatch(t, graph=None):
+def _redispatch(t, graph=None, verbose=0):
+    """Redistribute tree from graph."""
+    import copy
+
+    if graph is None: graph = Cmpi.computeGraph(t, type='proc')
+
+    nzonesMax = len(Internal.getZones(t))
+
+    for i in range(1, Cmpi.size):
+        graph_local = copy.deepcopy(graph)
+        
+        for rank in range(Cmpi.size): # create a local 2 by 2 connectivity graph to reduce memory consumption
+            if rank not in graph_local: graph_local[rank] = {}
+            else:
+                opp_rank = (rank+i)%Cmpi.size
+                if opp_rank in graph_local[rank]: graph_local[rank] = {opp_rank: graph_local[rank][opp_rank]}
+                else: graph_local[rank] = {}
+
+        Cmpi._addXZones(t, graph_local)
+
+        nzonesMax = max(nzonesMax, len(Internal.getZones(t)))
+        
+        for z in Internal.getZones(t):
+            tag = Internal.getNodeFromName1(z, 'XZone')
+            if tag is None:
+                proc = Cmpi.getProc(z)
+                if proc == (Cmpi.rank+i)%Cmpi.size:
+                    (p, c) = Internal.getParentOfNode(t, z)
+                    del p[2][c]
+            else: # remove node tag xzone
+                (p, c) = Internal.getParentOfNode(z, tag)
+                del p[2][c]
+
+    if verbose > 0:
+        nzones = len(Internal.getZones(t))
+        Cmpi.barrier()
+        print("Info: _redispatch: proc {} has {} zones (max #zones during operation {} (+{:2.2f}%))".format(Cmpi.rank, nzones, nzonesMax, (nzonesMax-nzones)/float(nzones)*100.), flush=True)
+        Cmpi.barrier()
+
+    return None
+
+def redispatch_old(t, graph=None):
+    """Redistribute tree from graph."""
+    tp = Internal.copyRef(t)
+    _redispatch_old(tp, graph)
+    return tp
+
+def _redispatch_old(t, graph=None):
     """Redistribute tree from graph."""
     if graph is None:
         graph = Cmpi.computeGraph(t, type='proc')


### PR DESCRIPTION
Reduces the risk of memory overflows during tree redispatching at the end of IBM preprocessing

Connector.IBM : removes ZoneSubRegion_t from skeleton tree (ID* and IBCD* zones)
Distributor2.Mpi : splits addXZones into (Cmpi.size - 1)*addXZones 