### PR TITLE
[IBM] Update Wire Mesh Model test cases

### DIFF
--- a/Cassiopee/Apps/test/FastIBMWireMeshModel_t1.py
+++ b/Cassiopee/Apps/test/FastIBMWireMeshModel_t1.py
@@ -43,15 +43,12 @@ snears    = 1
 vmin      = 11
 
 t,tc = X_IBM.prepareIBMData(tb               , None       , None     , tbox=tboffset,      
-                                snears=snears    , dfars=dfars  , vmin=vmin, 
-                                check=False      , frontType=1)
+                            snears=snears    , dfars=dfars  , vmin=vmin, 
+                            check=False      , frontType=1)
 
 test.testT(t , 1)
 test.testT(tc, 2)
 
-##NEEDED FOR THE MPI version
-C.convertPyTree2File(t , LOCAL+'/t_WMM.cgns')
-C.convertPyTree2File(tc, LOCAL+'/tc_WMM.cgns')
 
 ##COMPUTE
 NIT           = 25  # number of iterations 
@@ -108,5 +105,4 @@ test.testT(t , 3)
 test.testT(tc, 4)
 
 ##TO VISUALIZE
-#C.convertPyTree2File(t ,LOCAL+'/t_restart_WMM_check.cgns')
-#C.convertPyTree2File(tc,LOCAL+'/tc_restart_WMM_check.cgns')
+#C.convertPyTree2File(t,LOCAL+'/t_restart_WMM_check.cgns')

--- a/Cassiopee/Connector/Connector/IBM.py
+++ b/Cassiopee/Connector/Connector/IBM.py
@@ -182,10 +182,11 @@ def _computeMeshInfo(t):
     return None
 
 def prepareIBMData(t_case, t_out, tc_out, t_in=None, to=None, tbox=None, tinit=None, tbCurvi=None,
-                       snears=0.01, snearsf=None, dfars=10., dfarDir=0, vmin=21, depth=2, frontType=1, octreeMode=0,
-                       IBCType=1, verbose=True, expand=3,
-                       check=False, balancing=False, distribute=False, twoFronts=False, cartesian=False,
-                       yplus=100., Lref=1., correctionMultiCorpsF42=False, blankingF42=False, wallAdaptF42=None, heightMaxF42=-1.):
+                   snears=0.01, snearsf=None, dfars=10., dfarDir=0, vmin=21, depth=2, frontType=1, octreeMode=0,
+                   IBCType=1, verbose=True, expand=3,
+                   check=False, balancing=False, distribute=False, twoFronts=False, cartesian=False,
+                   yplus=100., Lref=1., correctionMultiCorpsF42=False, blankingF42=False, wallAdaptF42=None, heightMaxF42=-1.,
+                   skipRedispatchNonRegression=False):
     
     import Generator.IBM as G_IBM
     import time as python_time
@@ -288,9 +289,9 @@ def prepareIBMData(t_case, t_out, tc_out, t_in=None, to=None, tbox=None, tinit=N
                  filamentBases=filamentBases, isFilamentOnly=isFilamentOnly, tbFilament=tbFilament,
                  isWireModel=isWireModel)
     Cmpi.barrier()
-    _redispatch__(t=t)
+    if not skipRedispatchNonRegression: _redispatch__(t=t)
     if verbose: printTimeAndMemory__('blank by IBC bodies', time=python_time.time()-pt0)
-
+    
     #===================
     # STEP 4 : INTERP DATA CHIM
     #===================

--- a/Cassiopee/Connector/test/prepareIBMData_m1.py
+++ b/Cassiopee/Connector/test/prepareIBMData_m1.py
@@ -1,0 +1,20 @@
+# - prepareIBMData MPI (pyTree) -
+import Converter.PyTree as C
+import Converter.Mpi as Cmpi
+import Connector.IBM as X_IBM
+import KCore.test as test
+
+LOCAL = test.getLocal()
+
+tb = C.convertFile2PyTree('../../Apps/test/naca1DNS.cgns')
+
+# Prepare
+vmin      = 42
+dfars     = 5
+snears    = 1
+t, tc = X_IBM.prepareIBMData('naca1DNS.cgns', None         , None     ,
+                             snears=snears  , dfars=dfars  , vmin=vmin, 
+                             check=False    , frontType=1  , skipRedispatchNonRegression=True)
+if Cmpi.rank==0:
+    test.testT(t , 1)
+    test.testT(tc, 2)

--- a/Cassiopee/Connector/test/prepareIBMData_t1.py
+++ b/Cassiopee/Connector/test/prepareIBMData_t1.py
@@ -1,0 +1,20 @@
+# - prepareIBMData Serial (pyTree) -
+import Converter.PyTree as C
+import Converter.Mpi as Cmpi
+import Connector.IBM as X_IBM
+import KCore.test as test
+
+LOCAL = test.getLocal()
+
+tb = C.convertFile2PyTree('../../Apps/test/naca1DNS.cgns')
+
+# Prepare
+vmin      = 42
+dfars     = 5
+snears    = 1
+t, tc = X_IBM.prepareIBMData('naca1DNS.cgns', None         , None     ,
+                             snears=snears  , dfars=dfars  , vmin=vmin, 
+                             check=False    , frontType=1)
+test.testT(t , 1)
+test.testT(tc, 2)
+#C.convertPyTree2File(t,'t_check.cgns')


### PR DESCRIPTION
Update the Wire Mesh model test cases. The current results for _m1 are correct and should override the previous results. _t1 should not regress. 
This commit is dependent the previous **temporary bug patch** commit. 