### PR TITLE
Cmpi: order lists in graphs to avoid randomized parallel behavior. X_…

### DIFF
--- a/Cassiopee/Apps/test/FastIBMWireMeshModel_m1.py
+++ b/Cassiopee/Apps/test/FastIBMWireMeshModel_m1.py
@@ -48,7 +48,7 @@ vmin      = 11
 
 X_IBM.prepareIBMData(tb               , tFile        , tcFile   , tbox=tboffset,      
                      snears=snears    , dfars=dfars  , vmin=vmin, 
-                     check=True       , frontType=1  , skipRedispatchNonRegression=True)
+                     check=True       , frontType=1)
 App._distribute(tFile, tcFile, NP=Cmpi.size)
 t       = Fast.loadTree(tFile , split='single',  mpirun=True)
 tc,graph= Fast.loadFile(tcFile, split='single',  mpirun=True, graph=True)

--- a/Cassiopee/Connector/Connector/IBM.py
+++ b/Cassiopee/Connector/Connector/IBM.py
@@ -277,7 +277,7 @@ def prepareIBMData(t_case, t_out, tc_out, t_in=None, to=None, tbox=None, tinit=N
                  filamentBases=filamentBases, isFilamentOnly=isFilamentOnly, tbFilament=tbFilament,
                  isWireModel=isWireModel)
     Cmpi.barrier()
-    # _redispatch__(t=t)
+    _redispatch__(t=t)
     if verbose: printTimeAndMemory__('blank by IBC bodies', time=python_time.time()-pt0)
     
     #===================

--- a/Cassiopee/Connector/Connector/IBM.py
+++ b/Cassiopee/Connector/Connector/IBM.py
@@ -185,8 +185,7 @@ def prepareIBMData(t_case, t_out, tc_out, t_in=None, to=None, tbox=None, tinit=N
                    snears=0.01, snearsf=None, dfars=10., dfarDir=0, vmin=21, depth=2, frontType=1, octreeMode=0,
                    IBCType=1, verbose=True, expand=3,
                    check=False, balancing=False, distribute=False, twoFronts=False, cartesian=False,
-                   yplus=100., Lref=1., correctionMultiCorpsF42=False, blankingF42=False, wallAdaptF42=None, heightMaxF42=-1.,
-                   skipRedispatchNonRegression=False):
+                   yplus=100., Lref=1., correctionMultiCorpsF42=False, blankingF42=False, wallAdaptF42=None, heightMaxF42=-1.):
     
     import Generator.IBM as G_IBM
     import time as python_time
@@ -278,7 +277,7 @@ def prepareIBMData(t_case, t_out, tc_out, t_in=None, to=None, tbox=None, tinit=N
                  filamentBases=filamentBases, isFilamentOnly=isFilamentOnly, tbFilament=tbFilament,
                  isWireModel=isWireModel)
     Cmpi.barrier()
-    if not skipRedispatchNonRegression: _redispatch__(t=t)
+    # _redispatch__(t=t)
     if verbose: printTimeAndMemory__('blank by IBC bodies', time=python_time.time()-pt0)
     
     #===================

--- a/Cassiopee/Connector/test/prepareIBMData_m1.py
+++ b/Cassiopee/Connector/test/prepareIBMData_m1.py
@@ -12,7 +12,7 @@ dfars     = 5
 snears    = 1
 t, tc = X_IBM.prepareIBMData(tb             , None         , None     ,
                              snears=snears  , dfars=dfars  , vmin=vmin, 
-                             check=False    , frontType=1  , skipRedispatchNonRegression=True)
+                             check=False    , frontType=1)
 if Cmpi.rank==0:
     test.testT(t , 1)
     test.testT(tc, 2)

--- a/Cassiopee/Converter/Converter/Mpi4py.py
+++ b/Cassiopee/Converter/Converter/Mpi4py.py
@@ -592,7 +592,7 @@ def computeGraph(t, type='bbox', t2=None, procDict=None, reduction=True,
                 for j in i[k]:
                     if not j in graph[k]: graph[k][j] = []
                     graph[k][j] += i[k][j]
-                    graph[k][j] = list(set(graph[k][j]))
+                    graph[k][j] = sorted(list(set(graph[k][j])))
 
     return graph
 


### PR DESCRIPTION
…IBM: remove temporary patch.

The reference for FastIBMWireMeshModel_m1 must be regenerated!