### PR TITLE
Generator: closeMesh: conditionally export vertex indirection table

### DIFF
--- a/Cassiopee/Generator/Generator/Generator.py
+++ b/Cassiopee/Generator/Generator/Generator.py
@@ -829,27 +829,36 @@ def closeLegacy(array, tol=1.e-12, suppressDegeneratedNGons=False):
         
 def close(array, tol=1.e-12, rmOverlappingPts=True, rmOrphanPts=True,
           rmDuplicatedFaces=True, rmDuplicatedElts=True,
-          rmDegeneratedFaces=True, rmDegeneratedElts=True):
+          rmDegeneratedFaces=True, rmDegeneratedElts=True,
+          indices=None):
     """Close an unstructured mesh defined by an array gathering points closer than tol.
     Usage: close(array, tol)"""
+    exportIndirPts = False
+    if isinstance(indices, list) and not indices: exportIndirPts = True
     if isinstance(array[0], list):
         out = []
         for a in array:
+            indirl = None
             if len(a) == 5: # merge intra-borders (C-type meshes)
                 outl = generator.closeBorders([a], [], tol)[0]
             else:
                 outl = generator.closeMesh(a, tol, rmOverlappingPts,
                                            rmOrphanPts, rmDuplicatedFaces,
-                                           rmDuplicatedElts,
-                                           rmDegeneratedFaces,
-                                           rmDegeneratedElts)
+                                           rmDuplicatedElts, rmDegeneratedFaces,
+                                           rmDegeneratedElts, exportIndirPts)
+                if exportIndirPts: outl, indirl = outl
             out.append(outl)
+            if exportIndirPts: indices.append(indirl)
         return out
     else:
-        return generator.closeMesh(array, tol, rmOverlappingPts,
-                                   rmOrphanPts, rmDuplicatedFaces,
-                                   rmDuplicatedElts, rmDegeneratedFaces,
-                                   rmDegeneratedElts)
+        out = generator.closeMesh(array, tol, rmOverlappingPts,
+                                  rmOrphanPts, rmDuplicatedFaces,
+                                  rmDuplicatedElts, rmDegeneratedFaces,
+                                  rmDegeneratedElts, exportIndirPts)
+        if exportIndirPts:
+            out, indirl = out
+            indices.append(indirl)
+        return out
 
 def zip(array, tol=1e-12):
     """Zip a set of meshes defined by gathering exterior points closer than tol.

--- a/Cassiopee/Generator/Generator/PyTree.py
+++ b/Cassiopee/Generator/Generator/PyTree.py
@@ -844,22 +844,27 @@ def _closeLegacy(t, tol=1.e-12, suppressDegeneratedNGons=False):
     
 def close(a, tol=1.e-12, rmOverlappingPts=True, rmOrphanPts=True,
           rmDuplicatedFaces=True, rmDuplicatedElts=True,
-          rmDegeneratedFaces=True, rmDegeneratedElts=True):
+          rmDegeneratedFaces=True, rmDegeneratedElts=True,
+          indices=None):
     """Merge vertices distant of tol and remove multiply defined vertices/faces/elements.
     Usage: close(array, tol, rmOverlappingPts, rmOrphanPts, rmDuplicatedFaces,
-                 rmDuplicatedElts, rmDegeneratedFaces, rmDegeneratedElts)"""
+                 rmDuplicatedElts, rmDegeneratedFaces, rmDegeneratedElts,
+                 indices)"""
     t = Internal.copyRef(a)
     _close(t, tol, rmOverlappingPts, rmOrphanPts, rmDuplicatedFaces,
-           rmDuplicatedElts, rmDegeneratedFaces, rmDegeneratedElts)
+           rmDuplicatedElts, rmDegeneratedFaces, rmDegeneratedElts,
+           indices=indices)
     return t
 
 def _close(t, tol=1.e-12, rmOverlappingPts=True, rmOrphanPts=True,
            rmDuplicatedFaces=True, rmDuplicatedElts=True,
-           rmDegeneratedFaces=True, rmDegeneratedElts=True):
+           rmDegeneratedFaces=True, rmDegeneratedElts=True,
+           indices=None):
     fields = C.getAllFields(t, 'nodes')
     fields = Generator.close(fields, tol, rmOverlappingPts, rmOrphanPts,
                              rmDuplicatedFaces, rmDuplicatedElts,
-                             rmDegeneratedFaces, rmDegeneratedElts)
+                             rmDegeneratedFaces, rmDegeneratedElts,
+                             indices=indices)
     C.setFields(fields, t, 'nodes')
     return None
 

--- a/Cassiopee/Generator/Generator/close.cpp
+++ b/Cassiopee/Generator/Generator/close.cpp
@@ -40,11 +40,13 @@ PyObject* K_GENERATOR::closeMesh(PyObject* self, PyObject* args)
   E_Bool rmDuplicatedElts = true;
   E_Bool rmDegeneratedFaces = true;
   E_Bool rmDegeneratedElts = true;
+  E_Bool exportIndirPts = false;
   
-  if (!PYPARSETUPLE_(args, O_ R_ BB_ BBBB_,
+  if (!PYPARSETUPLE_(args, O_ R_ BBB_ BBBB_,
                     &array, &eps, &rmOverlappingPts, &rmOrphanPts,
                     &rmDuplicatedFaces, &rmDuplicatedElts,
-                    &rmDegeneratedFaces, &rmDegeneratedElts)) return NULL;
+                    &rmDegeneratedFaces, &rmDegeneratedElts,
+                    &exportIndirPts)) return NULL;
 
   // Check array
   E_Int im, jm, km;
@@ -84,7 +86,7 @@ PyObject* K_GENERATOR::closeMesh(PyObject* self, PyObject* args)
     PyObject* tpl = K_CONNECT::V_cleanConnectivity(
         varString, *f, *cn, eltType, eps,
         rmOverlappingPts, rmOrphanPts, rmDuplicatedFaces, rmDuplicatedElts,
-        rmDegeneratedFaces, rmDegeneratedElts);
+        rmDegeneratedFaces, rmDegeneratedElts, exportIndirPts);
 
     RELEASESHAREDU(array, f, cn);
     if (tpl == NULL) return array;

--- a/Cassiopee/Generator/test/closePT_t1.py
+++ b/Cassiopee/Generator/test/closePT_t1.py
@@ -21,3 +21,9 @@ test.testT(a2, 2)
 a3 = C.convertArray2Tetra(a)
 a3 = G.close(a3, 1.e-3)
 test.testT(a3, 3)
+
+# test close non structure tetra avec retour de la table d indir. des vertices
+indices = []
+a3 = C.convertArray2Tetra(a)
+a3 = G.close(a3, 1.e-3, indices=indices)
+test.testO(indices, 4)

--- a/Cassiopee/Generator/test/close_t1.py
+++ b/Cassiopee/Generator/test/close_t1.py
@@ -20,9 +20,11 @@ a3 = C.convertArray2Tetra(a)
 a3 = G.close(a3, 1.e-3)
 test.testA([a3], 3)
 
-# test close NGON
+# test close NGON avec retour de la table d indir. des vertices
+indices = []
 a4 =  G.cylinder((0.,0.,0.), 0.5, 1., 360., 0.01, 10., (10,10,10))
 a4 = C.convertArray2NGon(a4)
 a4 = C.addVars(a4, 'F')
-a4 = G.close(a4, 5.e-3)
+a4 = G.close(a4, 5.e-3, indices=indices)
 test.testA([a4], 4)
+test.testO(indices, 5)

--- a/Cassiopee/KCore/KCore/Connect/connect.h
+++ b/Cassiopee/KCore/KCore/Connect/connect.h
@@ -423,7 +423,8 @@ namespace K_CONNECT
     K_FLD::FldArrayI& cn, const char* eltType,
     E_Float tol=0., E_Bool rmOverlappingPts=true, E_Bool rmOrphanPts=true,
     E_Bool rmDuplicatedFaces=true, E_Bool rmDuplicatedElts=true,
-    E_Bool rmDegeneratedFaces=true, E_Bool rmDegeneratedElts=true);
+    E_Bool rmDegeneratedFaces=true, E_Bool rmDegeneratedElts=true,
+    E_Bool exportIndirPts=false);
 
   // Clean connectivity - NGON
   PyObject* V_cleanConnectivityNGon(
@@ -431,7 +432,8 @@ namespace K_CONNECT
     K_FLD::FldArrayF& f, K_FLD::FldArrayI& cn,
     E_Float tol=0., E_Bool rmOverlappingPts=true, E_Bool rmOrphanPts=true,
     E_Bool rmDuplicatedFaces=true, E_Bool rmDuplicatedElts=true,
-    E_Bool rmDegeneratedFaces=true, E_Bool rmDegeneratedElts=true);
+    E_Bool rmDegeneratedFaces=true, E_Bool rmDegeneratedElts=true,
+    E_Bool exportIndirPts=false);
 
   E_Int V_identifyDirtyPoints(
     E_Int posx, E_Int posy, E_Int posz, 
@@ -459,7 +461,8 @@ namespace K_CONNECT
     E_Int posx, E_Int posy, E_Int posz, const char* varString,
     K_FLD::FldArrayF& f, K_FLD::FldArrayI& cn, const char* eltType,
     E_Float tol=0., E_Bool rmOverlappingPts=true, E_Bool rmOrphanPts=true,
-    E_Bool rmDuplicatedElts=true, E_Bool rmDegeneratedElts=true);  
+    E_Bool rmDuplicatedElts=true, E_Bool rmDegeneratedElts=true,
+    E_Bool exportIndirPts=false);  
 
   E_Int V_identifyDirtyElementsME(
     E_Int dim, K_FLD::FldArrayI& cn, std::vector<E_Int>& indir,


### PR DESCRIPTION
Define an empty list, `indices`, and pass it in the form of a keyworded argument to `G.close` or `G._close` as
```py
# Let t be a PyTree
indices = []
G._close(t, tol=1.e-12, indices=indices)
```
`indices` will contain the vertex indirection table following mesh cleaning. Values of -1 mean that these vertices were deleted (ie, tagged as orphans or duplicates).
If `indices` is set to None (or not passed), the  vertex indirection table is not returned.
This could be used to update boundary face indices post-cleaning without resorting to `C.identifyNodes`
