### PR TITLE
[IBM] Rectilinear - add fine granularity. Lets the user choose between coarse (bounding box) and fine (blanking zones) granularity for the rectilinear meshing.

### DIFF
--- a/Cassiopee/Generator/Generator/IBM.py
+++ b/Cassiopee/Generator/Generator/IBM.py
@@ -620,7 +620,7 @@ def octree2StructLoc__(o, parento=None, vmin=15, ext=0, optimized=0, sizeMax=4e6
                 for i in range(NBases):
                     ZONEStbOneOver[i] = T.mergeCart(ZONEStbOneOverTmp[i][0]+ZONEStbOneOverTmp[i][1]+ \
                                                     ZONEStbOneOverTmp[i][2]+ZONEStbOneOverTmp[i][3], sizeMax=sizeMax)
-                    C.convertPyTree2File(ZONEStbOneOver[i],'t_Base_'+str(i)+'.cgns')
+                    #C.convertPyTree2File(ZONEStbOneOver[i],'t_Base_'+str(i)+'.cgns')
                     zones +=ZONEStbOneOver[i]
             del ZONEStbOneOver
             del ZONEStbOneOverTmp

--- a/Cassiopee/Generator/Generator/IBM.py
+++ b/Cassiopee/Generator/Generator/IBM.py
@@ -453,16 +453,33 @@ def octree2StructLoc__(o, parento=None, vmin=15, ext=0, optimized=0, sizeMax=4e6
         if dimPb==2:
             T._addkplane(tzones)
             T._contract(tzones, (0,0,0), (1,0,0), (0,1,0), 0.01)
+            tbOneOver=T.addkplane(tbOneOver)
+            T._contract(tbOneOver, (0,0,0), (1,0,0), (0,1,0), 0.01)
 
         ##RECTILINEAR REGION
-        tbbB            = G.BB(tbOneOver)
-        NBases          = len(Internal.getBases(tbbB))
-        interDict_scale = X.getIntersectingDomains(tbbB, tzones)
-        for i in interDict_scale:
-            listSavetbOneOverTmp = []
-            for z in interDict_scale[i]: listSavetbOneOverTmp.append(z)
-            listSavetbOneOver.append(listSavetbOneOverTmp)
-
+        tzones2         = C.newPyTree(['Base', tzones])
+        NBases          = len(Internal.getBases(tbOneOver))
+        for i in Internal.getBases(tbOneOver):
+            checkOneOver = Internal.getNodeByName(i,".Solver#define")
+            granularityLocal = 0
+            if checkOneOver: granularityLocal = Internal.getNodeByName(checkOneOver, 'granularity')[1]
+            if granularityLocal==1:
+                listSavetbOneOverTmp = []
+                C._initVars(tzones2, 'cellNOneOver', 1.)
+                X_IBM._blankByIBCBodies(tzones2, i, 'nodes', dimPb, cellNName='cellNOneOver')
+                
+                for z in Internal.getZones(tzones2):
+                    if C.getMinValue(z, 'cellNOneOver')<1:listSavetbOneOverTmp.append(z[0])
+                listSavetbOneOver.append(listSavetbOneOverTmp)
+            elif granularityLocal==0:
+                interDict_scale = X.getIntersectingDomains(G.BB(i), tzones)
+                listSavetbOneOverTmp = []
+                for j in interDict_scale:
+                    for z in interDict_scale[j]: listSavetbOneOverTmp.append(z)
+                    listSavetbOneOver.append(listSavetbOneOverTmp)
+                
+        del tzones2
+            
     if parento is None:
         ## Rectilinear mesh modifications
         ZONEStbOneOver    = None
@@ -565,6 +582,7 @@ def octree2StructLoc__(o, parento=None, vmin=15, ext=0, optimized=0, sizeMax=4e6
                     if nzones > 1:
                         print('Merging %d Cartesian zones of subdomain %d - OneOverRegion # %d '%(nzones,noo,i))
                         ZONEStbOneOverTmp[i][noo] = mergeByParent__(ZONEStbOneOverTmp[i][noo], parento[noo], sizeMax)
+                        #C.convertPyTree2File(ZONEStbOneOverTmp[i][noo],'t_BaseTmp_'+str(i)+'_'+str(noo)+'.cgns')
                         print('Nb of merged zones - OneOverRegion # %d : %d.' %(i,len(ZONEStbOneOverTmp[i][noo])))
         if dimPb == 3:
             ZONES0 = T.mergeCart(ZONES[0]+ZONES[4],sizeMax=sizeMax)# XM
@@ -602,7 +620,7 @@ def octree2StructLoc__(o, parento=None, vmin=15, ext=0, optimized=0, sizeMax=4e6
                 for i in range(NBases):
                     ZONEStbOneOver[i] = T.mergeCart(ZONEStbOneOverTmp[i][0]+ZONEStbOneOverTmp[i][1]+ \
                                                     ZONEStbOneOverTmp[i][2]+ZONEStbOneOverTmp[i][3], sizeMax=sizeMax)
-                    #C.convertPyTree2File(ZONEStbOneOver[i],'t_Base_'+str(i)+'.cgns')
+                    C.convertPyTree2File(ZONEStbOneOver[i],'t_Base_'+str(i)+'.cgns')
                     zones +=ZONEStbOneOver[i]
             del ZONEStbOneOver
             del ZONEStbOneOverTmp
@@ -799,25 +817,42 @@ def generateIBMMesh(tb, dimPb=3, vmin=15, snears=0.01, dfars=10., dfarDir=0,
         if dimPb==2:
             T._addkplane(tbb)
             T._contract(tbb, (0,0,0), (1,0,0), (0,1,0), 0.01)
+            tbOneOver2=T.addkplane(tbOneOver)
+            T._contract(tbOneOver2, (0,0,0), (1,0,0), (0,1,0), 0.01)
 
         ## RECTILINEAR REGION
-        ## Select regions that need to be coarsened
-        tbbB            = G.BB(tbOneOver)
-        interDict_scale = X.getIntersectingDomains(tbbB, tbb)
-        ## Avoid a zone to be coarsened twice
-        for i in interDict_scale:
-            (b,btmp) = Internal.getParentOfNode(tbOneOver,Internal.getNodeByName(tbOneOver,i))
-            checkOneOver = Internal.getNodeByName(b,".Solver#define")
+        tzones2  = Internal.copyTree(tbb)
+        for i in Internal.getBases(tbOneOver2):
+            checkOneOver = Internal.getNodeByName(i,".Solver#define")
             if checkOneOver:
-                b        = Internal.getNodeByName(b,".Solver#define")
-                oneoverX = int(Internal.getNodeByName(b, 'dirx')[1])
-                oneoverY = int(Internal.getNodeByName(b, 'diry')[1])
-                oneoverZ = int(Internal.getNodeByName(b, 'dirz')[1])
-                for z in interDict_scale[i]:
-                    if z not in listDone:
-                        zLocal = Internal.getNodeFromName(t,z)
-                        T._oneovern(zLocal, (oneoverX,oneoverY,oneoverZ));
-                        listDone.append(z)
+                granularityLocal = Internal.getNodeByName(checkOneOver, 'granularity')[1]
+                oneoverX         = int(Internal.getNodeByName(checkOneOver, 'dirx')[1])
+                oneoverY         = int(Internal.getNodeByName(checkOneOver, 'diry')[1])
+                oneoverZ         = int(Internal.getNodeByName(checkOneOver, 'dirz')[1])
+                ## Select regions that need to be coarsened
+                if granularityLocal==1:
+                    C._initVars(tzones2, 'cellNOneOver', 1.)
+                    X_IBM._blankByIBCBodies(tzones2, i, 'nodes', dimPb, cellNName='cellNOneOver')
+                    
+                    for z in Internal.getZones(tzones2):
+                        if C.getMinValue(z, 'cellNOneOver')<1:
+                            if z[0] not in listDone:
+                                zLocal = Internal.getNodeFromName(t,z[0])
+                                T._oneovern(zLocal, (oneoverX,oneoverY,oneoverZ));
+                                ### Avoid a zone to be coarsened twice
+                                listDone.append(z[0])
+                elif granularityLocal==0:
+                     interDict_scale = X.getIntersectingDomains(G.BB(i), tbb)
+                     ## Avoid a zone to be coarsened twice
+                     for j in interDict_scale:
+                         for z in interDict_scale[j]:
+                             if z not in listDone:
+                                 zLocal = Internal.getNodeFromName(t,z)
+                                 T._oneovern(zLocal, (oneoverX,oneoverY,oneoverZ));
+                                 listDone.append(z)                     
+
+        del tzones2
+        
     test.printMem(">>> cart grids --> rectilinear grids [end]")     
 
     zones = Internal.getZones(t)


### PR DESCRIPTION
See title. 
Coarse granularity: use bounding box & is most efficient for large areas
Fine granularity: use IBC blanking and is best for targeted areas that stretch out over large areas. This is for areas that are ill-represented with bounding boxes.

In the figure below, if for the selected zone (blue base) we are looking to have a rectilinear in this region only fine granularity is to be preferred. Coarse granularity will create a bounding box around this area and therefore perform rectilinear in undesired areas - i.e. a bounding box cannot be used to properly represent the areas of interest.
![image](https://github.com/user-attachments/assets/9397ef3e-c361-4956-84d8-8f937ac4a406)

In the figure below, coarse granularity is preferred as we are targeting a large area that can be properly represented with a bounding box.
![image](https://github.com/user-attachments/assets/2fe5b544-bb63-4a1c-b034-8263654d8e91)
