### PR TITLE
Envs + kpython: adding prod juno_coda

### DIFF
--- a/Cassiopee/Converter/Converter/kpython
+++ b/Cassiopee/Converter/Converter/kpython
@@ -200,6 +200,16 @@ else
             fi
             [ $? != 0 ] && exit 1;  
             ;;
+        'juno_coda' | 'juno_coda_*' ) # juno coda, to list before juno
+            # openMpi
+            if [ $SANITIZE = '1' ]
+            then
+                mpirun $ARGS -x LD_PRELOAD=$ASAN_LIB -x OMP_NUM_THREADS=$NTHREADS -np $NPROCS -x OMP_PLACES=cores $PYTHONEXE $SCRIPT  #--bind-to core --map-by socket:PE=$NTHREADS --report-bindings -x OMP_PROC_BIND=TRUE -x OMP_DISPLAY_ENV=VERBOSE
+            else
+                mpirun $ARGS -x OMP_NUM_THREADS=$NTHREADS -np $NPROCS -x OMP_PLACES=cores $PYTHONEXE $SCRIPT  #--bind-to core --map-by socket:PE=$NTHREADS --report-bindings -x OMP_PROC_BIND=TRUE -x OMP_DISPLAY_ENV=VERBOSE
+            fi
+            [ $? != 0 ] && exit 1;  
+            ;;
         'juno' | 'juno_*' ) # juno
             # intelMpi
             mpirun $ARGS -n $NPROCS -genv OMP_NUM_THREADS=$NTHREADS -l -ordered-output $PYTHONEXE $SCRIPT

--- a/Cassiopee/Envs/env_Cassiopee_local
+++ b/Cassiopee/Envs/env_Cassiopee_local
@@ -751,6 +751,12 @@ else if ($MAC == "juno_coda") then
         setenv OMP_NUM_THREADS 48
         setenv PYTHONEXE python3
         setenv PRODMODE 1
+        setenv PIP_DISABLE_PIP_VERSION_CHECK 1
+        unsetenv SLURM*
+        unsetenv OMP_PLACES
+        setenv ASAN_OPTIONS verify_asan_link_order=false
+        setenv LSAN_OPTIONS suppressions="$CASSIOPEE"/Dist/bin/"$ELSAPROD"/asan.supp:print_suppressions=0
+        setenv ASAN_LIB /opt/tools/gcc/12.1.0-gnu831/lib64/libasan.so
 
 else if ($MAC == "sator_brw") then
 #------------------------------- sator for broadwell ----------------------------------

--- a/Cassiopee/Envs/sh_Cassiopee_local
+++ b/Cassiopee/Envs/sh_Cassiopee_local
@@ -641,6 +641,9 @@ elif [ "$MAC" = "juno_coda" ]; then
     module load subversion/1.14.1-gnu831
     export PYTHONEXE=python3
     export PRODMODE=1
+    export PIP_DISABLE_PIP_VERSION_CHECK=1
+    unset $(env | grep SLURM | cut -d'=' -f 1)
+    unset OMP_PLACES
     export ASAN_OPTIONS=verify_asan_link_order=false
     export LSAN_OPTIONS=suppressions=$CASSIOPEE/Dist/bin/"$ELSAPROD"/asan.supp:print_suppressions=0
     export ASAN_LIB=/opt/tools/gcc/10.2.0-gnu831/lib64/libasan.so

--- a/Cassiopee/KCore/installBase.py
+++ b/Cassiopee/KCore/installBase.py
@@ -1001,7 +1001,7 @@ installDict = {
                     'gfortran', # f77compiler
                     'gfortran', # f90compiler
                     'gcc', # Cppcompiler
-                    ['-DCACHELINE=32'], # CppAdditionalOptions
+                    ['-DCACHELINE=32','-DNB_SOCKET=2','-DCORE_PER_SOCK=12','-DSIMD=AVX2'], # CppAdditionalOptions
                     [], # f77AdditionalOptions
                     True, # useOMP
                     False, # static
@@ -1106,7 +1106,7 @@ installDict = {
                    'gfortran', # f77compiler
                    'gfortran', # f90compiler
                    'gcc', # Cppcompiler
-                   ['-DCACHELINE=32'], # CppAdditionalOptions
+                   ['-DCACHELINE=32','-DNB_SOCKET=2','-DCORE_PER_SOCK=48','-DSIMD=AVX512'], # CppAdditionalOptions
                    [], # f77AdditionalOptions
                    True, # useOMP
                    False, # static


### PR DESCRIPTION
Note: these arguments 
`--bind-to core --map-by socket:PE=$NTHREADS --report-bindings -x OMP_PROC_BIND=TRUE -x OMP_DISPLAY_ENV=VERBOSE`
are slowing _kpython_ down by about 30% on juno