### PR TITLE
CPlot: validCassiopee: test duration and tag added to test metadata

### DIFF
--- a/Cassiopee/CPlot/apps/validCassiopee.py
+++ b/Cassiopee/CPlot/apps/validCassiopee.py
@@ -1,5 +1,6 @@
 # *Cassiopee* GUI for validation and tests
 import os, sys, re, glob, signal, platform
+import json
 import numpy as np
 import subprocess
 import threading
@@ -37,6 +38,10 @@ expTest4 = re.compile("_m[0-9]+") # distributed tests
 TESTS = []
 # Test filter: 0 (no filter), 1: sequential tests only, 2: distributed tests only
 TESTS_FILTER = 0
+# Test metadata: ref info (date, hashes), tag, duration
+TESTMETA = {}
+# Have test metadata been updated?
+TESTMETA_UPDATE = False
 
 # Name of the data folders
 DATA = None
@@ -46,8 +51,8 @@ CFDBASEPATH = os.path.join('Validation', 'Cases')
 MODULESDIR = {'LOCAL': {}, 'GLOBAL': {}}
 # Paths to the local and global ValidData folders
 VALIDDIR = {'LOCAL': None, 'GLOBAL': None}
-# Base used for comparisons. Default is the local base.
-BASE4COMPARE = 'LOCAL'
+# Base used for comparisons. Default is the global base.
+BASE4COMPARE = 'GLOBAL'
 
 # Si THREAD est None, les test unitaires ne tournent pas
 # Sinon, THREAD vaut le thread lance
@@ -318,38 +323,17 @@ def ljust(text, size):
 #==============================================================================
 def buildString(module, test, CPUtime='...', coverage='...%', status='...',
                 tag=' '):
-    modulesDir = MODULESDIR[BASE4COMPARE][module]
-    if module == 'CFDBase':
-        path = os.path.join(modulesDir, CFDBASEPATH)
-        fileTime = os.path.join(path, test, DATA, test+'.time')
-        fileStar = os.path.join(path, test, DATA, test+'.star')
-    else:
-        testr = os.path.splitext(test)
-        fileTime = os.path.join(modulesDir, module, 'test', DATA, testr[0]+'.time')
-        fileStar = os.path.join(modulesDir, module, 'test', DATA, testr[0]+'.star')
-
-    if os.access(fileTime, os.F_OK):
-        with open(fileTime, 'r') as f:
-            fileData = f.read()
-        fileData = fileData.split('\n')
-        if len(fileData) > 0: refDate = fileData[0]
-        else: refDate = '...'
-        if len(fileData) > 1: refCPUtime = fileData[1]
-        else: refCPUtime = '...'
-        if len(fileData) > 3 and fileData[2] != '': refCoverage = fileData[2]
-        else: refCoverage = '...%'
-    else:
-        refDate = '...'
-        refCPUtime = '...'
-        refCoverage = '...%'
-
-    if os.access(fileStar, os.F_OK):
-        with open(fileStar, 'r') as f:
-            fileData = f.read()
-        fileData = fileData.split('\n')
-        if len(fileData) > 0: refTag = fileData[0]
-        else: refTag = ' '
-    else: refTag = ' '
+    global TESTMETA, TESTMETA_UPDATE
+    testName = module+'/'+test
+    refDate = '...'
+    if testName not in TESTMETA:
+        TESTMETA_UPDATE = True
+        TESTMETA[testName] = newMetadata()
+    elif TESTMETA[testName].get('ref', []):
+        refDate = TESTMETA[module+'/'+test]['ref'][0].get('date', '...')
+    refCoverage = TESTMETA[module+'/'+test].get('coverage', '...%')
+    refCPUtime = TESTMETA[module+'/'+test].get('time', '...')
+    refTag = TESTMETA[module+'/'+test].get('tag', ' ')
 
     execTime = '../../.. ..h..'
     if status != '...': # Not First call
@@ -400,8 +384,7 @@ def setPaths():
         for mod in mods:
             if mod not in MODULESDIR[loc]:
                 a = os.access(os.path.join(cassiopeeIncDir, mod, 'test'), os.F_OK)
-                if a:
-                    MODULESDIR[loc][mod] = cassiopeeIncDir
+                if a: MODULESDIR[loc][mod] = cassiopeeIncDir
 
         # Validation CFD
         MODULESDIR[loc]['CFDBase'] = os.path.dirname(os.path.dirname(cassiopeeIncDir))
@@ -445,10 +428,8 @@ def getModules():
 # si module == 'CFDBase', retourne la liste des cas de validation CFD
 #==============================================================================
 def getTests(module):
-    a = []
-    if module == 'CFDBase': a += getCFDBaseTests()
-    else: a += getUnitaryTests(module)
-    return a
+    if module == 'CFDBase': return getCFDBaseTests()
+    return getUnitaryTests(module)
 
 #==============================================================================
 # Retourne la liste des tests unitaires pour un module donne
@@ -523,7 +504,7 @@ def writeFinal(filename, gitInfo="", logTxt=None, append=False):
         if logTxt is not None: f.write(logTxt+'\n')
 
 #==============================================================================
-# Read and update star dans un fichier star
+# Read un fichier star
 #==============================================================================
 def readStar(fileStar):
     star = ' '
@@ -533,18 +514,12 @@ def readStar(fileStar):
     except: pass
     return star
 
-def writeStar(fileStar, star):
-    try:
-        with open(fileStar, 'w') as f:
-            f.write(star+'\n')
-    except: pass
-
 #==============================================================================
 # Lance un seul test unitaire ou un cas de la base de validation
 #==============================================================================
-def runSingleTest(no, module, test):
-    if module == 'CFDBase': return runSingleCFDTest(no, module, test)
-    else: return runSingleUnitaryTest(no, module, test)
+def runSingleTest(no, module, test, update=False):
+    if module == 'CFDBase': return runSingleCFDTest(no, module, test, update)
+    return runSingleUnitaryTest(no, module, test, update)
 
 #==============================================================================
 # extrait le temps CPU d'un chaine output (utile sur windows)
@@ -617,7 +592,7 @@ def extractCPUTimeUnix(output):
 #==============================================================================
 # Lance un seul test unitaire de module
 #==============================================================================
-def runSingleUnitaryTest(no, module, test):
+def runSingleUnitaryTest(no, module, test, update=False):
     global TESTS
     testr = os.path.splitext(test)
     modulesDir = MODULESDIR[BASE4COMPARE][module]
@@ -705,11 +680,10 @@ def runSingleUnitaryTest(no, module, test):
         writeTime(fileTime, CPUtime, coverage)
 
     # Recupere le tag local
-    pathStar = os.path.join(MODULESDIR['LOCAL'][module], module, 'test')
-    fileStar = os.path.join(pathStar, DATA, testr[0]+'.star')
-    tag = ' '
-    if os.access(fileStar, os.R_OK):
-        tag = readStar(fileStar)
+    tag = TESTMETA[module+'/'+test]['tag']
+
+    if update:  # Update test metadata
+        updateTestMetadata(module, test, CPUtime)
 
     # update status
     if success == 0: status = 'OK'
@@ -733,7 +707,7 @@ def runSingleUnitaryTest(no, module, test):
 # module = 'CFDBase'
 # test = nom du repertoire du cas CFD
 #==============================================================================
-def runSingleCFDTest(no, module, test):
+def runSingleCFDTest(no, module, test, update=False):
     global TESTS
     print('Info: Running CFD test %s.'%test)
     path = os.path.join(MODULESDIR[BASE4COMPARE]['CFDBase'], CFDBASEPATH, test)
@@ -808,11 +782,10 @@ def runSingleCFDTest(no, module, test):
         writeTime(fileTime, CPUtime, coverage)
 
     # Recupere le tag local
-    pathStar = os.path.join(MODULESDIR[BASE4COMPARE][module], module, 'test')
-    fileStar = os.path.join(pathStar, DATA, test+'.star')
-    tag = ' '
-    if os.access(fileStar, os.R_OK):
-        tag = readStar(fileStar)
+    tag = TESTMETA[module+'/'+test]['tag']
+
+    if update:  # Update test metadata
+        updateTestMetadata(module, test, CPUtime)
 
     # update status
     if success == 0: status = 'OK'
@@ -848,7 +821,7 @@ def getTestsTime():
 # Run selected tests
 # Update TESTS, update listbox, update progression
 #==============================================================================
-def runTests():
+def runTests(update=False):
     global STOP, THREAD
     selection = Listbox.curselection()
     displayStatus(1)
@@ -864,82 +837,138 @@ def runTests():
         test = splits[1]
         module = module.strip()
         test = test.strip()
+        if update:  # Delete reference
+            modulesDir = MODULESDIR[BASE4COMPARE][module]
+            if module == 'CFDBase':
+                pathl = os.path.join(modulesDir, CFDBASEPATH, test)
+                testref = 'post.ref*'
+            else:
+                pathl = os.path.join(modulesDir, module, 'test')
+                testref = os.path.splitext(test)[0] + '.ref*'  
+            rmFile(pathl, testref)
         current += 1; displayProgress(current, total, remaining, elapsed)
         remaining -= string2Time(splits[3])
-        CPUtime = runSingleTest(no, module, test)
+        CPUtime = runSingleTest(no, module, test, update)
         elapsed += CPUtime # real elapsed time
         if STOP == 1: STOP = 0; displayStatus(0); return
     displayStatus(0)
     THREAD=None
     writeSessionLog()
 
-def runTestsInThread():
+def runTestsInThread(update=False):
     global THREAD, STOP
     if THREAD is not None: return
     STOP = 0
-    THREAD = threading.Thread(target=runTests)
+    THREAD = threading.Thread(target=runTests, args=(update,))
     THREAD.start()
 
 #==============================================================================
-# Update the data base and metadata for selected tests
+# Load, fill, update, and write test metadata
 #==============================================================================
-def updateRefMetadata(refMDDict, module, test):
-    from datetime import datetime
-    testName = os.path.join(module, test)
+def loadTestMetadata(loc=None):
+    global TESTMETA
+    if loc is None: loc = BASE4COMPARE
+    metaFilename = os.path.join(VALIDDIR[loc], "testMetadata.json")
+    if os.access(metaFilename, os.R_OK):
+        with open(metaFilename, 'r') as f: TESTMETA = json.load(f)
+        if loc == 'GLOBAL':  # overwrite global tags with local tags
+            metaFilename = os.path.join(VALIDDIR['LOCAL'], "testMetadata.json")
+            if os.access(metaFilename, os.R_OK):
+                with open(metaFilename, 'r') as f: tmpMeta = json.load(f)
+                for testName in TESTMETA:
+                    if testName in tmpMeta:
+                        TESTMETA[testName]['tag'] = tmpMeta[testName].get('tag', ' ')
+    else: fillTestMetadata()
+
+def newMetadata(coverage='...%', tag=' ', time='...'):
+    return {'coverage': coverage, 'tag': tag, 'ref': [], 'time': time}
+
+def newRefMetadata(date='...', hashCassiopee='Unknown', hashFast='Unknown'):
+    return {'date': date, 'hashCassiopee': hashCassiopee, 'hashFast': hashFast}
+
+def fillTestMetadata():
+    global TESTMETA, TESTMETA_UPDATE
+    TESTMETA = {}
+    TESTMETA_UPDATE = True
+    # Loop over all modules
+    for module in getModules():
+        tests = getTests(module)
+        # Loop over all tests of that module
+        for test in tests:
+            # Get local tag and reference time
+            modulesDirCmp = MODULESDIR[BASE4COMPARE][module]
+            modulesDirLoc = MODULESDIR['LOCAL'][module]
+            if module == 'CFDBase':
+                fileTime = os.path.join(modulesDirCmp, CFDBASEPATH, test, DATA, test+'.time')
+                fileStar = os.path.join(modulesDirLoc, CFDBASEPATH, test, DATA, test+'.star')
+            else:
+                testr = os.path.splitext(test)
+                fileTime = os.path.join(modulesDirCmp, module, 'test', DATA, testr[0]+'.time')
+                fileStar = os.path.join(modulesDirLoc, module, 'test', DATA, testr[0]+'.star')
+
+            if os.access(fileTime, os.R_OK):
+                with open(fileTime, 'r') as f: fileData = f.read().split('\n')
+                if len(fileData) > 0: refDate = fileData[0]
+                else: refDate = '...'
+                if len(fileData) > 1: refCPUtime = fileData[1]
+                else: refCPUtime = '...'
+                if len(fileData) > 3 and fileData[2] != '': refCoverage = fileData[2]
+                else: refCoverage = '...%'
+            else:
+                refDate = '...'
+                refCPUtime = '...'
+                refCoverage = '...%'
+            if os.access(fileStar, os.R_OK): refTag = readStar(fileStar)
+            else: refTag = ' '
+            
+            testName = module+'/'+test
+            TESTMETA[testName] = newMetadata(coverage=refCoverage, tag=refTag,
+                                             time=refCPUtime)
+            if refDate != '...':
+                TESTMETA[testName]['ref'].append(newRefMetadata(date=refDate))
+
+def updateTestMetadata(module, test, CPUtime='...'):
+    global TESTMETA, TESTMETA_UPDATE
+    TESTMETA_UPDATE = True
+    testName = module+'/'+test
     cassiopeeIncDir, fastIncDir = getInstallPaths()[:2]
     if fastIncDir is not None: hashFast = Dist.getGitHash(fastIncDir)[:7]
     else: hashFast = None
-    entry = {
-        "date": datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-        "hashCassiopee": Dist.getGitHash(cassiopeeIncDir)[:7],
-        "hashFast": hashFast
-    }
-    if testName in refMDDict: refMDDict[testName].append(entry)
-    else: refMDDict[testName] = [entry]
+    refEntry = newRefMetadata(
+        date=time.strftime('%d/%m/%y %Hh%M', time.localtime()),
+        hashCassiopee=Dist.getGitHash(cassiopeeIncDir)[:7],
+        hashFast=hashFast
+    )
+    if not isinstance(CPUtime, str):
+        mins = int(CPUtime//60)
+        secs = CPUtime%60
+        fullsec = int(secs)
+        csecs = int((secs - fullsec)*100)
+        CPUtime = "{}m{}.{:02d}s".format(mins, fullsec, csecs)
 
-def updateTests():
-    # Load ref metadata
-    import json
-    mDFilename = os.path.join(VALIDDIR['LOCAL'], "refs-metadata.json")
-    refMDDict = {}
-    if os.access(mDFilename, os.F_OK):
-        with open(mDFilename, 'r') as f:
-            refMDDict = json.load(f)
+    if testName in TESTMETA:
+        TESTMETA[testName]['time'] = CPUtime
+        if 'ref' in TESTMETA[testName]:
+            TESTMETA[testName]['ref'].insert(0, refEntry)
+            TESTMETA[testName]['ref'] = TESTMETA[testName]['ref'][:5]
+        else: TESTMETA[testName]['ref'] = [refEntry]
+    else:
+        TESTMETA[testName] = newMetadata(time=CPUtime)
+        TESTMETA[testName]['ref'] = [refEntry]
 
-    # Supprime les references
-    selection = Listbox.curselection()
-    for s in selection:
-        t = Listbox.get(s)
-        splits = t.split(separator)
-        module = splits[0]
-        test = splits[1]
-        module = module.strip()
-        testname = test.strip()
-        modulesDir = MODULESDIR[BASE4COMPARE][module]
-        if module == 'CFDBase':
-            pathl = os.path.join(modulesDir, CFDBASEPATH, testname)
-            test2 = testname+'.time'
-            test = 'post'+'.ref*'
-        else:
-            d = os.path.splitext(testname)
-            test = d[0]+'.ref*'
-            test2 = d[0]+'.time'
-            pathl = os.path.join(modulesDir, module, 'test')
-        rmFile(pathl, test)
-        rmFile(pathl, test2)
-        updateRefMetadata(refMDDict, module, testname)
+def writeTestMetadata():
+    if TESTMETA_UPDATE:
+        if BASE4COMPARE == 'GLOBAL':  # update tags in local test metadata only
+            from copy import deepcopy
+            tmpMeta = deepcopy(TESTMETA)
+            loadTestMetadata(loc='LOCAL')  # reload original local metadata
+            for testName in TESTMETA:
+                if testName in tmpMeta:
+                    TESTMETA[testName]['tag'] = tmpMeta[testName].get('tag', ' ')
 
-    # Run les tests
-    runTests()
-    # Update metadata
-    with open(mDFilename, 'w') as f:
-        json.dump(refMDDict, f, indent=4, sort_keys=True)
-
-def updateTestsInThread():
-    global THREAD
-    if THREAD is not None: return
-    THREAD = threading.Thread(target=updateTests)
-    THREAD.start()
+        metaFilename = os.path.join(VALIDDIR['LOCAL'], "testMetadata.json")
+        with open(metaFilename, 'w') as f:
+            json.dump(TESTMETA, f, indent=4, sort_keys=True)
 
 #==============================================================================
 # Supprime un fichier
@@ -1493,6 +1522,8 @@ def Quit(event=None):
         dst = os.path.join(VALIDDIR['LOCAL'], "session-{}.log".format(now))
         print("Saving session to: {}".format(dst))
         shutil.copyfile(logname, dst)
+    # Write test metadata
+    writeTestMetadata()
     os._exit(0)
 
 #==============================================================================
@@ -1502,7 +1533,8 @@ def Quit(event=None):
 # est globale
 #==============================================================================
 def tagSelection(event=None):
-    global TESTS
+    global TESTS, TESTMETA, TESTMETA_UPDATE
+    TESTMETA_UPDATE = True
     tagSymbols = '* r g b'.split()
     ntags = len(tagSymbols)
     selection = Listbox.curselection()
@@ -1512,14 +1544,10 @@ def tagSelection(event=None):
         splits = t.split(separator)
         module = splits[0].strip()
         test = splits[1].strip()
-        testr = os.path.splitext(test)
-        modulesDir = MODULESDIR['LOCAL'][module]
-        path = os.path.join(modulesDir, module, 'test')
-        fileStar = os.path.join(path, DATA, testr[0]+'.star')
         tag = splits[6].strip()
         if not tag: tag = '*'
         else: tag = tagSymbols[(tagSymbols.index(tag)+1)%ntags]
-        writeStar(fileStar, tag)
+        TESTMETA[module+'/'+test]['tag'] = tag
         splits[6] = ' {} '.format(tag)
         s = separator.join(i for i in splits)
         regTest = re.compile(' '+test+' ')
@@ -1533,7 +1561,8 @@ def tagSelection(event=None):
     return
 
 def untagSelection(event=None):
-    global TESTS
+    global TESTS, TESTMETA, TESTMETA_UPDATE
+    TESTMETA_UPDATE = True
     selection = Listbox.curselection()
     for s in selection:
         no = int(s)
@@ -1541,10 +1570,7 @@ def untagSelection(event=None):
         splits = t.split(separator)
         module = splits[0].strip()
         test = splits[1].strip()
-        testr = os.path.splitext(test)
-        modulesDir = MODULESDIR['LOCAL'][module]
-        path = os.path.join(modulesDir, module, 'test')
-        rmFile(path, testr[0]+'.star')
+        TESTMETA[module+'/'+test]['tag'] = ' '
         splits[6] = ' '*3
         s = separator.join(i for i in splits)
         regTest = re.compile(' '+test+' ')
@@ -1580,6 +1606,7 @@ def setupLocal(**kwargs):
 
     if INTERACTIVE: WIDGETS['UpdateButton'].configure(state=TK.NORMAL)
     createEmptySessionLog()
+    loadTestMetadata()
     buildTestList(**kwargs)
     updateDBLabel()
     return 0
@@ -1602,6 +1629,7 @@ def setupGlobal(**kwargs):
             setThreads()
     except: pass
     createEmptySessionLog()
+    loadTestMetadata()
     buildTestList(**kwargs)
     updateDBLabel()
     return 0
@@ -1853,6 +1881,7 @@ if __name__ == '__main__':
 
         Button = TK.Button(Frame, text='Stop', command=stopTests, fg='red')
         Button.grid(row=1, column=6, sticky=TK.EW)
+        updateTestsInThread = partial(runTestsInThread, True)
         UpdateButton = TK.Button(Frame, text='Update',
                                  command=updateTestsInThread, fg='blue')
         WIDGETS['UpdateButton'] = UpdateButton
@@ -1909,9 +1938,5 @@ if __name__ == '__main__':
                 if vcargs.leak_sanitizer: USE_ASAN[1] = True
                 updateASANOptions()
             selectAll()
-            runTests()
-            Quit()
-        elif vcargs.update:
-            selectAll()
-            updateTests()
+            runTests(update=vcargs.update)
             Quit()

--- a/Cassiopee/CPlot/apps/validCassiopee.py
+++ b/Cassiopee/CPlot/apps/validCassiopee.py
@@ -844,7 +844,7 @@ def runTests(update=False):
                 testref = 'post.ref*'
             else:
                 pathl = os.path.join(modulesDir, module, 'test')
-                testref = os.path.splitext(test)[0] + '.ref*'  
+                testref = os.path.splitext(test)[0] + '.ref*'
             rmFile(pathl, testref)
         current += 1; displayProgress(current, total, remaining, elapsed)
         remaining -= string2Time(splits[3])
@@ -920,7 +920,7 @@ def fillTestMetadata():
                 refCoverage = '...%'
             if os.access(fileStar, os.R_OK): refTag = readStar(fileStar)
             else: refTag = ' '
-            
+
             testName = module+'/'+test
             TESTMETA[testName] = newMetadata(coverage=refCoverage, tag=refTag,
                                              time=refCPUtime)


### PR DESCRIPTION
Test duration and tag added to the test metadata JSON dict in the ValidData folder. Use time and star file to first build the metadata file, then interrogate the JSON dict only which seems to be faster. Tags are local: markers will persist when switching to and from the local/global database. The reference history is kept down to a maximum of 5 entries.

- **May need further testing from other users before merging to _main_.**
- **Please do not push commits causing regressions while this commit is pending (metadata files already created and up-to-date on ld and juno).**

Example
```json
    "Apps/IBMrotation_t1.py": {
        "coverage": "0%",
        "ref": [
            {
                "date": "27/08/24 11h15",
                "hashCassiopee": "Unknown",
                "hashFast": "Unknown"
            }
        ],
        "tag": " ",
        "time": "0m2.49s"
    },
    "Apps/Mirabelle_t1.py": {
        "coverage": "0%",
        "ref": [
            {
                "date": "13/12/24 13h21",
                "hashCassiopee": "ff3425c",
                "hashFast": "3934c08"
            }
        ],
        "tag": " ",
        "time": "0m0.6s"
    },
```