### PR TITLE
[IBM] Change checkCartesian non-regression test cases. We now compare boolean and instead of a PyTree, thereby making these non-regressoin test cases lighter.

### DIFF
--- a/Cassiopee/Generator/test/checkCartesian_m1.py
+++ b/Cassiopee/Generator/test/checkCartesian_m1.py
@@ -23,13 +23,9 @@ t = Cmpi.convertFile2PyTree(LOCAL+'/t_TMP.cgns',proc=Cmpi.rank)
 
 ##Test 1 - Cartesian
 cartesian = G_IBM.checkCartesian(t)
-isCartesian = 0
-if cartesian: isCartesian=1
-Internal._createUniqueChild(t, 'TMP_Node', 'UserDefinedData_t')
-Internal._createUniqueChild(Internal.getNodeFromName1(t, 'TMP_Node'), 'Cartesian', 'DataArray_t', value=isCartesian)
 if Cmpi.rank == 0:
-    test.testT(t,1)
-    print('Is Cartesian::', cartesian, isCartesian)
+    test.testO(cartesian,1)
+    print('Is Cartesian::', cartesian)
 tsave = Internal.copyTree(t)
 #C.convertPyTree2File(t,'t_test1.cgns')
 
@@ -38,14 +34,9 @@ Internal._rmNode(t, Internal.getNodeFromName(t, 'TMP_Node'))
 coord = Internal.getNodeFromName(Internal.getZones(t)[0],'CoordinateZ')[1]
 for i in range(6): coord[:,:,i] = coord[:,:,i]*i/10+coord[:,:,i]
 cartesian = G_IBM.checkCartesian(t)
-
-isCartesian=0
-if cartesian: isCartesian=1
-Internal._createUniqueChild(t, 'TMP_Node', 'UserDefinedData_t')
-Internal._createUniqueChild(Internal.getNodeFromName1(t, 'TMP_Node'), 'Cartesian', 'DataArray_t', value=isCartesian)
 if Cmpi.rank == 0:
-    test.testT(t,2)
-    print('Is Cartesian::',cartesian,isCartesian)
+    test.testO(cartesian,2)
+    print('Is Cartesian::',cartesian)
 #C.convertPyTree2File(t,'t_test2.cgns')
 
 ## Test 3 - Y direction is non homogenous --> non Cartesian mesh
@@ -54,14 +45,9 @@ Internal._rmNode(t, Internal.getNodeFromName(t, 'TMP_Node'))
 coord = Internal.getNodeFromName(Internal.getZones(t)[0],'CoordinateY')[1]
 for i in range(6): coord[:,i,:] = coord[:,i,:]*i/10+coord[:,i,:]
 cartesian = G_IBM.checkCartesian(t)
-
-isCartesian=0
-if cartesian:isCartesian=1
-Internal._createUniqueChild(t, 'TMP_Node', 'UserDefinedData_t')
-Internal._createUniqueChild(Internal.getNodeFromName1(t, 'TMP_Node'), 'Cartesian', 'DataArray_t', value=isCartesian)
 if Cmpi.rank == 0:
-    test.testT(t,3)
-    print('Is Cartesian::',cartesian,isCartesian)
+    test.testO(cartesian,3)
+    print('Is Cartesian::',cartesian)
 #C.convertPyTree2File(t,'t_test3.cgns')
 
 ## Test 4 - Z direction is non homogenous --> non Cartesian mesh
@@ -70,14 +56,9 @@ Internal._rmNode(t, Internal.getNodeFromName(t, 'TMP_Node'))
 coord = Internal.getNodeFromName(Internal.getZones(t)[0],'CoordinateX')[1]
 for i in range(6): coord[i,:,:] = coord[i,:,:]*i/10+coord[i,:,:]
 cartesian = G_IBM.checkCartesian(t)
-
-isCartesian=0
-if cartesian:isCartesian=1
-Internal._createUniqueChild(t, 'TMP_Node', 'UserDefinedData_t')
-Internal._createUniqueChild(Internal.getNodeFromName1(t, 'TMP_Node'), 'Cartesian', 'DataArray_t', value=isCartesian)
 if Cmpi.rank == 0:
-    test.testT(t,4)
-    print('Is Cartesian::',cartesian,isCartesian)
+    test.testO(cartesian,4)
+    print('Is Cartesian::',cartesian)
 #C.convertPyTree2File(t,'t_test4.cgns')
 
 del t

--- a/Cassiopee/Generator/test/checkCartesian_t1.py
+++ b/Cassiopee/Generator/test/checkCartesian_t1.py
@@ -12,13 +12,9 @@ C._addState(t, 'EquationDimension', 3)
 
 ##Test 1 - Cartesian
 cartesian=G_IBM.checkCartesian(t)
-isCartesian=0
-if cartesian:isCartesian=1
-Internal._createUniqueChild(t, 'TMP_Node', 'UserDefinedData_t')
-Internal._createUniqueChild(Internal.getNodeFromName1(t, 'TMP_Node'), 'Cartesian', 'DataArray_t', value=isCartesian)
-test.testT(t,1)
+test.testO(cartesian,1)
 tsave = Internal.copyTree(t)
-print('Is Cartesian::',cartesian,isCartesian)
+print('Is Cartesian::',cartesian)
 #C.convertPyTree2File(t,'t_test1.cgns')
 
 ## Test 2 - Z direction is non homogenous --> non Cartesian mesh
@@ -26,13 +22,8 @@ Internal._rmNode(t, Internal.getNodeFromName(t, 'TMP_Node'))
 coord = Internal.getNodeFromName(t,'CoordinateZ')[1]
 for i in range(6): coord[:,:,i]=coord[:,:,i]*i/10+coord[:,:,i]
 cartesian=G_IBM.checkCartesian(t)
-
-isCartesian=0
-if cartesian:isCartesian=1
-Internal._createUniqueChild(t, 'TMP_Node', 'UserDefinedData_t')
-Internal._createUniqueChild(Internal.getNodeFromName1(t, 'TMP_Node'), 'Cartesian', 'DataArray_t', value=isCartesian)
-test.testT(t,2)
-print('Is Cartesian::',cartesian,isCartesian)
+test.testO(cartesian,2)
+print('Is Cartesian::',cartesian)
 #C.convertPyTree2File(t,'t_test2.cgns')
 
 ## Test 3 - Y direction is non homogenous --> non Cartesian mesh
@@ -41,26 +32,16 @@ Internal._rmNode(t, Internal.getNodeFromName(t, 'TMP_Node'))
 coord = Internal.getNodeFromName(t,'CoordinateY')[1]
 for i in range(6): coord[:,i,:]=coord[:,i,:]*i/10+coord[:,i,:]
 cartesian=G_IBM.checkCartesian(t)
-
-isCartesian=0
-if cartesian:isCartesian=1
-Internal._createUniqueChild(t, 'TMP_Node', 'UserDefinedData_t')
-Internal._createUniqueChild(Internal.getNodeFromName1(t, 'TMP_Node'), 'Cartesian', 'DataArray_t', value=isCartesian)
-test.testT(t,3)
-print('Is Cartesian::',cartesian,isCartesian)
+test.testO(cartesian,3)
+print('Is Cartesian::',cartesian)
 #C.convertPyTree2File(t,'t_test3.cgns')
 
-## Test 4 - Z direction is non homogenous --> non Cartesian mesh
+## Test 4 - X direction is non homogenous --> non Cartesian mesh
 t = Internal.copyTree(tsave)
 Internal._rmNode(t, Internal.getNodeFromName(t, 'TMP_Node'))
 coord = Internal.getNodeFromName(t,'CoordinateX')[1]
 for i in range(6): coord[i,:,:]=coord[i,:,:]*i/10+coord[i,:,:]
 cartesian=G_IBM.checkCartesian(t)
-
-isCartesian=0
-if cartesian:isCartesian=1
-Internal._createUniqueChild(t, 'TMP_Node', 'UserDefinedData_t')
-Internal._createUniqueChild(Internal.getNodeFromName1(t, 'TMP_Node'), 'Cartesian', 'DataArray_t', value=isCartesian)
-test.testT(t,4)
-print('Is Cartesian::',cartesian,isCartesian)
+test.testO(cartesian,4)
+print('Is Cartesian::',cartesian)
 #C.convertPyTree2File(t,'t_test4.cgns')

--- a/Cassiopee/Generator/test/checkCartesian_t2.py
+++ b/Cassiopee/Generator/test/checkCartesian_t2.py
@@ -12,13 +12,9 @@ C._addState(t, 'EquationDimension', 2)
 
 ##Test 1 - Cartesian
 cartesian=G_IBM.checkCartesian(t)
-isCartesian=0
-if cartesian:isCartesian=1
-Internal._createUniqueChild(t, 'TMP_Node', 'UserDefinedData_t')
-Internal._createUniqueChild(Internal.getNodeFromName1(t, 'TMP_Node'), 'Cartesian', 'DataArray_t', value=isCartesian)
-test.testT(t,1)
+test.testO(cartesian,1)
 tsave = Internal.copyTree(t)
-print('Is Cartesian::',cartesian,isCartesian)
+print('Is Cartesian::',cartesian)
 #C.convertPyTree2File(t,'t_test1.cgns')
 
 ## Test 2 - Y direction is non homogenous --> non Cartesian mesh
@@ -27,26 +23,16 @@ Internal._rmNode(t, Internal.getNodeFromName(t, 'TMP_Node'))
 coord = Internal.getNodeFromName(t,'CoordinateY')[1]
 for i in range(6): coord[:,i,:]=coord[:,i,:]*i/10+coord[:,i,:]
 cartesian=G_IBM.checkCartesian(t)
-
-isCartesian=0
-if cartesian:isCartesian=1
-Internal._createUniqueChild(t, 'TMP_Node', 'UserDefinedData_t')
-Internal._createUniqueChild(Internal.getNodeFromName1(t, 'TMP_Node'), 'Cartesian', 'DataArray_t', value=isCartesian)
-test.testT(t,2)
-print('Is Cartesian::',cartesian,isCartesian)
+test.testO(cartesian,2)
+print('Is Cartesian::',cartesian)
 #C.convertPyTree2File(t,'t_test2.cgns')
 
-## Test 3 - Z direction is non homogenous --> non Cartesian mesh
+## Test 3 - X direction is non homogenous --> non Cartesian mesh
 t = Internal.copyTree(tsave)
 Internal._rmNode(t, Internal.getNodeFromName(t, 'TMP_Node'))
 coord = Internal.getNodeFromName(t,'CoordinateX')[1]
 for i in range(6): coord[i,:,:]=coord[i,:,:]*i/10+coord[i,:,:]
 cartesian=G_IBM.checkCartesian(t)
-
-isCartesian=0
-if cartesian:isCartesian=1
-Internal._createUniqueChild(t, 'TMP_Node', 'UserDefinedData_t')
-Internal._createUniqueChild(Internal.getNodeFromName1(t, 'TMP_Node'), 'Cartesian', 'DataArray_t', value=isCartesian)
-test.testT(t,3)
-print('Is Cartesian::',cartesian,isCartesian)
+test.testO(cartesian,3)
+print('Is Cartesian::',cartesian)
 #C.convertPyTree2File(t,'t_test3.cgns')

--- a/Cassiopee/Generator/test/checkCartesian_t3.py
+++ b/Cassiopee/Generator/test/checkCartesian_t3.py
@@ -14,13 +14,9 @@ t = T.splitNParts(t, 10)
 
 ##Test 1 - Cartesian
 cartesian=G_IBM.checkCartesian(t)
-isCartesian=0
-if cartesian:isCartesian=1
-Internal._createUniqueChild(t, 'TMP_Node', 'UserDefinedData_t')
-Internal._createUniqueChild(Internal.getNodeFromName1(t, 'TMP_Node'), 'Cartesian', 'DataArray_t', value=isCartesian)
-test.testT(t,1)
+test.testO(cartesian,1)
 tsave = Internal.copyTree(t)
-print('Is Cartesian::',cartesian,isCartesian)
+print('Is Cartesian::',cartesian)
 #C.convertPyTree2File(t,'t_test1.cgns')
 
 ## Test 2 - Z direction is non homogenous --> non Cartesian mesh
@@ -28,13 +24,8 @@ Internal._rmNode(t, Internal.getNodeFromName(t, 'TMP_Node'))
 coord = Internal.getNodeFromName(Internal.getZones(t)[0],'CoordinateZ')[1]
 for i in range(6): coord[:,:,i]=coord[:,:,i]*i/10+coord[:,:,i]
 cartesian=G_IBM.checkCartesian(t)
-
-isCartesian=0
-if cartesian:isCartesian=1
-Internal._createUniqueChild(t, 'TMP_Node', 'UserDefinedData_t')
-Internal._createUniqueChild(Internal.getNodeFromName1(t, 'TMP_Node'), 'Cartesian', 'DataArray_t', value=isCartesian)
-test.testT(t,2)
-print('Is Cartesian::',cartesian,isCartesian)
+test.testO(cartesian,2)
+print('Is Cartesian::',cartesian)
 #C.convertPyTree2File(t,'t_test2.cgns')
 
 ## Test 3 - Y direction is non homogenous --> non Cartesian mesh
@@ -43,13 +34,8 @@ Internal._rmNode(t, Internal.getNodeFromName(t, 'TMP_Node'))
 coord = Internal.getNodeFromName(Internal.getZones(t)[0],'CoordinateY')[1]
 for i in range(6): coord[:,i,:]=coord[:,i,:]*i/10+coord[:,i,:]
 cartesian=G_IBM.checkCartesian(t)
-
-isCartesian=0
-if cartesian:isCartesian=1
-Internal._createUniqueChild(t, 'TMP_Node', 'UserDefinedData_t')
-Internal._createUniqueChild(Internal.getNodeFromName1(t, 'TMP_Node'), 'Cartesian', 'DataArray_t', value=isCartesian)
-test.testT(t,3)
-print('Is Cartesian::',cartesian,isCartesian)
+test.testO(cartesian,3)
+print('Is Cartesian::',cartesian)
 #C.convertPyTree2File(t,'t_test3.cgns')
 
 ## Test 4 - Z direction is non homogenous --> non Cartesian mesh
@@ -58,11 +44,6 @@ Internal._rmNode(t, Internal.getNodeFromName(t, 'TMP_Node'))
 coord = Internal.getNodeFromName(Internal.getZones(t)[0],'CoordinateX')[1]
 for i in range(6): coord[i,:,:]=coord[i,:,:]*i/10+coord[i,:,:]
 cartesian=G_IBM.checkCartesian(t)
-
-isCartesian=0
-if cartesian:isCartesian=1
-Internal._createUniqueChild(t, 'TMP_Node', 'UserDefinedData_t')
-Internal._createUniqueChild(Internal.getNodeFromName1(t, 'TMP_Node'), 'Cartesian', 'DataArray_t', value=isCartesian)
-test.testT(t,4)
-print('Is Cartesian::',cartesian,isCartesian)
+test.testO(cartesian,4)
+print('Is Cartesian::',cartesian)
 #C.convertPyTree2File(t,'t_test4.cgns')


### PR DESCRIPTION
See title - using testO instead of testT. Regressions are expected in  :

- Generator/test/checkCartesian_m1.py
- Generator/test/checkCartesian_t1.py
- Generator/test/checkCartesian_t2.py
- Generator/test/checkCartesian_t3.py

Changes made upon suggestion from @benoit128 