### PR TITLE
G_IBM: modif tol. for octree refinement using tbox.

### DIFF
--- a/Cassiopee/Generator/Generator/IBM.py
+++ b/Cassiopee/Generator/Generator/IBM.py
@@ -943,7 +943,7 @@ def addRefinementZones__(o, tb, tbox, snearsf, vmin, dim):
         to = X_IBM.blankByIBCBodies(to, tbSolid, 'nodes', 3)
         to = C.node2Center(to, 'cellN')
         Internal._rmNodesFromName(to, Internal.__FlowSolutionNodes__)
-        C._initVars(to, '{centers:cellN}=({centers:cellN}>0.9)')
+        C._initVars(to, '{centers:cellN}=({centers:cellN}>0.1)')
         C._initVars(to, '{centers:cellNBody}={centers:cellN}')
         nob = 0
         C._initVars(to, 'centers:indicator', 0.)


### PR DESCRIPTION
This commit changes the tolerance of cellN values during octree refinement using refinement bodies (tbox) due to the center2node operations applied to this field.

The same tolerance should not be used for blanking by the IBC bodies and blanking by the tbox bodies. For the former, we want to refine the octree for every cell that has even a small part inside the fluid domain. On the other hand, to ensure that the resolution is propagated far enough, the tolerance must now be set high enough to refine the octree up to the tbox boundaries.

See the two images attached: before and after the change. Since both tolerances were set to 0.9, the refinement could fail locally near the immersed boundaries (here a LEISA multi-element airfoil).

![before](https://github.com/user-attachments/assets/a1ce488f-e99f-4b1c-bd16-e566059c98a9)
![after](https://github.com/user-attachments/assets/24a327c2-fcbc-4081-b665-30ae5525a244)
