### PR TITLE
CPlot: small bug fix for tkibc

### DIFF
--- a/Cassiopee/CPlot/apps/tkIBC.py
+++ b/Cassiopee/CPlot/apps/tkIBC.py
@@ -349,7 +349,7 @@ def createApp(win):
     # -0- Snear -
     V = TK.DoubleVar(win); V.set(0.01); VARS.append(V)
     # -1- IBC type -
-    V = TK.StringVar(win); V.set('symmetry'); VARS.append(V)
+    V = TK.StringVar(win); V.set('None'); VARS.append(V)
     # -2- dfar local -
     V = TK.DoubleVar(win); V.set(20.); VARS.append(V)
     # -3- mask inv or not -
@@ -596,7 +596,7 @@ def createApp(win):
     B = TTK.Entry(wmm, textvariable=VARS[14], width=4, background="White")
     B.grid(row=11, column=2, sticky=TK.EW)
 
-    if 'tkViewMode' in CTK.PREFS: setMode()
+    setMode()
 
     ## - Zones that are missing IBC info  -
     #B = TTK.Label(Frame, text="No IBC (Zones)")


### PR DESCRIPTION
Initialization of the tkibc applet could be wrong if tkViewMode was not defined in the user's personal config file!
Default ibctype is also changed from 'Symmetry' to 'None'.

See below for an illustration of the problem:

![Pb_tkIBC](https://github.com/user-attachments/assets/4db2640f-49e0-4322-83b5-e7523da92e72)
