### PR TITLE
CPlot: validCassiopee: fails to set a different number of threads

### DIFF
--- a/Cassiopee/CPlot/apps/validCassiopee.py
+++ b/Cassiopee/CPlot/apps/validCassiopee.py
@@ -288,7 +288,7 @@ def check_output(cmd, shell, stderr):
                                    shell=shell, preexec_fn=ossid)
 
         # max accepted time is between 2 to 6 minutes
-        nthreads = float(KCore.kcore.getOmpMaxThreads())
+        nthreads = float(Threads.get())
         timeout = (100. + 120.*Dist.DEBUG)*(1. + 4.8/nthreads)
         stdout, stderr = PROCESS.communicate(None, timeout=timeout)
 
@@ -601,7 +601,7 @@ def runSingleUnitaryTest(no, module, test, update=False):
 
     m1 = expTest1.search(test) # seq (True) ou distribue (False)
 
-    nthreads = KCore.kcore.getOmpMaxThreads()
+    nthreads = int(Threads.get())
     bktest = "bk_{0}".format(test) # backup
 
     if mySystem == 'mingw' or mySystem == 'windows':
@@ -721,7 +721,7 @@ def runSingleCFDTest(no, module, test, update=False):
         try: import mpi4py
         except: m1 = None
 
-    nthreads = KCore.kcore.getOmpMaxThreads()
+    nthreads = int(Threads.get())
 
     if mySystem == 'mingw' or mySystem == 'windows':
         # Commande Dos (sans time)


### PR DESCRIPTION
In `runTests` that is called as
```py
threading.Thread(target=runTests, args=(update,))
```
a call to `KCore.kcore.getOmpMaxThreads()` always returns the default maximum number of threads, for ex. 48 on juno (thanks @alexandre-suss for spotting it). Setting another number in the dedicated text box does not propagate in `runTests`.

@benoit128 , would you happen to know why that is? Please reject this PR if there's a better solution.

The code is now using the value stored in the StringVar() `Threads`.

Example
```
Info: Num threads set to 37.

Running connectMatchPT_m1.py with Nprocs=2 and Nthreads=18

[...]

Running connectMatchPT_t1.py with Nprocs=0 and Nthreads=37
```