### PR TITLE
Apps/LBM: Removing the object-oriented part from Apps LBM.py

### DIFF
--- a/Cassiopee/Apps/Apps/Fast/LBM.py
+++ b/Cassiopee/Apps/Apps/Fast/LBM.py
@@ -1,11 +1,8 @@
 # Class for FastLBM prepare
-import FastC.PyTree as FastC
 import Converter.PyTree as C
-import Generator.PyTree as G
 import Transform.PyTree as T
 import Converter.Internal as Internal
 import Connector.PyTree as X
-from Apps.Fast.Common import Common
 import numpy
 try: range = xrange
 except: pass
@@ -21,7 +18,6 @@ def prepare(t_case, t_out, tc_out, translation=[0.,0.,0.], NP=0, format='single'
     # sequential prep
     if rank == 0: ret = prepare0(t_case, t_out, tc_out, translation, NP, format, NG=NG)
     return ret
-
 
 def prepare0(t_case, t_out, tc_out, translation=[0.,0.,0.], NP=0, format='single',NG=1):
     if isinstance(t_case, str): t = C.convertFile2PyTree(t_case)
@@ -344,28 +340,3 @@ def prepareNonUniform0(t_case, t_out, tc_out, zones_dict={}, translation=[0.,0.,
         Internal.createChild(z, 'ZoneRind', 'Rind_t',value=rindplanes, children=[])
 
     return t, tc
-
-#====================================================================================
-class LBM(Common):
-    """Preparation et caculs avec le module FastLBM."""
-    def __init__(self, format=None, numb=None, numz=None):
-        Common.__init__(self, format, numb, numz)
-        self.__version__ = "0.0"
-        self.authors = ["stephanie.peron@onera.fr"]
-        self.cartesian = True
-
-    # Prepare
-    def prepare(self, t_case, t_out=None, tc_out=None, NP=0, translation=[0.,0.,0.],NG=1):
-        #if NP is None: NP = Cmpi.size
-        #if NP == 0: print('Preparing for a sequential computation.')
-        #else: print('Preparing for a computation on %d processors.'%NP)
-        ret = prepare(t_case, t_out, tc_out, translation=translation, NP=NP, format=self.data['format'],NG=NG)
-        return ret
-
-    # Prepare for non uniform grids (overset and/or grid refinement)
-    def prepareNonUniform(self, t_case, t_out=None, tc_out=None, NP=0, zones_dict={}, translation=[0.,0.,0.],NG=1):
-        #if NP is None: NP = Cmpi.size
-        #if NP == 0: print('Preparing for a sequential computation.')
-        #else: print('Preparing for a computation on %d processors.'%NP)
-        ret = prepareNonUniform(t_case, t_out, tc_out, zones_dict=zones_dict, translation=translation, NP=NP, format=self.data['format'],NG=NG)
-        return ret

--- a/Cassiopee/Apps/test/FastLBM_t1.py
+++ b/Cassiopee/Apps/test/FastLBM_t1.py
@@ -1,5 +1,5 @@
 # - PSEUDO ISENTROPIC VORTEX MULTIBLOCK (pyTree) -
-import Apps.Fast.LBM as App
+import Apps.Fast.LBM as Apps_LBM
 import Connector.PyTree as X
 import Converter.Internal as Internal
 import Converter.PyTree as C
@@ -11,7 +11,6 @@ import Transform.PyTree as T
 import math
 import numpy
 
-myApp = App.LBM(format='single')
 VARSMACRO = ['Density','VelocityX','VelocityY','VelocityZ','Temperature']
 
 # Geometry and mesh
@@ -52,7 +51,7 @@ z_0 = C.getMeanValue(a1,'CoordinateZ')
 zmean = C.getMeanValue(a1,'CoordinateZ')
 a1 = T.splitNParts(a1,8)
 t = C.newPyTree(['Base',a1])
-t,tc = myApp.prepare(t, t_out=None, tc_out=None, NP=0, translation=[(Nx-1)*dx, (Ny-1)*dx,(Nz-1)*dx],NG=NG)
+t,tc = Apps_LBM.prepare(t, t_out=None, tc_out=None, NP=0, translation=[(Nx-1)*dx, (Ny-1)*dx,(Nz-1)*dx],NG=NG)
 
 #-------------------------
 # Initialization
@@ -107,8 +106,6 @@ numz["LBM_coll_model"]      =colop_select
 numz["LBM_relax_time"]      =0.5
 
 
-myApp.set(numb=numb)
-myApp.set(numz=numz)
 FastC._setNum2Zones(t, numz); FastC._setNum2Base(t, numb)
 
 (t, tc, metrics)  = FastLBM.warmup(t, tc,nghost=NG,flag_initprecise=0)


### PR DESCRIPTION
This pull request refactors the Apps `LBM.py` file by removing the object-oriented programming (OOP) components. This change was motivated by the observation that the OOP paradigm was not fully utilized in the current implementation and introduced unnecessary complexity.

The test case `FastLBM_t1.py` has been updated accordingly to ensure no regression.

**Warning:** The modules `Fast`, `FastASLBM`, and `FastLBM` must be updated simultaneously with Cassiopee since they all have test cases that have been modified to no longer use the OOP paradigm.