### PR TITLE
Apps/MB: Removing the object-oriented part from Apps MB.py

### DIFF
--- a/Cassiopee/Apps/Apps/Fast/MB.py
+++ b/Cassiopee/Apps/Apps/Fast/MB.py
@@ -9,7 +9,6 @@ import Converter.PyTree as C
 import Transform.PyTree as T
 import Converter.Internal as Internal
 import Connector.PyTree as X
-from Apps.Fast.Common import Common
 
 #================================================================================
 # Multibloc prepare (avec split)
@@ -282,25 +281,6 @@ def post0(t_in, t_out, wall_out, format='single'):
     return a, w
 
 #====================================================================================
-class MB(Common):
-    """Preparation et calculs avec le module FastS."""
-    def __init__(self, format=None, numb=None, numz=None):
-        Common.__init__(self, format, numb, numz)
-        self.__version__ = "0.0"
-        self.authors = ["ash@onera.fr"]
-
-    # Prepare
-    def prepare(self, t_case, t_out, tc_out, NP):
-        if NP == 0: print('Preparing for a sequential computation.')
-        else: print('Preparing for a computation on %d processors.'%NP)
-        return prepare(t_case, t_out, tc_out, NP, self.data['format'])
-
-    # post-processing: extrait la solution aux neouds + le champs sur les surfaces
-    def post(self, t_in, t_out, wall_out):
-        return post(t_in, t_out, wall_out, self.data['format'])
-
-
-
 def calc_cp_cf(t,h,listzones,isRANS=False,wallType='BCWall',mode=None):
     h._loadZones(t, znp=listzones)
 

--- a/Cassiopee/Apps/test/FastMB_m1.py
+++ b/Cassiopee/Apps/test/FastMB_m1.py
@@ -10,15 +10,6 @@ test.TOLERANCE = 2.e-5
 
 LOCAL = test.getLocal()
 
-# myApp = Apps_Common.Common()
-# myApp.set(format='single')
-# myApp.set(numb={"temporal_scheme": "implicit",
-#                 "ss_iteration":3})
-# myApp.set(numz={"time_step": 0.0007,
-#                 "scheme":"roe_min",
-#                 "time_step_nature":"local",
-#                 "cfl":4.})
-
 if Cmpi.rank == 0: # prep en seq pour l'instant
     t, tc = Apps_MB.prepare('naca.cgns', t_out=LOCAL+'/t.cgns', tc_out=LOCAL+'/tc.cgns', NP=Cmpi.size)
     test.testT(tc, 2)

--- a/Cassiopee/Apps/test/FastMB_m1.py
+++ b/Cassiopee/Apps/test/FastMB_m1.py
@@ -1,5 +1,6 @@
 # - Fast.MB -
-import Apps.Fast.MB as App
+import Apps.Fast.MB as Apps_MB
+import Apps.Fast.Common as Apps_Common
 import KCore.test as test
 import Converter.PyTree as C
 import Converter.Internal as Internal
@@ -8,7 +9,7 @@ test.TOLERANCE = 2.e-5
 
 LOCAL = test.getLocal()
 
-myApp = App.MB()
+myApp = Apps_Common.Common()
 myApp.set(format='single')
 myApp.set(numb={"temporal_scheme": "implicit",
                 "ss_iteration":3})
@@ -18,7 +19,7 @@ myApp.set(numz={"time_step": 0.0007,
                 "cfl":4.})
 
 if Cmpi.rank == 0: # prep en seq pour l'instant
-    t, tc = myApp.prepare('naca.cgns', t_out=LOCAL+'/t.cgns', tc_out=LOCAL+'/tc.cgns', NP=Cmpi.size)
+    t, tc = Apps_MB.prepare('naca.cgns', t_out=LOCAL+'/t.cgns', tc_out=LOCAL+'/tc.cgns', NP=Cmpi.size)
     test.testT(tc, 2)
 Cmpi.barrier()
 

--- a/Cassiopee/Apps/test/FastMB_m1.py
+++ b/Cassiopee/Apps/test/FastMB_m1.py
@@ -5,25 +5,74 @@ import KCore.test as test
 import Converter.PyTree as C
 import Converter.Internal as Internal
 import Converter.Mpi as Cmpi
+import FastC.PyTree as FastC
 test.TOLERANCE = 2.e-5
 
 LOCAL = test.getLocal()
 
-myApp = Apps_Common.Common()
-myApp.set(format='single')
-myApp.set(numb={"temporal_scheme": "implicit",
-                "ss_iteration":3})
-myApp.set(numz={"time_step": 0.0007,
-                "scheme":"roe_min",
-                "time_step_nature":"local",
-                "cfl":4.})
+# myApp = Apps_Common.Common()
+# myApp.set(format='single')
+# myApp.set(numb={"temporal_scheme": "implicit",
+#                 "ss_iteration":3})
+# myApp.set(numz={"time_step": 0.0007,
+#                 "scheme":"roe_min",
+#                 "time_step_nature":"local",
+#                 "cfl":4.})
 
 if Cmpi.rank == 0: # prep en seq pour l'instant
     t, tc = Apps_MB.prepare('naca.cgns', t_out=LOCAL+'/t.cgns', tc_out=LOCAL+'/tc.cgns', NP=Cmpi.size)
     test.testT(tc, 2)
 Cmpi.barrier()
 
-t, tc = myApp.compute(LOCAL+'/t.cgns', LOCAL+'/tc.cgns', t_out=LOCAL+'/restart.cgns', nit=300)
+if Cmpi.size > 1:
+    import FastS.Mpi as FastS
+    rank = Cmpi.rank; size = Cmpi.size
+else:
+    import FastS.PyTree as FastS
+    rank = 0; size = 1
+
+t,tc,ts,graph = FastC.load(LOCAL+'/t.cgns', LOCAL+'/tc.cgns', split='single')
+
+# Numerics
+numb={"temporal_scheme": "implicit",
+                "ss_iteration":3}
+numz={"time_step": 0.0007,
+                "scheme":"roe_min",
+                "time_step_nature":"local",
+                "cfl":4.}
+
+FastC._setNum2Zones(t, numz); FastC._setNum2Base(t, numb)
+
+(t, tc, metrics) = FastS.warmup(t, tc, graph)
+
+it0 = 0; time0 = 0.
+first = Internal.getNodeFromName1(t, 'Iteration')
+if first is not None: it0 = Internal.getValue(first)
+first = Internal.getNodeFromName1(t, 'Time')
+if first is not None: time0 = Internal.getValue(first)
+time_step = Internal.getNodeFromName(t, 'time_step')
+time_step = Internal.getValue(time_step)
+
+if 'modulo_verif' in numb: moduloVerif = numb['modulo_verif']
+else: moduloVerif = 200
+
+NIT = 300
+for it in range(NIT):
+    FastS._compute(t, metrics, it, tc, graph)
+    if it%moduloVerif == 0:
+        if rank == 0: print('- %d / %d - %f'%(it+it0, NIT+it0, time0))
+        FastS.display_temporal_criteria(t, metrics, it, format='double')
+        #if it%50 == 0:
+        #    import CPlot.PyTree as CPlot
+        #    CPlot.display(t, dim=2, mode='Scalar', scalarField='Density')
+    time0 += time_step
+
+# time stamp
+Internal.createUniqueChild(t, 'Iteration', 'DataArray_t', value=it0+NIT)
+Internal.createUniqueChild(t, 'Time', 'DataArray_t', value=time0)
+
+FastC.save(t, LOCAL+'/restart.cgns', split='single', compress=0)
+if Cmpi.size > 1: Cmpi.barrier()
 
 Cmpi.barrier()
 if Cmpi.rank == 0:

--- a/Cassiopee/Apps/test/FastMB_t1.py
+++ b/Cassiopee/Apps/test/FastMB_t1.py
@@ -1,12 +1,13 @@
 # - Fast.MB -
-import Apps.Fast.MB as App
+import Apps.Fast.MB as Apps_MB
+import Apps.Fast.Common as Apps_Common
 import Converter.PyTree as C
 import Converter.Internal as Internal
 import KCore.test as test
 
 LOCAL = test.getLocal()
 
-myApp = App.MB()
+myApp = Apps_Common.Common()
 myApp.set(format='single')
 myApp.set(numb={"temporal_scheme": "implicit",
                 "ss_iteration":3})
@@ -15,7 +16,7 @@ myApp.set(numz={"time_step": 0.0007,
                 "time_step_nature":"local",
                 "cfl":4.})
 
-t, tc = myApp.prepare('naca.cgns', t_out=LOCAL+'/t.cgns', tc_out=LOCAL+'/tc.cgns', NP=0)
+t, tc = Apps_MB.prepare('naca.cgns', t_out=LOCAL+'/t.cgns', tc_out=LOCAL+'/tc.cgns', NP=0)
 test.testT(tc, 2)
 
 t, tc = myApp.compute(LOCAL+'/t.cgns', LOCAL+'/tc.cgns', t_out=LOCAL+'/restart.cgns', nit=300)

--- a/Cassiopee/Apps/test/FastMB_t1.py
+++ b/Cassiopee/Apps/test/FastMB_t1.py
@@ -1,25 +1,44 @@
 # - Fast.MB -
 import Apps.Fast.MB as Apps_MB
-import Apps.Fast.Common as Apps_Common
+import FastC.PyTree as FastC
+import FastS.PyTree as FastS
 import Converter.PyTree as C
 import Converter.Internal as Internal
 import KCore.test as test
 
 LOCAL = test.getLocal()
 
-myApp = Apps_Common.Common()
-myApp.set(format='single')
-myApp.set(numb={"temporal_scheme": "implicit",
-                "ss_iteration":3})
-myApp.set(numz={"time_step": 0.0007,
-                "scheme":"roe_min",
-                "time_step_nature":"local",
-                "cfl":4.})
-
 t, tc = Apps_MB.prepare('naca.cgns', t_out=LOCAL+'/t.cgns', tc_out=LOCAL+'/tc.cgns', NP=0)
 test.testT(tc, 2)
 
-t, tc = myApp.compute(LOCAL+'/t.cgns', LOCAL+'/tc.cgns', t_out=LOCAL+'/restart.cgns', nit=300)
+## Compute
+numb={
+    "temporal_scheme": "implicit",
+    "ss_iteration":3
+}
+numz={
+    "time_step": 0.0007,
+    "scheme":"roe_min",
+    "time_step_nature":"local",
+    "cfl":4.
+}
+
+it0 = 0; time0 = 0.
+FastC._setNum2Zones(t, numz); FastC._setNum2Base(t, numb)
+
+(t, tc, metrics) = FastS.warmup(t, tc)
+
+nit = 300
+for it in range(nit):
+    FastS._compute(t, metrics, it, tc)
+    time0 += numz['time_step']
+
+# time stamp
+Internal.createUniqueChild(t, 'Iteration', 'DataArray_t', value=it0+nit)
+Internal.createUniqueChild(t, 'Time', 'DataArray_t', value=time0)
+
+FastC.save(t, LOCAL+'/restart.cgns', split='single', compress=0)
+
 t = C.convertFile2PyTree(LOCAL+'/restart.cgns')
 Internal._rmNodesByName(t, '.Solver#Param')
 Internal._rmNodesByName(t, '.Solver#ownData')


### PR DESCRIPTION
This pull request refactors the Apps `MB.py` file by removing the object-oriented programming (OOP) components. This change was motivated by the observation that the OOP paradigm was not fully utilized in the current implementation and introduced unnecessary complexity.

The test cases `FastMB_t1.py` and `FastMB_m1.py` have been updated accordingly to ensure no regression.