### PR TITLE
[IBM] Update the area refinement functionality

### DIFF
--- a/Cassiopee/Generator/Generator/IBM.py
+++ b/Cassiopee/Generator/Generator/IBM.py
@@ -944,6 +944,7 @@ def addRefinementZones__(o, tb, tbox, snearsf, vmin, dim):
     G._getVolumeMap(to)
     volmin0 = C.getMinValue(to, 'centers:vol')
     # volume minimum au dela duquel on ne peut pas raffiner
+    if minSneartb>1.0e09: minSneartb=min(snearsf)
     volmin0 *= (min(1.0,min(snearsf)/minSneartb)**(dim))
     while end == 0:
         # Do not refine inside obstacles

--- a/Cassiopee/Generator/Generator/IBM.py
+++ b/Cassiopee/Generator/Generator/IBM.py
@@ -904,13 +904,6 @@ generateIBMMeshPara = generateIBMMesh
 # only in buildOctree
 def addRefinementZones__(o, tb, tbox, snearsf, vmin, dim):
     tbSolid = Internal.rmNodesByName(tb, 'IBCFil*')
-    minSneartb = 1.0e10
-    for s in Internal.getZones(tbSolid):
-        sdd = Internal.getNodeFromName1(s, ".Solver#define")
-        if sdd is not None:
-            snearl = Internal.getNodeFromName1(sdd, "snear")
-            if snearl is not None:
-                minSneartb=min(minSneartb,Internal.getValue(snearl)*(vmin-1))
 
     if dim == 2:
         tbSolid = T.addkplane(tbSolid)
@@ -944,7 +937,9 @@ def addRefinementZones__(o, tb, tbox, snearsf, vmin, dim):
     G._getVolumeMap(to)
     volmin0 = C.getMinValue(to, 'centers:vol')
     # volume minimum au dela duquel on ne peut pas raffiner
-    if minSneartb>1.0e09: minSneartb=min(snearsf)
+    snears = Internal.getNodesFromName(tbSolid, 'snear')
+    if snears != []: minSneartb= min(snears, key=lambda x: x[1])[1][0]*(vmin-1)
+    else: minSneartb= min(snearsf)
     volmin0 *= (min(1.0,min(snearsf)/minSneartb)**(dim))
     while end == 0:
         # Do not refine inside obstacles

--- a/Cassiopee/Generator/Generator/IBM.py
+++ b/Cassiopee/Generator/Generator/IBM.py
@@ -904,6 +904,14 @@ generateIBMMeshPara = generateIBMMesh
 # only in buildOctree
 def addRefinementZones__(o, tb, tbox, snearsf, vmin, dim):
     tbSolid = Internal.rmNodesByName(tb, 'IBCFil*')
+    minSneartb = 1.0e10
+    for s in Internal.getZones(tbSolid):
+        sdd = Internal.getNodeFromName1(s, ".Solver#define")
+        if sdd is not None:
+            snearl = Internal.getNodeFromName1(sdd, "snear")
+            if snearl is not None:
+                minSneartb=min(minSneartb,Internal.getValue(snearl)*(vmin-1))
+
     if dim == 2:
         tbSolid = T.addkplane(tbSolid)
         tbSolid = T.translate(tbSolid, (0,0,-0.5))
@@ -930,13 +938,13 @@ def addRefinementZones__(o, tb, tbox, snearsf, vmin, dim):
                     if snearl is not None:
                         snearl = Internal.getValue(snearl)
                         snearsf.append(snearl*(vmin-1))
-
+    
     to = C.newPyTree(['Base', o])
     end = 0
     G._getVolumeMap(to)
     volmin0 = C.getMinValue(to, 'centers:vol')
     # volume minimum au dela duquel on ne peut pas raffiner
-    volmin0 = 1.*volmin0
+    volmin0 *= (min(1.0,min(snearsf)/minSneartb)**(dim))
     while end == 0:
         # Do not refine inside obstacles
         C._initVars(to,'cellN',1.)

--- a/Cassiopee/Generator/Generator/IBM.py
+++ b/Cassiopee/Generator/Generator/IBM.py
@@ -931,7 +931,7 @@ def addRefinementZones__(o, tb, tbox, snearsf, vmin, dim):
                     if snearl is not None:
                         snearl = Internal.getValue(snearl)
                         snearsf.append(snearl*(vmin-1))
-    
+
     to = C.newPyTree(['Base', o])
     end = 0
     G._getVolumeMap(to)


### PR DESCRIPTION
The area refinement for IBMs can now support an area refinement that is smaller than the smallest snear of the immersed geometry. This facilities the generation of IBMs meshes as that seen below.
![image](https://github.com/user-attachments/assets/c1de32fe-f89b-4a8e-9c86-d311f411858d)
