### PR TITLE
[IBM] Add functionality to clip/limit the octree. This adds more control to the volume mesh generation for geometries that have a clear directional preference (e.g. Lx>> Ly -> Dfar in the Y direction can be expected to be smalelr than the Dfar in the X direction).

### DIFF
--- a/Cassiopee/Connector/Connector/IBM.py
+++ b/Cassiopee/Connector/Connector/IBM.py
@@ -185,7 +185,8 @@ def prepareIBMData(t_case, t_out, tc_out, t_in=None, to=None, tbox=None, tinit=N
                    snears=0.01, snearsf=None, dfars=10., dfarDir=0, vmin=21, depth=2, frontType=1, octreeMode=0,
                    IBCType=1, verbose=True, expand=3, ext=-1, optimized=1,
                    check=False, twoFronts=False, cartesian=True, cleanCellN=True,
-                   yplus=100., Lref=1., correctionMultiCorpsF42=False, blankingF42=False, wallAdaptF42=None, heightMaxF42=-1.):
+                   yplus=100., Lref=1., correctionMultiCorpsF42=False, blankingF42=False, wallAdaptF42=None, heightMaxF42=-1.,
+                   isOnlyOctree=False):
 
     import Generator.IBM as G_IBM
     import time as python_time
@@ -271,7 +272,7 @@ def prepareIBMData(t_case, t_out, tc_out, t_in=None, to=None, tbox=None, tinit=N
         test.printMem("Info: prepareIBMData: generate Cartesian mesh [start]")
         t = G_IBM.generateIBMMesh(tbLocal, vmin=vmin, snears=snears, dimPb=dimPb, dfars=dfars, tbox=tbox,
                                   snearsf=snearsf, check=check, to=to, ext=ext, optimized=optimized,
-                                  expand=expand, dfarDir=dfarDir, octreeMode=octreeMode)
+                                  expand=expand, dfarDir=dfarDir, octreeMode=octreeMode, isOnlyOctree=isOnlyOctree)
         Internal._rmNodesFromName(tb,"SYM")
 
         _redispatch__(t=t)

--- a/Cassiopee/Generator/Generator/IBM.py
+++ b/Cassiopee/Generator/Generator/IBM.py
@@ -714,7 +714,7 @@ def generateIBMMesh(tb, dimPb=3, vmin=15, snears=0.01, dfars=10., dfarDir=0,
         tbOneOverF1 = tbOneOver+tbF1
         tbox        = Internal.rmNodesByName(Internal.rmNodesByName(Internal.rmNodesByName(tbox, '*OneOver*'), '*KeepF1*'), '*RM*')
         if len(Internal.getBases(tbox))==0: tbox=None
-    
+
     # Octree identical on all procs
     if to is not None:
         if isinstance(to, str):
@@ -771,7 +771,7 @@ def generateIBMMesh(tb, dimPb=3, vmin=15, snears=0.01, dfars=10., dfarDir=0,
 
     if tbRM:
         to       = C.newPyTree(["OCTREE",o])
-        ##loop is needed to avoid unwanted & unexpected behavior 
+        ##loop is needed to avoid unwanted & unexpected behavior
         for b in Internal.getBases(tbRM):
             bodies   = [b]
             nBasesRM = len(bodies)
@@ -786,7 +786,7 @@ def generateIBMMesh(tb, dimPb=3, vmin=15, snears=0.01, dfars=10., dfarDir=0,
 
     if Cmpi.rank==0 and check: C.convertPyTree2File(o, 'octree.cgns')
     if isOnlyOctree: exit()
-    
+
     # Split octree
     bb = G.bbox(o)
     NPI = Cmpi.size


### PR DESCRIPTION
See tittle & see figure below for an example of the new functionality. Red: modified Octree; Black: original Octree
![image](https://github.com/user-attachments/assets/70ec989b-3b8a-464f-9fe2-89bb4fea0956)
![image](https://github.com/user-attachments/assets/117cf73f-4ffe-4d2a-bc7f-0efc5739502c)

