### PR TITLE
[IBM] Add functionality to clip/limit the octree. This adds more control to the volume mesh generation for geometries that have a clear directional preference (e.g. Lx>> Ly -> Dfar in the Y direction can be expected to be smalelr than the Dfar in the X direction).

### DIFF
--- a/Cassiopee/Connector/Connector/IBM.py
+++ b/Cassiopee/Connector/Connector/IBM.py
@@ -185,8 +185,7 @@ def prepareIBMData(t_case, t_out, tc_out, t_in=None, to=None, tbox=None, tinit=N
                    snears=0.01, snearsf=None, dfars=10., dfarDir=0, vmin=21, depth=2, frontType=1, octreeMode=0,
                    IBCType=1, verbose=True, expand=3, ext=-1, optimized=1,
                    check=False, twoFronts=False, cartesian=True, cleanCellN=True,
-                   yplus=100., Lref=1., correctionMultiCorpsF42=False, blankingF42=False, wallAdaptF42=None, heightMaxF42=-1.,
-                   isOnlyOctree=False):
+                   yplus=100., Lref=1., correctionMultiCorpsF42=False, blankingF42=False, wallAdaptF42=None, heightMaxF42=-1.):
 
     import Generator.IBM as G_IBM
     import time as python_time
@@ -272,7 +271,7 @@ def prepareIBMData(t_case, t_out, tc_out, t_in=None, to=None, tbox=None, tinit=N
         test.printMem("Info: prepareIBMData: generate Cartesian mesh [start]")
         t = G_IBM.generateIBMMesh(tbLocal, vmin=vmin, snears=snears, dimPb=dimPb, dfars=dfars, tbox=tbox,
                                   snearsf=snearsf, check=check, to=to, ext=ext, optimized=optimized,
-                                  expand=expand, dfarDir=dfarDir, octreeMode=octreeMode, isOnlyOctree=isOnlyOctree)
+                                  expand=expand, dfarDir=dfarDir, octreeMode=octreeMode)
         Internal._rmNodesFromName(tb,"SYM")
 
         _redispatch__(t=t)

--- a/Cassiopee/Connector/Connector/IBM.py
+++ b/Cassiopee/Connector/Connector/IBM.py
@@ -185,7 +185,8 @@ def prepareIBMData(t_case, t_out, tc_out, t_in=None, to=None, tbox=None, tinit=N
                    snears=0.01, snearsf=None, dfars=10., dfarDir=0, vmin=21, depth=2, frontType=1, octreeMode=0,
                    IBCType=1, verbose=True, expand=3, ext=-1, optimized=1,
                    check=False, twoFronts=False, cartesian=True, cleanCellN=True,
-                   yplus=100., Lref=1., correctionMultiCorpsF42=False, blankingF42=False, wallAdaptF42=None, heightMaxF42=-1.):
+                   yplus=100., Lref=1., correctionMultiCorpsF42=False, blankingF42=False, wallAdaptF42=None, heightMaxF42=-1.,
+                   isOnlyOctree=False):
 
     import Generator.IBM as G_IBM
     import time as python_time
@@ -271,7 +272,7 @@ def prepareIBMData(t_case, t_out, tc_out, t_in=None, to=None, tbox=None, tinit=N
         test.printMem("Info: prepareIBMData: generate Cartesian mesh [start]")
         t = G_IBM.generateIBMMesh(tbLocal, vmin=vmin, snears=snears, dimPb=dimPb, dfars=dfars, tbox=tbox,
                                   snearsf=snearsf, check=check, to=to, ext=ext, optimized=optimized,
-                                  expand=expand, dfarDir=dfarDir, octreeMode=octreeMode)
+                                  expand=expand, dfarDir=dfarDir, octreeMode=octreeMode, isOnlyOctree=isOnlyOctree)
         Internal._rmNodesFromName(tb,"SYM")
 
         _redispatch__(t=t)

--- a/Cassiopee/Generator/Generator/IBM.py
+++ b/Cassiopee/Generator/Generator/IBM.py
@@ -714,7 +714,7 @@ def generateIBMMesh(tb, dimPb=3, vmin=15, snears=0.01, dfars=10., dfarDir=0,
         tbOneOverF1 = tbOneOver+tbF1
         tbox        = Internal.rmNodesByName(Internal.rmNodesByName(Internal.rmNodesByName(tbox, '*OneOver*'), '*KeepF1*'), '*RM*')
         if len(Internal.getBases(tbox))==0: tbox=None
-    
+
     # Octree identical on all procs
     if to is not None:
         if isinstance(to, str):
@@ -771,7 +771,7 @@ def generateIBMMesh(tb, dimPb=3, vmin=15, snears=0.01, dfars=10., dfarDir=0,
 
     if tbRM:
         to       = C.newPyTree(["OCTREE",o])
-        ##loop is needed to avoid unwanted & unexpected behavior 
+        ##loop is needed to avoid unwanted & unexpected behavior
         for b in Internal.getBases(tbRM):
             bodies   = [b]
             nBasesRM = len(bodies)
@@ -786,7 +786,7 @@ def generateIBMMesh(tb, dimPb=3, vmin=15, snears=0.01, dfars=10., dfarDir=0,
 
     if Cmpi.rank==0 and check: C.convertPyTree2File(o, 'octree.cgns')
     if isOnlyOctree: exit()
-    
+
     # Split octree
     bb = G.bbox(o)
     NPI = Cmpi.size

--- a/Cassiopee/Generator/Generator/IBM.py
+++ b/Cassiopee/Generator/Generator/IBM.py
@@ -688,17 +688,9 @@ def buildParentOctrees__(o, tb, dimPb=3, vmin=15, snears=0.01, snearFactor=1., d
                     OCTREEPARENTS.append(parento2)
     return OCTREEPARENTS
 
-# main function
-def generateIBMMesh(tb, dimPb=3, vmin=15, snears=0.01, dfars=10., dfarDir=0,
-                    tbox=None, snearsf=None, check=False, to=None,
-                    ext=2, optimized=1, expand=3, octreeMode=0, isOnlyOctree=False):
-    """Generates the full Cartesian mesh for IBMs."""
-    import KCore.test as test
-    # refinementSurfFile: surface meshes describing refinement zones
-    if tbox is not None:
-        if isinstance(tbox, str): tbox = C.convertFile2PyTree(tbox)
-        else: tbox = tbox
-
+def generateIBMOctree(tb, dimPb=3, vmin=15, snears=0.01, dfars=10., dfarDir=0,
+                      tbox=None, snearsf=None, check=False, to=None,
+                      expand=3, octreeMode=0):
     ## tbox = tbox(area refinement)[legacy tbox] + tb(area for one over)[tbOneOver] + tb(zones to keep as F1)[tbF1]
     ## here we divide tbox into tbOneOver (rectilinear region)  & tbF1 (WM F1 approach region) & tbox; tbox will henceforth only consist of the area that will be refined.
     ## Note: tb(zones to keep as F1)[tbF1] is still in development, is experimental, & subject to major/minor changes with time. Please use with a lot of caution & see A.Jost @ DAAA/DEFI [28/08/2024] as
@@ -771,21 +763,35 @@ def generateIBMMesh(tb, dimPb=3, vmin=15, snears=0.01, dfars=10., dfarDir=0,
 
     if tbRM:
         to       = C.newPyTree(["OCTREE",o])
-        ##loop is needed to avoid unwanted & unexpected behavior
-        for b in Internal.getBases(tbRM):
-            bodies   = [b]
-            nBasesRM = len(bodies)
-            BM2      = numpy.ones((2,nBasesRM),dtype=Internal.E_NpyInt)
-            if dimPb ==2:
-                XRAYDIM1 = 20000; XRAYDIM2 = XRAYDIM1
-                to = X.blankCells(to, bodies, BM2, blankingType='node_in', XRaydim1=XRAYDIM1, XRaydim2=XRAYDIM2, dim=dimPb, cellNName='cellN')
-            else:
-                to = X.blankCellsTri(to, bodies, BM2, blankingType='node_in', cellNName='cellN')
-            to = P.selectCells(to,'{cellN}>0.',strict=1)
-            o = Internal.getZones(to)[0]
+        bodies   = [Internal.getBases(tbRM)]
+        nBasesRM = len(bodies)
+        BM2      = numpy.ones((2,nBasesRM),dtype=Internal.E_NpyInt)
+        if dimPb ==2:
+            XRAYDIM1 = 20000; XRAYDIM2 = XRAYDIM1
+            to = X.blankCells(to, bodies, BM2, blankingType='node_in', XRaydim1=XRAYDIM1, XRaydim2=XRAYDIM2, dim=dimPb, cellNName='cellN')
+        else:
+            to = X.blankCellsTri(to, bodies, BM2, blankingType='node_in', cellNName='cellN')
+        to = P.selectCells(to,'{cellN}<=0.',strict=1)
+        C._initVars(to,'{cellN}=1')
+        o = Internal.getZones(to)[0]
 
     if Cmpi.rank==0 and check: C.convertPyTree2File(o, 'octree.cgns')
-    if isOnlyOctree: exit()
+    return o, parento, tbOneOver, tbF1, tbOneOverF1, symmetry
+
+# main function
+def generateIBMMesh(tb, dimPb=3, vmin=15, snears=0.01, dfars=10., dfarDir=0,
+                    tbox=None, snearsf=None, check=False, to=None,
+                    ext=2, optimized=1, expand=3, octreeMode=0):
+    """Generates the full Cartesian mesh for IBMs."""
+    import KCore.test as test
+    # refinementSurfFile: surface meshes describing refinement zones
+    if tbox is not None:
+        if isinstance(tbox, str): tbox = C.convertFile2PyTree(tbox)
+        else: tbox = tbox
+
+    o, parento, tbOneOver, tbF1, tbOneOverF1, symmetry = generateIBMOctree(tb, dimPb=dimPb, vmin=vmin, snears=snears, dfars=dfars, dfarDir=dfarDir,
+                                                                           tbox=tbox, snearsf=snearsf, check=check, to=to,
+                                                                           expand=expand, octreeMode=octreeMode)
 
     # Split octree
     bb = G.bbox(o)


### PR DESCRIPTION
Improved implementation of the commit proposed in #319.

A frutiful discussion with @BconstantMMK highlighted this more streamlined approach.