### PR TITLE
X_IBM: bug fix adaptF42, increase tol for 2nd IP

### DIFF
--- a/Cassiopee/Connector/Connector/IBM.py
+++ b/Cassiopee/Connector/Connector/IBM.py
@@ -2376,8 +2376,8 @@ def getAllIBMPoints(t, loc='nodes', hi=0., he=0., tb=None, tfront=None, frontTyp
             snearl = xt[1]-xt[0]
             if twoFronts: snearl *= 2
             listOfSnearsLoc.append(snearl)
-            
-            if frontType == 42: 
+
+            if frontType == 42:
                 hmod = G_IBM_Height.computeModelisationHeight(Re=Reynolds, yplus=yplus, L=Lref)
                 if twoFronts: hmod *= 2
                 listOfModelisationHeightsLoc.append(hmod)
@@ -2404,8 +2404,8 @@ def getAllIBMPoints(t, loc='nodes', hi=0., he=0., tb=None, tfront=None, frontTyp
             snearl = xt[1]-xt[0]
             if twoFronts: snearl *= 2
             listOfSnearsLoc.append(snearl)
-            
-            if frontType == 42: 
+
+            if frontType == 42:
                 hmod = G_IBM_Height.computeModelisationHeight(Re=Reynolds, yplus=yplus, L=Lref)
                 if twoFronts: hmod *= 2
                 listOfModelisationHeightsLoc.append(hmod)

--- a/Cassiopee/Connector/Connector/IBM.py
+++ b/Cassiopee/Connector/Connector/IBM.py
@@ -558,7 +558,7 @@ def prepareIBMDataAdapt(t_case, t_out, tc_out, t_in,
 
     import time as python_time
 
-    if model is None: raise ValueError('prepareIBMDataAdapt: input tree is missing.')
+    if t_in is None: raise ValueError('prepareIBMDataAdapt: input tree is missing.')
 
     if isinstance(t_in, str): t = Cmpi.convertFile2PyTree(t_in, proc=Cmpi.rank)
     else: t = Internal.copyTree(t_in)
@@ -644,7 +644,7 @@ def prepareIBMDataAdapt(t_case, t_out, tc_out, t_in,
     #===================
     if verbose: pt0 = python_time.time(); printTimeAndMemory__('initialize and clean', time=-1)
 
-    t, tc, tc2 = initializeIBM(Internal.copyRef(t), tc, tb, dimPb=dimPb, twoFronts=twoFronts)
+    _, tc, tc2 = initializeIBM(None, tc, tb, dimPb=dimPb, twoFronts=twoFronts)
 
     _redispatch__(t=t, tc=tc, tc2=tc2)
 
@@ -1828,7 +1828,7 @@ def initializeIBM(t, tc, tb, tinit=None, tbCurvi=None, dimPb=3, twoFronts=False,
     if ibctypes is None: raise ValueError('initializeIBM: ibctype is missing in input geometry tree.')
     ibctypes = list(set(Internal.getValue(ibc) for ibc in ibctypes))
 
-    if model != 'Euler':
+    if model != 'Euler' and t is not None:
         _recomputeDistForViscousWall__(t, tb, tbCurvi=tbCurvi, dimPb=dimPb, tbFilament=tbFilament)
         # if not cleanCellN: C._initVars(t, '{centers:TurbulentDistanceWallBC}={centers:TurbulentDistance}')
 
@@ -1845,7 +1845,7 @@ def initializeIBM(t, tc, tb, tinit=None, tbCurvi=None, dimPb=3, twoFronts=False,
         tc2 = None
 
     _tcInitialize__(tc, tc2=tc2, ibctypes=ibctypes, isWireModel=isWireModel)
-    if t: _tInitialize__(t, tinit=tinit, model=model, isWireModel=isWireModel)
+    if t is not None: _tInitialize__(t, tinit=tinit, model=model, isWireModel=isWireModel)
 
     return t, tc, tc2
 
@@ -2371,11 +2371,16 @@ def getAllIBMPoints(t, loc='nodes', hi=0., he=0., tb=None, tfront=None, frontTyp
             ah = C.getField('he', z)[0]
             if ah != []: an = Converter.addVars([an,ah])
             correctedPts = Connector.getInterpolatedPoints__(an)
+            allCorrectedPts.append(correctedPts)
             xt = C.getField('CoordinateX', z)[0][1][0]
             snearl = xt[1]-xt[0]
+            if twoFronts: snearl *= 2
             listOfSnearsLoc.append(snearl)
-            allCorrectedPts.append(correctedPts)
-            if frontType == 42: listOfModelisationHeightsLoc.append(G_IBM_Height.computeModelisationHeight(Re=Reynolds, yplus=yplus, L=Lref))
+            
+            if frontType == 42: 
+                hmod = G_IBM_Height.computeModelisationHeight(Re=Reynolds, yplus=yplus, L=Lref)
+                if twoFronts: hmod *= 2
+                listOfModelisationHeightsLoc.append(hmod)
             else:
                 listOfModelisationHeightsLoc.append(0.)
     else:
@@ -2397,9 +2402,13 @@ def getAllIBMPoints(t, loc='nodes', hi=0., he=0., tb=None, tfront=None, frontTyp
             allCorrectedPts.append(correctedPts)
             xt = C.getField('CoordinateX',z)[0][1][0]
             snearl = xt[1]-xt[0]
-
+            if twoFronts: snearl *= 2
             listOfSnearsLoc.append(snearl)
-            if frontType == 42: listOfModelisationHeightsLoc.append(G_IBM_Height.computeModelisationHeight(Re=Reynolds, yplus=yplus, L=Lref))
+            
+            if frontType == 42: 
+                hmod = G_IBM_Height.computeModelisationHeight(Re=Reynolds, yplus=yplus, L=Lref)
+                if twoFronts: hmod *= 2
+                listOfModelisationHeightsLoc.append(hmod)
             else:
                 listOfModelisationHeightsLoc.append(0.)
     #-------------------------------------------

--- a/Cassiopee/Connector/Connector/getIBMPtsWithFront.cpp
+++ b/Cassiopee/Connector/Connector/getIBMPtsWithFront.cpp
@@ -486,6 +486,7 @@ PyObject* K_CONNECTOR::getIBMPtsWithFront(PyObject* self, PyObject* args)
         E_Float heightloc = vectOfModelisationHeightsLoc[noz];
         //distance max for image pt to its corrected pt : height*sqrt(3)
 
+        //old way of setting max tolerances
         heightloc = heightloc*1.1 + 3*snearloc*sqrt(3.); // for 2nd image point
         heightloc = heightloc*heightloc;
 
@@ -494,6 +495,13 @@ PyObject* K_CONNECTOR::getIBMPtsWithFront(PyObject* self, PyObject* args)
 
         E_Float distMaxF2 = max(toldistFactorImage*snearloc, heightloc);// distance au carre maximale des pts cibles au front via depth ou modelisationHeight
         E_Float distMaxB2 = max(toldistFactorWall*snearloc, heightloc);// distance au carre maximale des pts cibles au projete paroi via depth ou modelisationHeight
+
+        //new way of setting max tolerances
+        // heightloc = heightloc*heightloc;
+        // snearloc = snearloc*snearloc;
+        // E_Float distMaxF2 = max(toldistFactorImage*snearloc, 4*heightloc); // squared maximum projection distance for target points based on local near-wall resolution or modeling height
+        // E_Float distMaxB2 = max(toldistFactorWall*snearloc, 4*heightloc); // squared maximum projection distance for target points based on local near-wall resolution or modeling height
+        // These max distances are based on 2*hmod instead of hmod to allow some tolerance for complex geometries
 
         vector<FldArrayI*> vectOfIndicesByIBCType(nbodies);
         vector<E_Int> nPtsPerIBCType(nbodies);//nb de pts projetes sur la surface paroi de type associe 

--- a/Cassiopee/Generator/Generator/IBM.py
+++ b/Cassiopee/Generator/Generator/IBM.py
@@ -1154,7 +1154,7 @@ def buildOctree(tb, dimPb=3, vmin=15, snears=0.01, snearFactor=1., dfars=10., df
 #==============================================================================
 #
 #==============================================================================
-def createRefinementBodies(tb, dimPb=3, hmod=0.01, pointsPerUnitLength=None):
+def createRefinementBodies(tb, dimPb=3, hmod=0.01, hmax=None, pointsPerUnitLength=None):
     """Creates refinement bodies from the immersed boundaries to extend the finest resolution in the fluid domain."""
     import Geom.IBM as D_IBM
     import Geom.Offset as O
@@ -1168,13 +1168,14 @@ def createRefinementBodies(tb, dimPb=3, hmod=0.01, pointsPerUnitLength=None):
     tb = Internal.rmNodesFromName(tb, "SYM")
     tb = Internal.rmNodesFromName(tb, "*_sym")
 
-    snears    = Internal.getNodesFromName(tb, 'snear')
-    h         = min(snears, key=lambda x: x[1])[1][0]
+    if hmax is None:
+        snears = Internal.getNodesFromName(tb, 'snear')
+        hmax   = min(snears, key=lambda x: x[1])[1][0]
 
     for z in Internal.getZones(tb):
         snear = Internal.getNodeFromName(z, 'snear')[1]
         zname = z[0]
-        if snear <= 1.5*h:
+        if snear <= 1.5*hmax:
             if dimPb == 2:
                 z2 = D_IBM.closeContour(z)
             else:


### PR DESCRIPTION
In prepareIBMDataAdapt, initializeIBM() would erroneously erase the density solution from the steady-state solution stored in t, which is needed to restart the simulation.

In Connector, the tolerance for the second image points (based on the twoFront argument) is increased by multiplying the modeling height and the local snear by two to leave the c function (getIBMPointsWithFront) unchanged. A simplified and corrected tolerance setting is also suggested in the latter c function, but is intentionally left commented as it causes regressions in the following test cases: 

```
Connector    : setInterpDataIBMPT_t1.py                : 0m1s      : 0m1.15s   : 07/05/24 15h31  : 0%   :   :  FAILED    
Connector    : setInterpDataIBMPT_t2.py                : 0m1.54s   : 0m1.4s    : 07/05/24 15h31  : 0%   :   :  FAILED    
Fast         : FastIBM2DMEA_t1.py                      : Unknown   : 0m8.16s   : 24/02/25 17h32  : 0%   :   :  FAILED    
Fast         : FastIBMWireMeshModel_t1.py              : Unknown   : 0m6.05s   : 24/02/25 17h33  : 0%   :   :  FAILED    
Fast         : IBMOutletControlPressure_t1.py          : 0m3.49s   : 0m0.38s   : 24/02/25 17h35  : 0%   :   :  FAILED
```
Note that this new settings has been used and validated in the CRM-HL.