### PR TITLE
Generator: adaptMesh seq and mpi;  XCore: unitary test adaptMeshPT_m1 added

### DIFF
--- a/Cassiopee/Generator/Generator/Mpi.py
+++ b/Cassiopee/Generator/Generator/Mpi.py
@@ -8,9 +8,9 @@ import Converter.Internal as Internal
 import Generator.PyTree as G
 import numpy
 
-def adaptMesh(a, indicator="indicator", hook=None, dim=3, conformize=False, 
+def adaptMesh(a, indicator="indicator", hook=None, dim=3, conformize=False,
               splitInfos=None):
-    
+
     if splitInfos is None:
         print("Warning: no input provided to adapt the parts of the mesh. They will be adapted independently.", flush=True)
     a = Internal.getZones(a)[0]
@@ -19,8 +19,8 @@ def adaptMesh(a, indicator="indicator", hook=None, dim=3, conformize=False,
     if eltType != 'NGON':
         print("adaptMesh: input mesh must be NGON v4. No adaptation performed.", flush=True)
         return a
-    
-    return G.adaptMesh__(a, indicator=indicator, hook=hook, dim=dim, 
+
+    return G.adaptMesh__(a, indicator=indicator, hook=hook, dim=dim,
                          conformize=conformize, splitInfos=splitInfos)
 
 def bbox(t):

--- a/Cassiopee/Generator/Generator/Mpi.py
+++ b/Cassiopee/Generator/Generator/Mpi.py
@@ -8,6 +8,21 @@ import Converter.Internal as Internal
 import Generator.PyTree as G
 import numpy
 
+def adaptMesh(a, indicator="indicator", hook=None, dim=3, conformize=False, 
+              splitInfos=None):
+    
+    if splitInfos is None:
+        print("Warning: no input provided to adapt the parts of the mesh. They will be adapted independently.", flush=True)
+    a = Internal.getZones(a)[0]
+    dimZ = Internal.getZoneDim(a)
+    eltType=dimZ[3]
+    if eltType != 'NGON':
+        print("adaptMesh: input mesh must be NGON v4. No adaptation performed.", flush=True)
+        return a
+    
+    return G.adaptMesh__(a, indicator=indicator, hook=hook, dim=dim, 
+                         conformize=conformize, splitInfos=splitInfos)
+
 def bbox(t):
     """Return the bounding box of a pytree."""
     bb = PyTree.bbox(t)

--- a/Cassiopee/Generator/Generator/PyTree.py
+++ b/Cassiopee/Generator/Generator/PyTree.py
@@ -124,12 +124,12 @@ def conformUnstr(surface1, surface2=None, tol=0., left_or_right=0):
     return C.convertArrays2ZoneNode('conformized', [s])
 
 #------------------------------------------------------------------------------
-# Adapt a HEXA conformal mesh   
+# Adapt a HEXA conformal mesh
 # IN : a : HEXA/QUAD or NGON (HEXA/QUAD-like) mesh
 # IN/OUT : hook : hook on the adaptation structure; if hook is [], it is returned, else it is released
 # IN : dim: dim of the pb
-# IN : conformize: Boolean (True=returns a NGON, False: return a HEXA mesh) 
-# OUT : adapted mesh 
+# IN : conformize: Boolean (True=returns a NGON, False: return a HEXA mesh)
+# OUT : adapted mesh
 #------------------------------------------------------------------------------
 def adaptMesh(a, indicator="indicator", hook=None, dim=3, conformize=False):
     return adaptMesh__(a, indicator="indicator", hook=None, dim=3, conformize=False, splitInfos=None)
@@ -140,13 +140,13 @@ def adaptMesh__(a, indicator="indicator", hook=None, dim=3, conformize=False, sp
     a = Internal.getZones(a)[0]
     dimZ = Internal.getZoneDim(a)
     eltType=dimZ[3]
-        
+
     conformizei = 0
     if conformize: conformizei=1
-    
+
     hangHook=True
     if hook is None: hangHook=False
-    if hook is None or hook==[]: 
+    if hook is None or hook==[]:
         hook = _createHook4AdaptMesh(a, dim=dim, splitInfos=None)
 
     FSC = Internal.getNodeFromName(a, Internal.__FlowSolutionCenters__)
@@ -155,7 +155,7 @@ def adaptMesh__(a, indicator="indicator", hook=None, dim=3, conformize=False, sp
     if f is None: return a
     f = f[1]
     REF = f.astype(dtype=Internal.E_NpyInt)
-    
+
     XC.AdaptMesh_AssignRefData(hook, REF)
     XC.AdaptMesh_Adapt(hook)
     a = XC.AdaptMesh_ExtractMesh(hook, conformize=conformizei)
@@ -164,13 +164,13 @@ def adaptMesh__(a, indicator="indicator", hook=None, dim=3, conformize=False, sp
         C._convertArray2NGon(a)
     if not hangHook:
         XC.AdaptMesh_Exit(hook)
-        return a 
+        return a
     else:
         return (a,hook)
 
 
-# Create the hook for adaptMesh - 
-# IN : conformal mesh ; infos : dictionary 
+# Create the hook for adaptMesh -
+# IN : conformal mesh ; infos : dictionary
 # splitInfos["graph"]=comms between parts
 # splitInfos["cellGlobalIndex"] : global indices of the cells of the mesh
 # splitInfos["faceGlobalIndex"] : global indices of the faces in the mesh
@@ -187,21 +187,21 @@ def _createHook4AdaptMesh(a, dim=3, splitInfos=None):
     eltType=dimZ[3]
     if dimZ[0]=='Unstructured':
         if eltType == 'HEXA':
-            C._convertArray2NGon(a, recoverBC=True, api=3)               
+            C._convertArray2NGon(a, recoverBC=True, api=3)
             if splitInfos is not None:
-                print("Warning: createHook4AdaptMesh: splitInfos only valid for NGONs.", flush=True) 
+                print("Warning: createHook4AdaptMesh: splitInfos only valid for NGONs.", flush=True)
         elif eltType=='NGON':
             pass
         else:
-            print("Warning: adaptMesh not implemented for elt type %s. No adaptation performed."%(eltType), flush=True) 
+            print("Warning: adaptMesh not implemented for elt type %s. No adaptation performed."%(eltType), flush=True)
             return a
     else:
         if splitInfos is not None:
-            print("Warning: createHook4AdaptMesh: splitInfos only valid for NGONs.", flush=True) 
-        C._convertArray2NGon(a, recoverBC=True, api=3)    
-        
+            print("Warning: createHook4AdaptMesh: splitInfos only valid for NGONs.", flush=True)
+        C._convertArray2NGon(a, recoverBC=True, api=3)
+
     Internal._adaptNGon32NGon4(a)
-    
+
     if dim==3: normal2D = None
     else:normal2D = numpy.array([0.0,0.0,1.0])
     if splitInfos is None or eltType != 'NGON':
@@ -212,9 +212,9 @@ def _createHook4AdaptMesh(a, dim=3, splitInfos=None):
         ER = Internal.getNodeFromName(nfaceselts,'ElementRange')[1]
         ncells = ER[1]-ER[0]+1
         gcells=numpy.arange(0, ncells)
-        gfaces=numpy.arange(1,nfaces+1)        
+        gfaces=numpy.arange(1,nfaces+1)
         hook = XC.AdaptMesh_Init(a, normal2D, comm=[], gcells=gcells, gfaces=gfaces)
-    else:    
+    else:
         comms = splitInfos["graph"]
         print(comms)
         gcells = splitInfos["cellGlobalIndex"]
@@ -222,9 +222,9 @@ def _createHook4AdaptMesh(a, dim=3, splitInfos=None):
         hook = XC.AdaptMesh_Init(a, normal2D, comm=comms, gcells=gcells, gfaces=gfaces)
     return hook
 
-def freeHook4AdaptMesh(hook):        
+def freeHook4AdaptMesh(hook):
     import XCore.PyTree as XC
-    XC.AdaptMesh_Exit(hook)    
+    XC.AdaptMesh_Exit(hook)
     return None
 #------------------------------------------------------------------------------
 # Conversion d'un maillage octree en ensemble de grilles cartesiennes

--- a/Cassiopee/Generator/Generator/PyTree.py
+++ b/Cassiopee/Generator/Generator/PyTree.py
@@ -124,6 +124,109 @@ def conformUnstr(surface1, surface2=None, tol=0., left_or_right=0):
     return C.convertArrays2ZoneNode('conformized', [s])
 
 #------------------------------------------------------------------------------
+# Adapt a HEXA conformal mesh   
+# IN : a : HEXA/QUAD or NGON (HEXA/QUAD-like) mesh
+# IN/OUT : hook : hook on the adaptation structure; if hook is [], it is returned, else it is released
+# IN : dim: dim of the pb
+# IN : conformize: Boolean (True=returns a NGON, False: return a HEXA mesh) 
+# OUT : adapted mesh 
+#------------------------------------------------------------------------------
+def adaptMesh(a, indicator="indicator", hook=None, dim=3, conformize=False):
+    return adaptMesh__(a, indicator="indicator", hook=None, dim=3, conformize=False, splitInfos=None)
+
+def adaptMesh__(a, indicator="indicator", hook=None, dim=3, conformize=False, splitInfos=None):
+    import XCore.PyTree as XC
+
+    a = Internal.getZones(a)[0]
+    dimZ = Internal.getZoneDim(a)
+    eltType=dimZ[3]
+        
+    conformizei = 0
+    if conformize: conformizei=1
+    
+    hangHook=True
+    if hook is None: hangHook=False
+    if hook is None or hook==[]: 
+        hook = _createHook4AdaptMesh(a, dim=dim, splitInfos=None)
+
+    FSC = Internal.getNodeFromName(a, Internal.__FlowSolutionCenters__)
+    if FSC is None: return a
+    f = Internal.getNodeFromName(FSC, indicator)
+    if f is None: return a
+    f = f[1]
+    REF = f.astype(dtype=Internal.E_NpyInt)
+    
+    XC.AdaptMesh_AssignRefData(hook, REF)
+    XC.AdaptMesh_Adapt(hook)
+    a = XC.AdaptMesh_ExtractMesh(hook, conformize=conformizei)
+    a = Internal.getZones(a)[0]
+    if eltType=='NGON':
+        C._convertArray2NGon(a)
+    if not hangHook:
+        XC.AdaptMesh_Exit(hook)
+        return a 
+    else:
+        return (a,hook)
+
+
+# Create the hook for adaptMesh - 
+# IN : conformal mesh ; infos : dictionary 
+# splitInfos["graph"]=comms between parts
+# splitInfos["cellGlobalIndex"] : global indices of the cells of the mesh
+# splitInfos["faceGlobalIndex"] : global indices of the faces in the mesh
+# splitInfos is only compatible with NGON !!!
+# otherwise a is modified & converted into a NGON v4 !!
+def createHook4AdaptMesh(a, dim=3, splitInfos=None):
+    a2 = Internal.copyRef(a)
+    return _createHook4AdaptMesh(a2, dim=dim, splitInfos=splitInfos)
+
+def _createHook4AdaptMesh(a, dim=3, splitInfos=None):
+    import XCore.PyTree as XC
+
+    dimZ = Internal.getZoneDim(a)
+    eltType=dimZ[3]
+    if dimZ[0]=='Unstructured':
+        if eltType == 'HEXA':
+            C._convertArray2NGon(a, recoverBC=True, api=3)               
+            if splitInfos is not None:
+                print("Warning: createHook4AdaptMesh: splitInfos only valid for NGONs.", flush=True) 
+        elif eltType=='NGON':
+            pass
+        else:
+            print("Warning: adaptMesh not implemented for elt type %s. No adaptation performed."%(eltType), flush=True) 
+            return a
+    else:
+        if splitInfos is not None:
+            print("Warning: createHook4AdaptMesh: splitInfos only valid for NGONs.", flush=True) 
+        C._convertArray2NGon(a, recoverBC=True, api=3)    
+        
+    Internal._adaptNGon32NGon4(a)
+    
+    if dim==3: normal2D = None
+    else:normal2D = numpy.array([0.0,0.0,1.0])
+    if splitInfos is None or eltType != 'NGON':
+        ngonelts = Internal.getNodeFromName(a,"NGonElements")
+        ER = Internal.getNodeFromName(ngonelts,'ElementRange')[1]
+        nfaces = ER[1]
+        nfaceselts = Internal.getNodeFromName(a,"NFaceElements")
+        ER = Internal.getNodeFromName(nfaceselts,'ElementRange')[1]
+        ncells = ER[1]-ER[0]+1
+        gcells=numpy.arange(0, ncells)
+        gfaces=numpy.arange(1,nfaces+1)        
+        hook = XC.AdaptMesh_Init(a, normal2D, comm=[], gcells=gcells, gfaces=gfaces)
+    else:    
+        comms = splitInfos["graph"]
+        print(comms)
+        gcells = splitInfos["cellGlobalIndex"]
+        gfaces = splitInfos["faceGlobalIndex"]
+        hook = XC.AdaptMesh_Init(a, normal2D, comm=comms, gcells=gcells, gfaces=gfaces)
+    return hook
+
+def freeHook4AdaptMesh(hook):        
+    import XCore.PyTree as XC
+    XC.AdaptMesh_Exit(hook)    
+    return None
+#------------------------------------------------------------------------------
 # Conversion d'un maillage octree en ensemble de grilles cartesiennes
 #------------------------------------------------------------------------------
 def octree2Struct(o, vmin=15, ext=0, optimized=1, merged=1, AMR=0,

--- a/Cassiopee/Generator/test/adaptMeshPT.py
+++ b/Cassiopee/Generator/test/adaptMeshPT.py
@@ -1,0 +1,9 @@
+import Generator.PyTree as G
+import Converter.PyTree as C
+
+# HEXA but no adaptation in the 3rd direction (2D adaptation)
+a = G.cartHexa((0,0,0),(0.1,0.1,0.1),(11,11,2))
+C._fillEmptyBCWith(a,'nref','BCFarfield',dim=2)
+C._initVars(a,'{centers:indicator}=({centers:CoordinateX})>0.5')
+a = G.adaptMesh(a, indicator="indicator", hook=None, dim=2, conformize=False)
+C.convertPyTree2File(a,"out.cgns")

--- a/Cassiopee/Generator/test/adaptMeshPT_m1.py
+++ b/Cassiopee/Generator/test/adaptMeshPT_m1.py
@@ -1,0 +1,54 @@
+import Generator.PyTree as G
+import Generator.Mpi as Gmpi
+import Converter.PyTree as C
+import Converter.Filter2 as Filter2
+import Converter.Internal as Internal
+import Converter.Mpi as Cmpi
+import KCore.test as test
+
+a = G.cartNGon((0,0,0),(0.1,0.1,0.1),(11,11,2))
+Internal._adaptNGon32NGon4(a)
+C._fillEmptyBCWith(a,'nref','BCFarfield')
+C._initVars(a,"F",1.)
+C._initVars(a,'{centers:indicator}=({centers:CoordinateX})>0.35')
+if Cmpi.rank==0: C.convertPyTree2File(a,"tmp.cgns")
+Cmpi.barrier()
+
+a, res = Filter2.loadAndSplit('tmp.cgns')
+splitInfos={}
+splitInfos["graph"]=res[1]
+splitInfos["cellGlobalIndex"]=res[5]
+splitInfos["faceGlobalIndex"]=res[6]
+
+a2 = Gmpi.adaptMesh(a, indicator="indicator", hook=None, dim=2, 
+                 conformize=False, splitInfos=splitInfos)
+test.testT(a2,Cmpi.rank)
+
+a2 = Gmpi.adaptMesh(a, indicator="indicator", hook=None, dim=2, 
+                conformize=True, splitInfos=splitInfos)
+test.testT(a2,Cmpi.rank+Cmpi.size)
+
+
+a = G.cartNGon((0,0,0),(0.1,0.1,0.1),(11,11,11))
+Internal._adaptNGon32NGon4(a)
+C._fillEmptyBCWith(a,'nref','BCFarfield')
+C._initVars(a,"F",1.)
+C._initVars(a,'{centers:indicator}=({centers:CoordinateX})>0.35')
+if Cmpi.rank==0: C.convertPyTree2File(a,"tmp.cgns")
+Cmpi.barrier()
+
+a, res = Filter2.loadAndSplit('tmp.cgns')
+splitInfos={}
+splitInfos["graph"]=res[1]
+splitInfos["cellGlobalIndex"]=res[5]
+splitInfos["faceGlobalIndex"]=res[6]
+
+a2 = Gmpi.adaptMesh(a, indicator="indicator", hook=None, dim=3, 
+                 conformize=False, splitInfos=splitInfos)
+test.testT(a2,Cmpi.rank+2*Cmpi.size)
+
+a2 = Gmpi.adaptMesh(a, indicator="indicator", hook=None, dim=3, 
+                conformize=True, splitInfos=splitInfos)
+test.testT(a2,Cmpi.rank+3*Cmpi.size)
+Cmpi.convertPyTree2File(a2,"out.cgns")
+C.convertPyTree2File(a2,"out_%d.cgns"%(Cmpi.rank))

--- a/Cassiopee/Generator/test/adaptMeshPT_m1.py
+++ b/Cassiopee/Generator/test/adaptMeshPT_m1.py
@@ -20,12 +20,12 @@ splitInfos["graph"]=res[1]
 splitInfos["cellGlobalIndex"]=res[5]
 splitInfos["faceGlobalIndex"]=res[6]
 
-a2 = Gmpi.adaptMesh(a, indicator="indicator", hook=None, dim=2, 
-                 conformize=False, splitInfos=splitInfos)
+a2 = Gmpi.adaptMesh(a, indicator="indicator", hook=None, dim=2,
+                    conformize=False, splitInfos=splitInfos)
 test.testT(a2,Cmpi.rank)
 
-a2 = Gmpi.adaptMesh(a, indicator="indicator", hook=None, dim=2, 
-                conformize=True, splitInfos=splitInfos)
+a2 = Gmpi.adaptMesh(a, indicator="indicator", hook=None, dim=2,
+                    conformize=True, splitInfos=splitInfos)
 test.testT(a2,Cmpi.rank+Cmpi.size)
 
 
@@ -43,12 +43,12 @@ splitInfos["graph"]=res[1]
 splitInfos["cellGlobalIndex"]=res[5]
 splitInfos["faceGlobalIndex"]=res[6]
 
-a2 = Gmpi.adaptMesh(a, indicator="indicator", hook=None, dim=3, 
-                 conformize=False, splitInfos=splitInfos)
+a2 = Gmpi.adaptMesh(a, indicator="indicator", hook=None, dim=3,
+                    conformize=False, splitInfos=splitInfos)
 test.testT(a2,Cmpi.rank+2*Cmpi.size)
 
-a2 = Gmpi.adaptMesh(a, indicator="indicator", hook=None, dim=3, 
-                conformize=True, splitInfos=splitInfos)
+a2 = Gmpi.adaptMesh(a, indicator="indicator", hook=None, dim=3,
+                    conformize=True, splitInfos=splitInfos)
 test.testT(a2,Cmpi.rank+3*Cmpi.size)
 Cmpi.convertPyTree2File(a2,"out.cgns")
 C.convertPyTree2File(a2,"out_%d.cgns"%(Cmpi.rank))

--- a/Cassiopee/Generator/test/adaptMeshPT_t1.py
+++ b/Cassiopee/Generator/test/adaptMeshPT_t1.py
@@ -1,0 +1,63 @@
+import Generator.PyTree as G
+import Converter.PyTree as C
+import KCore.test as test
+
+# HEXA but no adaptation in the 3rd direction (2D adaptation)
+a = G.cartHexa((0,0,0),(0.1,0.1,0.1),(11,11,2))
+C._fillEmptyBCWith(a,'nref','BCFarfield',dim=2)
+C._initVars(a,"F",1.)
+C._initVars(a,'{centers:indicator}=({centers:CoordinateX})>0.5')
+a2 = G.adaptMesh(a, indicator="indicator", hook=None, dim=2, conformize=False)
+test.testT(a2,1)
+a2 = G.adaptMesh(a, indicator="indicator", hook=None, dim=2, conformize=True)
+test.testT(a2,2)
+
+a = G.cartNGon((0,0,0),(0.1,0.1,0.1),(11,11,2))
+C._fillEmptyBCWith(a,'nref','BCFarfield',dim=2)
+C._initVars(a,"F",1.)
+C._initVars(a,'{centers:indicator}=({centers:CoordinateX})>0.5')
+a2 = G.adaptMesh(a, indicator="indicator", hook=None, dim=2, conformize=False)
+test.testT(a2,3)
+a2 = G.adaptMesh(a, indicator="indicator", hook=None, dim=2, conformize=True)
+test.testT(a2,4)
+
+#3D HEXA
+a = G.cartHexa((0,0,0),(0.1,0.1,0.1),(11,11,11))
+C._fillEmptyBCWith(a,'nref','BCFarfield',dim=3)
+C._initVars(a,"F",1.)
+C._initVars(a,'{centers:indicator}=({centers:CoordinateX})>0.5')
+a2 = G.adaptMesh(a, indicator="indicator", hook=None, dim=3, conformize=False)
+test.testT(a2,5)
+a2 = G.adaptMesh(a, indicator="indicator", hook=None, dim=3, conformize=True)
+test.testT(a2,6)
+
+a = G.cartNGon((0,0,0),(0.1,0.1,0.1),(11,11,11))
+C._fillEmptyBCWith(a,'nref','BCFarfield',dim=3)
+C._initVars(a,"F",1.)
+C._initVars(a,'{centers:indicator}=({centers:CoordinateX})>0.5')
+a2 = G.adaptMesh(a, indicator="indicator", hook=None, dim=3, conformize=False)
+test.testT(a2,7)
+a2 = G.adaptMesh(a, indicator="indicator", hook=None, dim=3, conformize=True)
+test.testT(a2,8)
+
+# Returns the hook on the tree structure 
+a = G.cartHexa((0,0,0),(0.1,0.1,0.1),(11,11,11))
+C._fillEmptyBCWith(a,'nref','BCFarfield',dim=3)
+C._initVars(a,"F",1.)
+C._initVars(a,'{centers:indicator}=({centers:CoordinateX})>0.5')
+a2,hooka = G.adaptMesh(a, indicator="indicator", hook=[], dim=3, conformize=False)
+test.testT(a2,9)
+C._initVars(a2,'{centers:indicator}=({centers:CoordinateZ})>0.5')
+a2,hooka = G.adaptMesh(a2, indicator="indicator", hook=hooka, dim=3, conformize=False)
+G.freeHook4AdaptMesh(hooka)
+test.testT(a2,10)
+
+# Structured but no adaptation in the 3rd direction (2D adaptation)
+a = G.cart((0,0,0),(0.1,0.1,0.1),(11,11,2))
+C._fillEmptyBCWith(a,'nref','BCFarfield',dim=2)
+C._initVars(a,"F",1.)
+C._initVars(a,'{centers:indicator}=({centers:CoordinateX})>0.5')
+a2 = G.adaptMesh(a, indicator="indicator", hook=None, dim=2, conformize=False)
+test.testT(a2,11)
+a2 = G.adaptMesh(a, indicator="indicator", hook=None, dim=2, conformize=True)
+test.testT(a2,12)

--- a/Cassiopee/Generator/test/adaptMeshPT_t1.py
+++ b/Cassiopee/Generator/test/adaptMeshPT_t1.py
@@ -40,7 +40,7 @@ test.testT(a2,7)
 a2 = G.adaptMesh(a, indicator="indicator", hook=None, dim=3, conformize=True)
 test.testT(a2,8)
 
-# Returns the hook on the tree structure 
+# Returns the hook on the tree structure
 a = G.cartHexa((0,0,0),(0.1,0.1,0.1),(11,11,11))
 C._fillEmptyBCWith(a,'nref','BCFarfield',dim=3)
 C._initVars(a,"F",1.)

--- a/Cassiopee/XCore/test/adaptMeshPT.py
+++ b/Cassiopee/XCore/test/adaptMeshPT.py
@@ -1,12 +1,10 @@
 import Generator.PyTree as G
 import Converter.PyTree as C
 import XCore.PyTree as XC
-import Converter.Mpi as Cmpi
 import Converter.Internal as Internal
-import KCore.test as test
 import numpy
 
-# 2D QUAD
+# HEXA but no adaptation in the 3rd direction (2D adaptation)
 a = G.cartHexa((0,0,0),(0.1,0.1,0.1),(11,11,2))
 a = C.convertArray2NGon(a)
 C._fillEmptyBCWith(a, 'nref', 'BCFarfield', dim=2)

--- a/Cassiopee/XCore/test/adaptMeshPT_m1.py
+++ b/Cassiopee/XCore/test/adaptMeshPT_m1.py
@@ -1,0 +1,84 @@
+import Generator.PyTree as G
+import Converter.PyTree as C
+import XCore.PyTree as XC
+import Converter.Mpi as Cmpi
+import Converter.Internal as Internal
+import Converter.Mpi as Cmpi
+import KCore.test as test
+import numpy
+
+# 2D QUAD
+no_test = 0
+a = G.cartHexa((0,0,0),(0.1,0.1,0.1),(11,11,2))
+a = C.convertArray2NGon(a)
+C._fillEmptyBCWith(a, 'nref', 'BCFarfield', dim=2)
+Internal._adaptNGon32NGon4(a)
+if Cmpi.rank==0: C.convertPyTree2File(a,"tmp.cgns")
+Cmpi.barrier()
+
+a, res = XC.loadAndSplitNGon('tmp.cgns')
+gcells = res[5]
+gfaces = res[6]
+comm = res[1]
+
+normal2D = numpy.array([0.0,0.0,1.0])
+AM = XC.AdaptMesh_Init(a, normal2D, comm=[], gcells=gcells, gfaces=gfaces)
+C._initVars(a, 'centers:indicator', 1.)
+f = Internal.getNodeFromName(a, 'indicator')[1]
+REF = f.astype(dtype=Internal.E_NpyInt)
+XC.AdaptMesh_AssignRefData(AM, REF)
+XC.AdaptMesh_Adapt(AM)
+a = XC.AdaptMesh_ExtractMesh(AM, conformize=0)
+test.testT(a, no_test*Cmpi.size+Cmpi.rank)
+no_test+=1
+#
+C._initVars(a, '{centers:indicator}=({centers:CoordinateX}<0.5)')
+f = Internal.getNodeFromName(a, 'indicator')[1]
+REF = f.astype(dtype=Internal.E_NpyInt)
+XC.AdaptMesh_AssignRefData(AM, REF)
+XC.AdaptMesh_Adapt(AM)
+a = XC.AdaptMesh_ExtractMesh(AM, conformize=0)
+test.testT(a, no_test*Cmpi.size+Cmpi.rank)
+no_test+=1
+#
+a = XC.AdaptMesh_ExtractMesh(AM, conformize=1)
+test.testT(a,no_test*Cmpi.size+Cmpi.rank)
+no_test+=1
+
+# 3D HEXA
+a = G.cartHexa((0,0,0),(0.1,0.1,0.1),(11,11,11))
+a = C.convertArray2NGon(a)
+C._fillEmptyBCWith(a, 'nref', 'BCFarfield', dim=3)
+Internal._adaptNGon32NGon4(a)
+if Cmpi.rank==0: C.convertPyTree2File(a,"tmp.cgns")
+Cmpi.barrier()
+
+a, res = XC.loadAndSplitNGon('tmp.cgns')
+gcells = res[5]
+gfaces = res[6]
+comm = res[1]
+
+normal2D = None
+
+AM = XC.AdaptMesh_Init(a, normal2D, comm=[], gcells=gcells, gfaces=gfaces)
+C._initVars(a, 'centers:indicator', 1.)
+f = Internal.getNodeFromName(a, 'indicator')[1]
+REF = f.astype(dtype=Internal.E_NpyInt)
+XC.AdaptMesh_AssignRefData(AM, REF)
+XC.AdaptMesh_Adapt(AM)
+a = XC.AdaptMesh_ExtractMesh(AM, conformize=0)
+test.testT(a,no_test*Cmpi.size+Cmpi.rank)
+no_test+=1
+#
+C._initVars(a, '{centers:indicator}=({centers:CoordinateX}<0.5)')
+f = Internal.getNodeFromName(a, 'indicator')[1]
+REF = f.astype(dtype=Internal.E_NpyInt)
+XC.AdaptMesh_AssignRefData(AM, REF)
+XC.AdaptMesh_Adapt(AM)
+a = XC.AdaptMesh_ExtractMesh(AM, conformize=0)
+test.testT(a,no_test*Cmpi.size+Cmpi.rank)
+no_test+=1
+#
+a = XC.AdaptMesh_ExtractMesh(AM, conformize=1)
+test.testT(a,no_test*Cmpi.size+Cmpi.rank)
+no_test+=1


### PR DESCRIPTION
- One commit seems to be a merge from Christophe's ??
- Warning: intersectMeshPT.py does not work. It fails in debug mode. Do not understand what is going on. 
- Creation of a Generator.adaptMesh function, idem in Generator.Mpi. Hierarchical structure can be hung, many checks are performed. Note : unitary test adaptMeshPT_m1.py requires comms between parts and global indices of cells & faces, so a temporary file tmp.cgns is dumped and read by Filter2.loadAndSplit.  
