### PR TITLE
Add tol in getIntersectingDomains

### DIFF
--- a/Cassiopee/Connector/Connector/OversetData.py
+++ b/Cassiopee/Connector/Connector/OversetData.py
@@ -78,7 +78,6 @@ def _addCellN__(t, loc='centers', cellNName='cellN'):
 #=============================================================================
 # 1. CALCUL DES INTERSECTIONS ENTRE DOMAINES
 #=============================================================================
-
 def getIntersectingDomainsAABB(t, tol=1.e-10):
     """Return the intersection list of a list of bounding boxes."""
     m = C.getFields(Internal.__GridCoordinates__, t, api=2)
@@ -114,7 +113,7 @@ def getBBIntersectingDomains(A, B, tol=1.e-6):
 
 #------------------------------------------------------------------------------
 def getIntersectingDomains(t, t2=None, method='AABB', taabb=None, tobb=None,
-                           taabb2=None, tobb2=None):
+                           taabb2=None, tobb2=None, tol=1e-10):
     """Returns the dictionary of intersecting zones.
     Usage: getIntersectingDomains(t, t2, method, taabb, tobb, taabb2, tobb2)"""
     try: import Generator.PyTree as G
@@ -144,7 +143,7 @@ def getIntersectingDomains(t, t2=None, method='AABB', taabb=None, tobb=None,
         if not taabb: taabb = G.BB(t)
         if not t2:
             # fast: t, taabb=t avec t bbox
-            IntDict = getIntersectingDomainsAABB(taabb, tol=1.e-10)
+            IntDict = getIntersectingDomainsAABB(taabb, tol=tol)
             #TotInter = 0
         else:
             if not taabb2: taabb2 = G.BB(t2)
@@ -154,7 +153,7 @@ def getIntersectingDomains(t, t2=None, method='AABB', taabb=None, tobb=None,
                 IntDict[z1[0]] = []
                 for z2 in zones2:
                     if z1[0] != z2[0]:
-                        if G.bboxIntersection(z1, z2, tol=1.e-10, isBB=True, method='AABB') == 1:
+                        if G.bboxIntersection(z1, z2, tol=tol, isBB=True, method='AABB') == 1:
                             IntDict[z1[0]].append(z2[0]) # saves the intersected zones names
                             #TotInter += 1
 
@@ -170,7 +169,7 @@ def getIntersectingDomains(t, t2=None, method='AABB', taabb=None, tobb=None,
                 if z1 != z2:
                     obb2 = Internal.getZones(tobb2)
                     obb2 = Internal.getNodeFromName(obb2,z2)
-                    if G.bboxIntersection(obb1, obb2, isBB=True, method='OBB') == 1:
+                    if G.bboxIntersection(obb1, obb2, tol=tol, isBB=True, method='OBB') == 1:
                         IntDict[z1].append(z2) # saves the intersected zones names
                         #TotInter += 1
 
@@ -194,26 +193,26 @@ def getIntersectingDomains(t, t2=None, method='AABB', taabb=None, tobb=None,
                     obb2 = Internal.getNodeFromName(obb2,z2)
                     aabb2 = Internal.getZones(taabb2)
                     aabb2 = Internal.getNodeFromName(aabb2,z2)
-                    if G.bboxIntersection(obb1, obb2, isBB=True,method='OBB') == 0:
+                    if G.bboxIntersection(obb1, obb2, tol=tol, isBB=True,method='OBB') == 0:
                         continue
-                    elif G.bboxIntersection(aabb1, aabb2, tol=1.e-10, isBB=True,method='AABB') == 0:
+                    elif G.bboxIntersection(aabb1, aabb2, tol=tol, isBB=True,method='AABB') == 0:
                         continue
-                    elif G.bboxIntersection(aabb1, obb2, isBB=True,method='AABBOBB') == 0:
+                    elif G.bboxIntersection(aabb1, obb2, tol=tol, isBB=True,method='AABBOBB') == 0:
                         continue
-                    elif G.bboxIntersection(aabb2, obb1, isBB=True,method='AABBOBB') == 0:
+                    elif G.bboxIntersection(aabb2, obb1, tol=tol, isBB=True,method='AABBOBB') == 0:
                         continue
                     else:
                         IntDict[z1].append(z2) # saves the intersected zones names
                         #TotInter += 1
     else:
         print('Warning: getIntersectingDomains: method %s not implemented. Switched to AABB.'%method)
-        return getIntersectingDomains(t, method='AABB', taabb=taabb, tobb=tobb)
+        return getIntersectingDomains(t, method='AABB', tol=tol, taabb=taabb, tobb=tobb)
 
     #print('Total zone/zone intersections: %d.'%TotInter)
     return IntDict
 
 #------------------------------------------------------------------------------
-def getCEBBIntersectingDomains(basis0, bases0, sameBase=0):
+def getCEBBIntersectingDomains(basis0, bases0, sameBase=0, tol=1e-6):
     """Return the list of interpolation domains defined in bases for any zone in basis.
     Usage: getCEBBIntersectingDomains(basis, bases, sameBase)"""
     try: import Generator.PyTree as G
@@ -225,7 +224,6 @@ def getCEBBIntersectingDomains(basis0, bases0, sameBase=0):
     if len(bases) < 1: raise TypeError("getCEBBIntersectingDomains: not a list of CGNS bases.")
     basis = basis[0]
     # precond : recherche des bases intersectantes
-    tol = 1e-6
     [xmin1,ymin1,zmin1,xmax1,ymax1,zmax1] = G.bbox(basis)
     basename1 = basis[0]
     bases2 = []
@@ -252,11 +250,11 @@ def getCEBBIntersectingDomains(basis0, bases0, sameBase=0):
                 for z2 in zones2:
                     name2 = z2[0]
                     if name1 != name2:
-                        if G.CEBBIntersection(z1, z2) == 1:
+                        if G.CEBBIntersection(z1, z2, tol=tol) == 1:
                             doms1.append(z2[0])
             else:
                 for z2 in zones2:
-                    if G.CEBBIntersection(z1, z2) == 1:
+                    if G.CEBBIntersection(z1, z2, tol=tol) == 1:
                         doms1.append(z2[0])
         doms.append(doms1)
     return doms
@@ -264,7 +262,7 @@ def getCEBBIntersectingDomains(basis0, bases0, sameBase=0):
 #==============================================================================
 def getCEBBTimeIntersectingDomains(base0, func, bases0, funcs, \
                                    inititer=0, niter=1, dt=1, \
-                                   sameBase=0):
+                                   sameBase=0, tol=1e-6):
     """Return the list domains defined in bases, that intersect in time
     with base. Func defines a python motion of base with respect to time.
     Usage: getCEBBTimeIntersectingDomains(base, func, bases, funcs,
@@ -292,7 +290,7 @@ def getCEBBTimeIntersectingDomains(base0, func, bases0, funcs, \
             else: bp = Internal.copyRef(b)
             basesp.append(bp)
             nob += 1
-        domsp = getCEBBIntersectingDomains(basep, basesp, sameBase)
+        domsp = getCEBBIntersectingDomains(basep, basesp, sameBase, tol=tol)
         if domsp != [[]]*nzones:
             # premieres intersections
             if doms == []: doms = domsp

--- a/Cassiopee/Connector/doc/source/Connector.rst
+++ b/Cassiopee/Connector/doc/source/Connector.rst
@@ -100,14 +100,19 @@ Multiblock connectivity
 
         ::
 
-         t = X.connectMatch(t, tol=1.e-6, dim=3)
+         t = X.connectMatch(t, tol=1.e-6, dim=3, type='all')
         
         Detect and set all matching windows in a zone node, a list of zone nodes or a complete pyTree.
         Set automatically the Transform node corresponding to the transformation from matching block 1 to block 2.
-        If the CFD problem is 2D, then dim must be set to 2.
 
     :param t: input data
     :type  t: pyTree, base, zone, list of zones
+    :param tol: geometrical tolerance between abutting zones
+    :type tol: float
+    :param dim: dimension of the problem (2 or 3, only for structured grids)
+    :type dim: integer
+    :param type: can be 'structured', 'unstructured', 'hybrid' or 'all'
+    :type type: string
     :rtype:  identical to input
 
     Exists also as parallel distributed version (X.Mpi.connectMatch).
@@ -133,12 +138,22 @@ Multiblock connectivity
 
     :param t: input data
     :type  t: pyTree, base, zone, list of zones
+    :param tol: geometrical tolerance between periodical abutting zones
+    :type tol: float
+    :param dim: dimension of the problem (2 or 3, only for structured grids)
+    :type dim: integer
+    :param rotationCenter: coordinates of the rotation center for periodicity by rotation
+    :type rotationCenter: list of 3 floats
+    :param translation: translation vector for periodicity by translation
+    :type translation: list of 3 floats
+    :param rotationAngle: rotation angle, the only one non-zero provides the rotation axis
+    :type rotationAngle: list of 3 floats
+    :param unitAngle: angle unit ('Degree' or 'Radian' or None). None means 'Degree' (default value).
+    :type unitAngle: float
     :rtype:  identical to input
 
 
     Set automatically the Transform node corresponding to the transformation from matching block 1 to block 2, and the 'GridConnectivityProperty/Periodic' for periodic matching BCs.
-
-    If the CFD problem is 2D, then dim must be set to 2.
 
     For periodicity by rotation, the rotation angle units can be specified by argument unitAngle, which can be 'Degree','Radian',None.
 
@@ -176,6 +191,12 @@ Multiblock connectivity
 
     :param t: input data
     :type  t: pyTree, base, zone, list of zones
+    :param ratio: defines the 1-over-ratio abutting grids in all the directions
+    :type ratio: integer or list of 3 integers
+    :param tol: tolerance between 1-to-n abutting grids
+    :type tol: float
+    :param dim: dimension of the problem (2 only valid for structured grids)
+    :type dim: integer
     :rtype:  identical to input
 
     *Example of use:*
@@ -193,6 +214,14 @@ Multiblock connectivity
     If the problem is 2D according to (i,j), then parameter 'dim' must be set to 2.
     Parameter 'tol' defines a distance below which a window is assumed degenerated.
     
+    :param t: input data
+    :type  t: pyTree, base, zone, list of zones
+    :param tol: tolerance under which cells are considered as degenerated
+    :type tol: float
+    :param dim: dimension of the problem (2 only valid for structured grids)
+    :type dim: integer
+    :rtype:  identical to input
+
     *Example of use:*
 
     * `Add degenerated line as BCs in a pyTree (pyTree) <Examples/Connector/setDegeneratedBCPT.py>`_:
@@ -525,7 +554,7 @@ Overset connectivity
 
         ::
 
-         t = X.optimizeOverlap(t, double_wall=0, priorities=[], planarTol=0.)
+         t = X.optimizeOverlap(t, double_wall=0, priorities=[], planarTol=0., intersectionsDict=None)
 
         Optimize the overlapping between all structured zones defined in a pyTree t.
         The 'cellN' variable located at cell centers is modified, such that cellN=2 for a cell interpolable from another zone. 
@@ -548,7 +577,7 @@ Overset connectivity
 
 -----------------------------------------------------------------------------------------------------------------------
 
-.. py:function:: Connector.maximizeBlankedCells(a, depth=2, dir=1)
+.. py:function:: Connector.maximizeBlankedCells(a, depth=2, dir=1, cellNName='cellN', addGC=True)
 
 
     Change useless interpolated points status (2) to blanked points (0).
@@ -617,7 +646,7 @@ Overset connectivity
  
 -----------------------------------------------------------------------------------------------------------------------------
     
-.. py:function:: Connector.getIntersectingDomains(t, t2=None, method='AABB', taabb=None, tobb=None, taabb2=None, tobb2=None)
+.. py:function:: Connector.getIntersectingDomains(t, t2=None, tol=1e-6, method='AABB', taabb=None, tobb=None, taabb2=None, tobb2=None)
     
     Create a Python dictionary describing the intersecting zones. If t2 is not provided, then the computed dictionary states the self-intersecting zone names, otherwise, it
     computes the intersection between t and t2. Mode can be 'AABB', for Axis-Aligned Bounding Box method, 'OBB' for Oriented Bounding Box method, or 'hybrid', using a combination
@@ -636,7 +665,7 @@ Overset connectivity
 
 -----------------------------------------------------------------------------------------------------------------------------
 
-.. py:function:: Connector.getCEBBIntersectingDomains(A, B, sameBase)
+.. py:function:: Connector.getCEBBIntersectingDomains(A, B, sameBase=0, tol=1e-6)
 
     Detect the domains defined in the list of bases B whose CEBB
     intersect domains defined in base A.
@@ -651,7 +680,7 @@ Overset connectivity
 
 -----------------------------------------------------------------------------------------------------------------------------
 
-.. py:function:: X.getCEBBTimeIntersectingDomains(base, func, bases, funcs, inititer=0, niter=1, dt=1, sameBase)
+.. py:function:: X.getCEBBTimeIntersectingDomains(base, func, bases, funcs, inititer=0, niter=1, dt=1, sameBase=0, tol=1.e-6)
 
     in a Chimera pre-processing for bodies in relative motion,
     it can be useful to determine intersecting domains at any iteration.
@@ -670,7 +699,7 @@ Overset connectivity
 
 -----------------------------------------------------------------------------------------------------------------------------
 
-.. py:function::  X.applyBCOverlaps(t, depth=2, loc='centers')
+.. py:function::  X.applyBCOverlaps(t, depth=2, loc='centers',val=2, cellNName='cellN')
 
     set the cellN to 2 for the fringe nodes or cells (depending on parameter 'loc'='nodes' or 'centers') near the overlap borders defined in the pyTree t.
     Parameter 'depth' defines the number of layers of interpolated points.
@@ -699,7 +728,7 @@ Overset connectivity
 -----------------------------------------------------------------------------------------------------------------------------
 
 
-.. py:function:: Connector.PyTree.cellN2OversetHoles(t)
+.. py:function:: Connector.PyTree.cellN2OversetHoles(t, append=False)
 
     Compute the OversetHoles node into a pyTree from the cellN field, located at nodes or centers. For structured zones, defines it as a list of ijk indices, located at nodes or centers.
     For unstructured zones, defines the OversetHoles node as a list of indices ind, defining the cell vertices that are of cellN=0 if the cellN is located at nodes, and defining the cell centers that are of cellN=0 if the cellN is located at centers.
@@ -718,8 +747,8 @@ Overset connectivity
    
 -----------------------------------------------------------------------------------------------------------------------------
 
-.. py:function:: Connector.PyTree.setInterpData(aR, aD, order=2, penalty=1, nature=0, extrap=1, loc='nodes', storage='direct', topTreeRcv=None, topTreeDnr=None, sameName=0)
-
+.. py:function:: Connector.PyTree.setInterpData(aR, aD, order=2, penalty=1, nature=0, extrap=1, method='lagrangian', loc='nodes', storage='direct', interpDataType=1, hook=None, verbose=2, topTreeRcv=None, topTreeDnr=None, sameName=1, dim=3, itype='both', dictOfModels=None)
+    
     Compute and store in a pyTree the interpolation information (donor and receptor points, interpolation type, interpolation coefficients) given receptors defined by aR,
     donor zones given by aD. If storage='direct', then aR with interpolation data stored in receptor zones are returned, and if storage='inverse', then aD with interpolation data stored in donor zones are returned.
     Donor zones can be structured or unstructured TETRA. receptor zones can be structured or unstructured.

--- a/Cassiopee/Generator/Generator/Generator.py
+++ b/Cassiopee/Generator/Generator/Generator.py
@@ -1789,14 +1789,14 @@ def conformOctree3(octree):
 def balanceOctree__(octree, ratio=2, corners=0):
     return generator.balanceOctree(octree, ratio, corners)
 
-def extendCartGrids(A, ext=0, optimized=0, extBnd=0):
-    A, rinds = generator.extendCartGrids(A, ext, optimized, extBnd)
+def extendCartGrids(A, ext=0, optimized=0, extBnd=0, tol=1.e-6):
+    A, rinds = generator.extendCartGrids(A, ext, optimized, extBnd, tol)
     return A, rinds
 
-def extendOctreeGrids__(A, ext, optimized, extBnd=0):
+def extendOctreeGrids__(A, ext, optimized, extBnd=0,tol=1.e-6):
     """Extend grids with ext cells. If optimized is ext, the minimum overlapping is ensured.
     Usage: extendOctreeGrids__(cartGrids, ext, optimized, extBnd)"""
-    A, rinds = extendCartGrids(A, ext, optimized, extBnd)
+    A, rinds = extendCartGrids(A, ext, optimized, extBnd, tol)
     return A
 
 def adaptOctree(octreeHexa, indicField, balancing=1, ratio=2):

--- a/Cassiopee/Generator/Generator/extendCartGrids.cpp
+++ b/Cassiopee/Generator/Generator/extendCartGrids.cpp
@@ -30,7 +30,8 @@ PyObject* K_GENERATOR::extendCartGrids(PyObject* self, PyObject* args)
 {
   PyObject *arrays;
   E_Int ext, optimized, extBnd;
-  if (!PYPARSETUPLE_(args, O_ III_, &arrays, &ext, &optimized, &extBnd)) return NULL;
+  E_Float tol=1.e-6;
+  if (!PYPARSETUPLE_(args, O_ III_ R_, &arrays, &ext, &optimized, &extBnd, &tol)) return NULL;
 
   if (ext < 0) 
   {
@@ -95,7 +96,7 @@ PyObject* K_GENERATOR::extendCartGrids(PyObject* self, PyObject* args)
   E_Float* xminp = bbox.begin(1); E_Float* xmaxp = bbox.begin(4);
   E_Float* yminp = bbox.begin(2); E_Float* ymaxp = bbox.begin(5);
   E_Float* zminp = bbox.begin(3); E_Float* zmaxp = bbox.begin(6);
-  E_Float tol = 1.e-6; E_Float tol2 = tol*tol;
+  E_Float tol2 = tol*tol;
   for (E_Int v = 0; v < nzones; v++)
   {
     K_COMPGEOM::boundingBox(

--- a/Cassiopee/XCore/test/intersectMeshPT.py
+++ b/Cassiopee/XCore/test/intersectMeshPT.py
@@ -10,7 +10,6 @@ m = G.cartNGon((0,0,0),(0.1,0.1,0.1),(11,11,11))
 C._initVars(m, 'centers:keep', 1.0)
 # Triangulate the external quads
 X._triangulateSkin(m)
-I._adaptNGon42NGon3(m)
 
 # Initialize the IntersectMesh hook
 IM = X.IntersectMesh_Init(m)
@@ -24,7 +23,6 @@ c = G.close(c)
 cp = X.removeIntersectingKPlanes(IM, c)
 # Mark the original cells to keep
 C._initVars(cp, 'centers:keep', 1.0)
-I._adaptNGon42NGon3(cp)
 
 # Drop the IntersectMesh hook
 X.IntersectMesh_Exit(IM)
@@ -37,6 +35,7 @@ X.icapsuleSetMaster(IC, m)
 X.icapsuleSetSlaves(IC, [cp])
 
 # Intersect
+X.icapsuleAdapt2(IC)
 X.icapsuleIntersect2(IC)
 # Extract the resulting meshes as zones
 Mi = X.icapsuleExtractMaster(IC)


### PR DESCRIPTION
Connector:getIntersectingDomains: tol in the interface (useful for wind farms configs + IBM) + doc upgrade to be consistent with the python functions
XCore: add IntersectMesh in test case: removal of adaptNGON42NGON3 (not useful hier) + add icapsuleAdapt2 => still does not work  
