### PR TITLE
Converter: bug in Internal.setElementConnectivity2 for BE/ME in api3

### DIFF
--- a/Cassiopee/Converter/Converter/Internal.py
+++ b/Cassiopee/Converter/Converter/Internal.py
@@ -4125,7 +4125,7 @@ def setElementConnectivity2(z, array):
       else: cname = 'GridElements%d'%nc
       z[2].append([cname, i, [], 'Elements_t'])
       info = z[2][len(z[2])-1]
-      i = numpy.empty((2), E_NpyInt); i[0] = 1; i[1] = gc.shape[1]
+      i = numpy.empty((2), E_NpyInt); i[0] = 1; i[1] = gc.shape[0]
       info[2].append(['ElementRange', i, [], 'IndexRange_t'])
       info[2].append(['ElementConnectivity', gc, [], 'DataArray_t'])
       _updateElementRange(z)

--- a/Cassiopee/KCore/KCore/Connect/v_cleanConnectivity.cpp
+++ b/Cassiopee/KCore/KCore/Connect/v_cleanConnectivity.cpp
@@ -686,6 +686,7 @@ PyObject* K_CONNECT::V_cleanConnectivityME(
   E_Int nc = cn.getNConnect();
   E_Int vidx;
   E_Int nfld = f.getNfld(), npts = f.getSize(), api = f.getApi();
+  if (nc > 1) api = 3; // force array3 for ME
   std::vector<char*> eltTypes;
   K_ARRAY::extractVars(eltType, eltTypes);
 


### PR DESCRIPTION
Bug in `Internal.setElementConnectivity2` for BE/ME in api2 or api3.  
Upper bound of `ElementRange` miscalculated: it used the number of vertices per element of a  connectivity rather than the number of elements of that connectivity.

Snippet to reproduce the problem:
```py
# - mergeConnectivity (pyTree) -
import Converter.PyTree as C
import Converter.Internal as Internal
import Generator.PyTree as G
import numpy as np

# merge element connectivity
a = G.cartHexa( (0,0,0), (1,1,1), (10,10,10) )
b = G.cartTetra( (0,0,9), (1,1,1), (10,10,10) )
c = C.mergeConnectivity(a, b, boundary=0)

n_ers = Internal.getNodesFromName(c, "ElementRange")
print(n_ers)
# CORRECT before calling setElementConnectivity2
# [['ElementRange', array([  1, 729], dtype=int32), [], 'IndexRange_t'], ['ElementRange', array([ 730, 4374], dtype=int32), [], 'IndexRange_t']]

fields = C.getAllFields(c, 'nodes', api=3)
C.setFields(fields, c, 'nodes')

n_ers = Internal.getNodesFromName(c, "ElementRange")
print(n_ers)
# WRONG
# [['ElementRange', array([  1, 8], dtype=int32), [], 'IndexRange_t'], ['ElementRange', array([ 9, 12], dtype=int32), [], 'IndexRange_t']]
```

**Regressions**:
```
Converter       : convertHO2LOPT_t1.py                    : 0m0.26s   : 0m0.25s   : 16/07/25 10h31  : 0%   :   :  FAILED    
Converter       : convertLO2HOPT_t1.py                    : 0m0.26s   : 0m0.25s   : 16/07/25 10h31  : 0%   :   :  FAILED    
Converter       : convertPenta2StrandPT_t1.py             : 0m0.24s   : 0m0.24s   : 16/07/25 10h31  : 0%   :   :  FAILED    
Converter       : convertStrand2PentaPT_t1.py             : 0m0.24s   : 0m0.24s   : 16/07/25 10h31  : 0%   :   :  FAILED    
Transform       : rotatePT_t1.py                          : 0m0.27s   : 0m0.26s   : 16/07/25 10h40  : 100% :   :  FAILED    
```

For instance in Converter/test/convertStrand2PentaPT_t1.py, a box of 16 Pentas (27 vertices) used to return an ElementRange of [1 6]. Now [ 1 16].
```py
Running convertStrand2PentaPT_t1.py with Nprocs=0 and Nthreads=24
['cartPenta', array([[27, 16,  0]], dtype=int32)
Reading Data_ubuntu/convertStrand2PentaPT_t1.ref1 (bin_pickle)...done.
DIFF: valeurs differentes pour le noeud: ElementRange.
DIFF: reference: [1 6]
DIFF: courant: [ 1 16]
```
