### PR TITLE
Connector: K_METRIC::compVolOfStructCell - conv Fortran to C

### DIFF
--- a/Cassiopee/Connector/Connector/setInterpolations.cpp
+++ b/Cassiopee/Connector/Connector/setInterpolations.cpp
@@ -23,14 +23,6 @@
 using namespace std;
 using namespace K_FLD;
 
-extern "C"
-{
-  void 
-  k6compvolofstructcell_(
-    const E_Int& ni, const E_Int& nj, const E_Int& nk, 
-    const E_Int& indcell, const E_Int& indnode, 
-    const E_Float* xt, const E_Float* yt, const E_Float* zc, E_Float& vol);
-}
 //=============================================================================
 /* Calcul et stocke les coefficients d'interpolation pour les centres des 
    cellules
@@ -693,8 +685,9 @@ void K_CONNECTOR::compAndStoreEXInterpCoefs(
         ind0 = indi[1] + indi[3] * ni1 + indi[5] * ni1nj1;
         ind0ext = icv[indg]-1+(jcv[indg]-1)*(ni1+2)+(kcv[indg]-1)*(ni1+2)*(nj1+2);
                
-        k6compvolofstructcell_(nit[blocNb], njt[blocNb], nkt[blocNb], ind0, -1,
-                               xni, yni, zni, vol);
+        K_METRIC::compVolOfStructCell3D(
+          nit[blocNb], njt[blocNb], nkt[blocNb], ind0, -1,
+          xni, yni, zni, vol);
         ret = extrapv[indg]; if ( ret == 0 ) vol = vol + 500;
 
         if (vol < volSav)
@@ -788,8 +781,9 @@ void K_CONNECTOR::compAndStoreEXInterpCoefs(
             E_Float* xni = coords[blocNb]->begin(1);
             E_Float* yni = coords[blocNb]->begin(2);
             E_Float* zni = coords[blocNb]->begin(3);
-            k6compvolofstructcell_(nit[blocNb], njt[blocNb], nkt[blocNb], 
-                                   ind0, -1, xni, yni, zni, vol);
+            K_METRIC::compVolOfStructCell3D(
+              nit[blocNb], njt[blocNb], nkt[blocNb], ind0, -1,
+              xni, yni, zni, vol);
             ret = extrapv[indg]; 
             if ( ret == 0 ) vol = vol + 1000;
 
@@ -885,8 +879,9 @@ void K_CONNECTOR::compAndStoreEXInterpCoefs(
         ind0 = indi[1] + indi[3]*ni1 + indi[5]*ni1nj1;
         ind0ext = ic-1+(jc-1)*(ni1+2)+(kc-1)*(ni1+2)*(nj1+2);
 
-        k6compvolofstructcell_(nit[blocNb], njt[blocNb], nkt[blocNb], ind0, -1,
-                               xni, yni, zni, vol);
+        K_METRIC::compVolOfStructCell3D(
+          nit[blocNb], njt[blocNb], nkt[blocNb], ind0, -1,
+          xni, yni, zni, vol);
         if ( ret == 0 ) vol = vol + 1000*test;
 
         if (vol < volSavExtrap)
@@ -1150,8 +1145,9 @@ void K_CONNECTOR::compAndStoreInterpCoefs(
         //interpType = indi[0];
         ind0 = indi[1] + indi[3] * ni1 + indi[5] * ni1nj1;
         ind0ext = icv[indg]-1+(jcv[indg]-1)*(ni1+2)+(kcv[indg]-1)*(ni1+2)*(nj1+2);       
-        k6compvolofstructcell_(nit[blocNb], njt[blocNb], nkt[blocNb], ind0, -1,
-                               xni, yni, zni, vol);
+        K_METRIC::compVolOfStructCell3D(
+          nit[blocNb], njt[blocNb], nkt[blocNb], ind0, -1,
+          xni, yni, zni, vol);
         ret = extrapv[indg]; if (ret == 0) vol += 500.;
 
         if (vol < volSavExplicit)
@@ -1241,8 +1237,9 @@ void K_CONNECTOR::compAndStoreInterpCoefs(
             E_Float* xni = coords[blocNb]->begin(1);
             E_Float* yni = coords[blocNb]->begin(2);
             E_Float* zni = coords[blocNb]->begin(3);
-            k6compvolofstructcell_(nit[blocNb], njt[blocNb], nkt[blocNb], ind0, -1,
-                                   xni, yni, zni, vol);
+            K_METRIC::compVolOfStructCell3D(
+              nit[blocNb], njt[blocNb], nkt[blocNb], ind0, -1,
+              xni, yni, zni, vol);
             ret = extrapv[indg]; if (ret == 0) vol += 1000.;
             if (vol < volSavExtrap)
             {
@@ -1335,8 +1332,9 @@ void K_CONNECTOR::compAndStoreInterpCoefs(
             ind0 = indi[1] + indi[3]*ni1 + indi[5]*ni1nj1;
             ind0ext = ic-1+(jc-1)*(ni1+2)+(kc-1)*(ni1+2)*(nj1+2);
           
-            k6compvolofstructcell_(nit[blocNb], njt[blocNb], nkt[blocNb], ind0, -1,
-                                   xni, yni, zni, vol);
+            K_METRIC::compVolOfStructCell3D(
+              nit[blocNb], njt[blocNb], nkt[blocNb], ind0, -1,
+              xni, yni, zni, vol);
             if (ret == 0) vol = vol + 1000*test;
 
             if (vol < volSavExtrap)


### PR DESCRIPTION
Regressions in Connector/chimeraInfoPT_t1.py

```
Running chimeraInfoPT_t1.py with Nprocs=0 and Nthreads=16
Warning: _setInterpolations: inverse storage is mandatory if no Chimera connectivity files are written.
Zone cylindre1: interpolated=156 ; extrapolated=6 ; orphan=435
Warning: zone cylindre1 has 435 orphan points !
Zone cylindre2: interpolated=153 ; extrapolated=12 ; orphan=432
Warning: zone cylindre2 has 432 orphan points !
Reading Data_ubuntu/chimeraInfoPT_t1.ref1 (bin_pickle)...done.
DIFF: Variable=centers:DcellRatio, L0=0.000000000029, L2=0.000000000001
Reading Data_ubuntu/chimeraInfoPT_t1.ref1 (bin_pickle)...done.
DIFF: Variable=centers:DcellRatio, L0=0.000000000029, L2=0.000000000001
Zone cylindre1: interpolated=156 ; extrapolated=6 ; orphan=435
Warning: zone cylindre1 has 435 orphan points !
Zone cylindre2: interpolated=153 ; extrapolated=12 ; orphan=432
Warning: zone cylindre2 has 432 orphan points !
Reading Data_ubuntu/chimeraInfoPT_t1.ref2 (bin_pickle)...done.
DIFF: Variable=centers:DcellRatio, L0=0.000000000029, L2=0.000000000001
0.53user 0.14system 0:00.52elapsed 130%CPU (0avgtext+0avgdata 76320maxresident)k
0inputs+0outputs (0major+19366minor)pagefaults 0swaps
```