### PR TITLE
KCore: fix crash in K_KCore::setOmpMaxThreads (int size)

### DIFF
--- a/Cassiopee/KCore/KCore/OmpMaxThreads.cpp
+++ b/Cassiopee/KCore/KCore/OmpMaxThreads.cpp
@@ -23,11 +23,11 @@
 //=============================================================================
 PyObject* K_KCORE::getOmpMaxThreads(PyObject* self, PyObject* args)
 {
-  E_Int i = 1;
+  int i = 1;
 #ifdef _OPENMP
   i = omp_get_max_threads();
 #endif
-  return Py_BuildValue("l", long(i));
+  return Py_BuildValue("i", i);
 }
 
 //=============================================================================
@@ -35,8 +35,8 @@ PyObject* K_KCORE::getOmpMaxThreads(PyObject* self, PyObject* args)
 //=============================================================================
 PyObject* K_KCORE::setOmpMaxThreads(PyObject* self, PyObject* args)
 {
-  E_Int i;
-  if (!PyArg_ParseTuple(args, "l", &i)) return NULL;
+  int i;
+  if (!PyArg_ParseTuple(args, "i", &i)) return NULL;
 #ifdef _OPENMP
   omp_set_num_threads(i);
 #endif


### PR DESCRIPTION
This function
```c
PyObject* K_KCORE::setOmpMaxThreads(PyObject* self, PyObject* args)
{
  E_Int i;
  if (!PyArg_ParseTuple(args, "l", &i)) return NULL;
#ifdef _OPENMP
  omp_set_num_threads(i);
#endif
  return Py_None;
}
```
returns the following error in validCassiopee when the number of threads is edited.

```
*** stack smashing detected ***: terminated
Aborted (core dumped)
```

Any reason why it used to be a `long` int?

Ref: [omp-set-num-threads](https://learn.microsoft.com/en-us/cpp/parallel/openmp/reference/openmp-functions?view=msvc-170#omp-set-num-threads)