### PR TITLE
Generator: add ME compatibility to getBBOfCells()

### DIFF
--- a/Cassiopee/Generator/test/bboxOfCellsPT_t3.py
+++ b/Cassiopee/Generator/test/bboxOfCellsPT_t3.py
@@ -1,0 +1,41 @@
+# - bboxOfCells (pyTree) -
+import Generator.PyTree as G
+import Converter.PyTree as C
+import KCore.test as test
+
+# STRUCT
+z = G.cart((0.,0.,0.),(0.1,0.1,0.1),(10,10,10))
+z1 = G.bboxOfCells(z)
+test.testT(z1, 11)
+G._bboxOfCells(z)
+test.testT(z, 1)
+
+# NGONv3
+z = G.cartNGon((0.,0.,0.),(0.1,0.1,0.1),(10,10,10), api=1)
+z1 = G.bboxOfCells(z)
+test.testT(z1, 21)
+G._bboxOfCells(z)
+test.testT(z, 2)
+
+# NGONv4
+z = G.cartNGon((0.,0.,0.),(0.1,0.1,0.1),(10,10,10), api=3)
+z1 = G.bboxOfCells(z)
+test.testT(z1, 31)
+G._bboxOfCells(z)
+test.testT(z, 3)
+
+# BE (HEXA)
+z = G.cartHexa((0.,0.,0.),(0.1,0.1,0.1),(10,10,10))
+z1 = G.bboxOfCells(z)
+test.testT(z1, 41)
+G._bboxOfCells(z)
+test.testT(z, 4)
+
+# ME (HEXA+TETRA)
+a = G.cartHexa((0.,0.,0.),(0.1,0.1,0.1),(10,10,10))
+b = G.cartTetra((0.9,0.,0.),(0.1,0.1,0.1),(10,10,10))
+z = C.mergeConnectivity(a, b, boundary=0)
+z1 = G.bboxOfCells(z)
+test.testT(z1, 51)
+G._bboxOfCells(z)
+test.testT(z, 5)


### PR DESCRIPTION
No regression. New test case (bboxOfCellsPT_t3.py) to test all possibilities (NGON v3/4, Struct, BE, and ME) with both in-place and non-in-place functions. The algorithm is the same between 2D and 3D cases for both structured and unstructured meshes. The algorithm is also the same for all BE connectivities.