### PR TITLE
KCore/Envs: user config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ Cassiopee/XCore/merge.l
 Cassiopee/Modeler/merge.l
 Cassiopee/KCore/buildInfo.py
 Cassiopee/KCore/installPath.py
-Cassiopee/KCore/installUserBase.py
+Cassiopee/KCore/installBaseUser.py
+Cassiopee/Envs/sh_Cassiopee_user
 Cassiopee/KCore/doc/source/*.rst
 Cassiopee/CPlot/apps/Output
 ValidData*

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Cassiopee/XCore/merge.l
 Cassiopee/Modeler/merge.l
 Cassiopee/KCore/buildInfo.py
 Cassiopee/KCore/installPath.py
+Cassiopee/KCore/installUserBase.py
 Cassiopee/KCore/doc/source/*.rst
 Cassiopee/CPlot/apps/Output
 ValidData*

--- a/Cassiopee/Envs/sh_Cassiopee_local
+++ b/Cassiopee/Envs/sh_Cassiopee_local
@@ -191,18 +191,18 @@ elif [ "$MAC" = "macosx" ]; then
     unset BUNDLE
     export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATHL
 
-# elif [ "$MAC" = "ubuntu" ]; then
-# #-------------------------------- ubuntu --------------------------------------
-#     export ELSAPROD=ubuntu
-#     export ELSAPROD=$ELSAPROD$EXT
-#     export OMP_NUM_THREADS=4
-#     export PYTHONEXE=python3
-#     export PRODMODE=1
-#     export PIP_DISABLE_PIP_VERSION_CHECK=1
-#     export ASAN_OPTIONS=verify_asan_link_order=false
-#     export LSAN_OPTIONS=suppressions=$CASSIOPEE/Dist/bin/"$ELSAPROD"/asan.supp:print_suppressions=0
-#     export ASAN_LIB=/usr/lib/gcc/x86_64-linux-gnu/13/libasan.so
-#     ulimit -s 8192 # for ASAN
+elif [ "$MAC" = "ubuntu" ]; then
+#-------------------------------- ubuntu --------------------------------------
+    export ELSAPROD=ubuntu
+    export ELSAPROD=$ELSAPROD$EXT
+    export OMP_NUM_THREADS=4
+    export PYTHONEXE=python3
+    export PRODMODE=1
+    export PIP_DISABLE_PIP_VERSION_CHECK=1
+    export ASAN_OPTIONS=verify_asan_link_order=false
+    export LSAN_OPTIONS=suppressions=$CASSIOPEE/Dist/bin/"$ELSAPROD"/asan.supp:print_suppressions=0
+    export ASAN_LIB=/usr/lib/gcc/x86_64-linux-gnu/13/libasan.so
+    ulimit -s 8192 # for ASAN
 
 elif [ "$MAC" = "ubuntu-jax" ]; then
 #-------------------------------- ubuntu --------------------------------------

--- a/Cassiopee/Envs/sh_Cassiopee_local
+++ b/Cassiopee/Envs/sh_Cassiopee_local
@@ -85,6 +85,11 @@ fi
 
 
 # ----------------------------- Prods ------------------------------------------
+if [ -f "$CASSIOPEE/Cassiopee/Envs/sh_Cassiopee_user" ]; then
+    . "$CASSIOPEE/Cassiopee/Envs/sh_Cassiopee_user"
+fi
+
+if [ -z $ELSAPROD ]; then
 if [ "$MAC" = "ld_eos8" ]; then
 #------------------------------- ld centos 8 + python 3 -----------------------------------
     export ELSAPROD=eos8_r8
@@ -899,10 +904,7 @@ elif [ "$MAC" = "msys2" ]; then
     export PYTHONEXE=python3
     export PRODMODE=1
     export PIP_DISABLE_PIP_VERSION_CHECK=1
-
-elif [ -f "$CASSIOPEE/Cassiopee/Envs/sh_Cassiopee_user" ]; then
-#----------------------------- user prods --------------------------------------
-    . "$CASSIOPEE/Cassiopee/Envs/sh_Cassiopee_user"
+fi
 fi
 
 if [ -z $ELSAPROD ]; then

--- a/Cassiopee/Envs/sh_Cassiopee_local
+++ b/Cassiopee/Envs/sh_Cassiopee_local
@@ -16,29 +16,37 @@ fi
 
 # Detect machine (shortest first)
 KC=$(uname -n)
-if echo "$KC" | grep -q 'n'; then export MAC="sator_cas"; fi
-if echo "$KC" | grep -q 'ld'; then export MAC="ld"; fi
-if echo "$KC" | grep -q 'f0'; then export MAC="juno"; fi
-if echo "$KC" | grep -q 'n0'; then export MAC="juno"; fi
-if echo "$KC" | grep -q 'b0'; then export MAC="juno"; fi
-if echo "$KC" | grep -q 'v0'; then export MAC="juno"; fi
-if echo "$KC" | grep -q 'fv-az'; then export MAC="azure"; fi
-if echo "$KC" | grep -q 'clausius'; then export MAC="ld"; fi
-if echo "$KC" | grep -q 'ubuntu'; then export MAC="ubuntu"; fi
-if echo "$KC" | grep -q 'visio'; then export MAC="visio"; fi
-if echo "$KC" | grep -q 'austri'; then export MAC="austri"; fi
-if echo "$KC" | grep -q 'celeste'; then export MAC="visio"; fi
-if echo "$KC" | grep -q 'visung'; then export MAC="visung"; fi
-if echo "$KC" | grep -q 'giulia'; then export MAC="giulia"; fi
-if echo "$KC" | grep -q 'sator'; then export MAC="sator_cas"; fi
-if echo "$KC" | grep -q 'spiro'; then export MAC="spiro_el8"; fi
-if echo "$KC" | grep -q 'cobalt'; then export MAC="cobalt"; fi
-if echo "$KC" | grep -q 'irene'; then export MAC="irene"; fi
-if echo "$KC" | grep -q 'jean-zay'; then export MAC="jean-zay"; fi
-if echo "$KC" | grep -q 'node6.cluster'; then export MAC="macosx"; fi
-if echo "$KC" | grep -q 'topaze'; then export MAC="topaze"; fi
-if echo "$KC" | grep -q 'atlas'; then export MAC="atlas"; fi
-if echo "$KC" | grep -q 'WDAAA161Z'; then export MAC="WDAAA161Z"; fi
+for pattern in \
+  "n:sator_cas" \
+  "ld:ld" \
+  "f0:juno" \
+  "n0:juno" \
+  "b0:juno" \
+  "v0:juno" \
+  "fv-az:azure" \
+  "clausius:ld" \
+  "ubuntu:ubuntu" \
+  "visio:visio" \
+  "austri:austri" \
+  "celeste:visio" \
+  "visung:visung" \
+  "giulia:giulia" \
+  "sator:sator_cas" \
+  "spiro:spiro_el8" \
+  "cobalt:cobalt" \
+  "irene:irene" \
+  "jean-zay:jean-zay" \
+  "node6.cluster:macosx" \
+  "topaze:topaze" \
+  "atlas:atlas" \
+  "WDAAA161Z:WDAAA161Z"
+do
+  key=${pattern%%:*}; val=${pattern#*:}
+  if echo "$KC" | grep -q "$key"; then
+    export MAC="$val"
+    break
+  fi
+done
 
 # Detect MAC environement from MACHINE
 EXT=""
@@ -183,18 +191,18 @@ elif [ "$MAC" = "macosx" ]; then
     unset BUNDLE
     export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATHL
 
-elif [ "$MAC" = "ubuntu" ]; then
-#-------------------------------- ubuntu --------------------------------------
-    export ELSAPROD=ubuntu
-    export ELSAPROD=$ELSAPROD$EXT
-    export OMP_NUM_THREADS=4
-    export PYTHONEXE=python3
-    export PRODMODE=1
-    export PIP_DISABLE_PIP_VERSION_CHECK=1
-    export ASAN_OPTIONS=verify_asan_link_order=false
-    export LSAN_OPTIONS=suppressions=$CASSIOPEE/Dist/bin/"$ELSAPROD"/asan.supp:print_suppressions=0
-    export ASAN_LIB=/usr/lib/gcc/x86_64-linux-gnu/13/libasan.so
-    ulimit -s 8192 # for ASAN
+# elif [ "$MAC" = "ubuntu" ]; then
+# #-------------------------------- ubuntu --------------------------------------
+#     export ELSAPROD=ubuntu
+#     export ELSAPROD=$ELSAPROD$EXT
+#     export OMP_NUM_THREADS=4
+#     export PYTHONEXE=python3
+#     export PRODMODE=1
+#     export PIP_DISABLE_PIP_VERSION_CHECK=1
+#     export ASAN_OPTIONS=verify_asan_link_order=false
+#     export LSAN_OPTIONS=suppressions=$CASSIOPEE/Dist/bin/"$ELSAPROD"/asan.supp:print_suppressions=0
+#     export ASAN_LIB=/usr/lib/gcc/x86_64-linux-gnu/13/libasan.so
+#     ulimit -s 8192 # for ASAN
 
 elif [ "$MAC" = "ubuntu-jax" ]; then
 #-------------------------------- ubuntu --------------------------------------
@@ -892,9 +900,14 @@ elif [ "$MAC" = "msys2" ]; then
     export PRODMODE=1
     export PIP_DISABLE_PIP_VERSION_CHECK=1
 
-else
+elif [ -f "$CASSIOPEE/Cassiopee/Envs/sh_Cassiopee_user" ]; then
+#----------------------------- user prods --------------------------------------
+    . "$CASSIOPEE/Cassiopee/Envs/sh_Cassiopee_user"
+fi
+
+if [ -z $ELSAPROD ]; then
     echo 'Error: your machine was not found in Envs.'
-    exit 1
+    return 1
 fi
 
 #-------------------------- Common to all prods --------------------------------

--- a/Cassiopee/KCore/Dist.py
+++ b/Cassiopee/KCore/Dist.py
@@ -518,7 +518,7 @@ def writeSetupCfg():
 
 #==============================================================================
 # Retourne le compilo c, c++ et ses options tels que definis dans distutils
-# ou dans config.py (installBase.py ou installUserBase.py)
+# ou dans config.py (installBase.py ou installBaseUser.py)
 #==============================================================================
 def getDistUtilsCompilers():
     vars = sysconfig.get_config_vars('CC', 'CXX', 'OPT',
@@ -2609,7 +2609,7 @@ def writeBuildInfo():
 
 #==============================================================================
 # Ecrit la base d'installation (ancien config.py) dans le fichier
-# installBase.py ou installUserBase.py
+# installBase.py
 # IN: dict: dictionnaire d'install
 #==============================================================================
 def writeInstallBase(dict):

--- a/Cassiopee/KCore/Dist.py
+++ b/Cassiopee/KCore/Dist.py
@@ -518,7 +518,7 @@ def writeSetupCfg():
 
 #==============================================================================
 # Retourne le compilo c, c++ et ses options tels que definis dans distutils
-# ou dans config.py (installBase.py)
+# ou dans config.py (installBase.py ou installUserBase.py)
 #==============================================================================
 def getDistUtilsCompilers():
     vars = sysconfig.get_config_vars('CC', 'CXX', 'OPT',
@@ -2609,7 +2609,7 @@ def writeBuildInfo():
 
 #==============================================================================
 # Ecrit la base d'installation (ancien config.py) dans le fichier
-# installBase.py
+# installBase.py ou installUserBase.py
 # IN: dict: dictionnaire d'install
 #==============================================================================
 def writeInstallBase(dict):

--- a/Cassiopee/KCore/README
+++ b/Cassiopee/KCore/README
@@ -14,11 +14,11 @@ See doc/KCore.txt for installation requirements.
 installing KCore:
 =============================================================================
 - type "python installer.py". Use File/check All Paths. Correct paths
-if needed. Use File/Save installUserBase.
+if needed. Use File/Save installBaseUser.
 
 -or-
 
-- edit installUserBase.py. Set the correct compiler names and libraries.
+- edit installBaseUser.py. Set the correct compiler names and libraries.
 
 Then,
 

--- a/Cassiopee/KCore/README
+++ b/Cassiopee/KCore/README
@@ -14,11 +14,11 @@ See doc/KCore.txt for installation requirements.
 installing KCore:
 =============================================================================
 - type "python installer.py". Use File/check All Paths. Correct paths
-if needed. Use File/Save installBase.
+if needed. Use File/Save installUserBase.
 
 -or-
 
-- edit installBase.py. Set the correct compiler names and libraries.
+- edit installUserBase.py. Set the correct compiler names and libraries.
 
 Then,
 

--- a/Cassiopee/KCore/config.py
+++ b/Cassiopee/KCore/config.py
@@ -41,7 +41,7 @@ if key == '':
             key = i; break
 
 if key == '': # not found in install base
-    print("Warning: %s was not found in KCore/installBase.py."%host)
+    print("Warning: neither %s nor %s were found in KCore/installBase.py."%(prod, host))
     print("Warning: using default compilers and options.")
     print("Warning: to change that, add a block in KCore/installBase.py.")
     key = 'default'

--- a/Cassiopee/KCore/install
+++ b/Cassiopee/KCore/install
@@ -2,7 +2,7 @@
 #
 # Installation du module KCore
 #
-# 1. Modifier le fichier KCore/installBase.py
+# 1. Modifier le fichier KCore/installUserBase.py
 # 2. Pour l'installation standard (dans $CASSIOPEE/Dist/bin/$ELSAPROD/),
 # taper  : ./install
 #    Pour une installation dans un repertoire <rep>, taper : ./install <rep>

--- a/Cassiopee/KCore/install
+++ b/Cassiopee/KCore/install
@@ -2,7 +2,7 @@
 #
 # Installation du module KCore
 #
-# 1. Modifier le fichier KCore/installUserBase.py
+# 1. Modifier le fichier KCore/installBaseUser.py
 # 2. Pour l'installation standard (dans $CASSIOPEE/Dist/bin/$ELSAPROD/),
 # taper  : ./install
 #    Pour une installation dans un repertoire <rep>, taper : ./install <rep>

--- a/Cassiopee/KCore/installBase.py
+++ b/Cassiopee/KCore/installBase.py
@@ -5,6 +5,11 @@
 # additionalIncludePaths, additionalLibs, additionalLibPaths].
 # Paths are list of strings. useOMP, static, useCuda are booleans.
 # Others are strings.
+try:
+    from installUserBase import installDict as installUserDict
+except:
+    installUserDict = {}
+
 installDict = {
     ###############################################################################
     'DESKTOP...': [ 'Windows ubuntu',
@@ -1346,5 +1351,7 @@ installDict = {
                [], # additionalLibPaths
                False, # useCuda
                [] # NvccAdditionalOptions
-               ]
+               ],
+    ###############################################################################
+    **installUserDict
 }

--- a/Cassiopee/KCore/installBase.py
+++ b/Cassiopee/KCore/installBase.py
@@ -6,9 +6,13 @@
 # Paths are list of strings. useOMP, static, useCuda are booleans.
 # Others are strings.
 try:
-    from installUserBase import installDict as installUserDict
-except:
-    installUserDict = {}
+    from installBaseUser import installDict as installDictUser
+except ImportError:
+    try:
+        from . import installBaseUser
+        installDictUser = installBaseUser.installDict
+    except:
+        installDictUser = {}
 
 installDict = {
     ###############################################################################
@@ -1353,5 +1357,5 @@ installDict = {
                [] # NvccAdditionalOptions
                ],
     ###############################################################################
-    **installUserDict
+    **installDictUser
 }

--- a/Cassiopee/KCore/installLib.py
+++ b/Cassiopee/KCore/installLib.py
@@ -41,6 +41,8 @@ shutil.copyfile("config.py", installPath+"/config.py")
 shutil.copyfile("Dist.py", installPath+"/Dist.py")
 shutil.copyfile("installPath.py", installPath+"/installPath.py")
 shutil.copyfile("installBase.py", installPath+"/installBase.py")
+if os.access("installBaseUser.py", os.R_OK):
+    shutil.copyfile("installBaseUser.py", installPath+"/installBaseUser.py")
 shutil.copyfile("test/notify.py", installPath+"/notify.py")
 
 # Ecrit les infos d'install

--- a/Cassiopee/KCore/installer.py
+++ b/Cassiopee/KCore/installer.py
@@ -18,7 +18,7 @@ WIDTH=40
 # tous les chemins dans config.py (ancien systeme).
 #==============================================================================
 try: import Tkinter as TK
-except: raise ImportError('Cassiopee installer requires tkinter.\nIf your python dont run tkinter, edit the installUserBase.py file manually and add your machine settings.')
+except: raise ImportError('Cassiopee installer requires tkinter.\nIf your python dont run tkinter, edit the installBaseUser.py file manually and add your machine settings.')
 
 import Dist
 import os.path

--- a/Cassiopee/KCore/installer.py
+++ b/Cassiopee/KCore/installer.py
@@ -18,7 +18,7 @@ WIDTH=40
 # tous les chemins dans config.py (ancien systeme).
 #==============================================================================
 try: import Tkinter as TK
-except: raise ImportError('Cassiopee installer requires tkinter.\nIf your python dont run tkinter, edit the installBase.py file manually and add your machine settings.')
+except: raise ImportError('Cassiopee installer requires tkinter.\nIf your python dont run tkinter, edit the installUserBase.py file manually and add your machine settings.')
 
 import Dist
 import os.path


### PR DESCRIPTION
[PLEASE SQUASH COMMITS]
Open to discussion and changing the names of the new files if you want.
Optional: Two untracked new files: Cassiopee/KCore/installBaseUser.py and Cassiopee/Envs/sh_Cassiopee_user (env_* also later)

Example for Cassiopee/KCore/installBaseUser.py
```py
# This is the dictionary keeping track of installation.
# The key is the machine name. For each key a list is stored.
# [description,
# f77compiler, f90compiler, Cppcompiler, useOMP, static,
# additionalIncludePaths, additionalLibs, additionalLibPaths].
# Paths are list of strings. useOMP, static, useCuda are booleans.
# Others are strings.

installDict = {
    'myUbuntu': [
        'Linux ubuntu 24.04',
        'gfortran', # f77compiler
        'gfortran', # f90compiler
        'gcc', # Cppcompiler
        [], # CppAdditionalOptions
        [], # f77AdditionalOptions
        True, # useOMP
        False, # static
        ['/usr/include', '/usr/include/hdf5/openmpi', '/usr/lib/x86_64-linux-gnu/openmpi/include'], # additionalIncludePaths
        ['gfortran', 'gomp'], # additionalLibs
        ['/usr/lib/x86_64-linux-gnu/hdf5/openmpi', '/usr/lib/x86_64-linux-gnu'], # additionalLibPaths
        False, # useCuda
        [] # NvccAdditionalOptions
    ],
}
```


Example for Cassiopee/Envs/sh_Cassiopee_user

```sh
#! /bin/sh
# *Cassiopee* machine specific (local) variables

# ----------------------------- User prods -------------------------------------
if [ "$MAC" = "myUbuntu" ]; then
#------------------------------- ubuntu -----------------------------------
    export ELSAPROD=myUbuntu
    export ELSAPROD=$ELSAPROD$EXT
    export OMP_NUM_THREADS=4
    export PYTHONEXE=python3
    export PRODMODE=1
    export PIP_DISABLE_PIP_VERSION_CHECK=1
    export ASAN_OPTIONS=verify_asan_link_order=false
    export LSAN_OPTIONS=suppressions=$CASSIOPEE/Dist/bin/"$ELSAPROD"/asan.supp:print_suppressions=0
    export ASAN_LIB=/usr/lib/gcc/x86_64-linux-gnu/13/libasan.so
    ulimit -s 8192 # for ASAN
fi
```