### PR TITLE
Post: fix errors in test cases

### DIFF
--- a/Cassiopee/Post/test/exteriorEltsPT_t1.py
+++ b/Cassiopee/Post/test/exteriorEltsPT_t1.py
@@ -4,7 +4,7 @@ import Post.PyTree as P
 import Generator.PyTree as G
 import KCore.test as test
 
-a = G.cartTetra((0,0,0), (1,1.,1), (20,20,20))
+a = G.cartTetra((0,0,0), (1,1.,1), (10,10,10))
 C._addVars(a,'Density'); C._addVars(a,'centers:cellN')
-b = P.exteriorFaces(a)
+b = P.exteriorElts(a)
 test.testT(b, 1)

--- a/Cassiopee/Post/test/integNorm_t1.py
+++ b/Cassiopee/Post/test/integNorm_t1.py
@@ -22,8 +22,7 @@ c0 = C.initVars(c0,'vy', f2, ['x','y'])
 c = C.extractVars(c0, ['vx','vy'])
 res = P.integNorm([m], [c], [])
 out = C.array('resvx,resvy', 3, 1, 1)
-out[1][0,0] = res[0][0]; out[1][0,1] = res[0][1]; out[1][0,2] = res[0][2];
-out[1][0,0] = res[1][0]; out[1][0,1] = res[1][1]; out[1][0,2] = res[1][2];
+out[1][:,:] = res
 test.testA([out], 1)
 
 # STRUCT 2D NODE / NODE
@@ -35,8 +34,7 @@ c0 = C.initVars(c0,'vy', f2, ['x','y'])
 c = C.extractVars(c0, ['vx','vy'])
 res = P.integNorm([m], [c], [])
 out = C.array('resvx,resvy', 3, 1, 1)
-out[1][0,0] = res[0][0]; out[1][0,1] = res[0][1]; out[1][0,2] = res[0][2];
-out[1][0,0] = res[1][0]; out[1][0,1] = res[1][1]; out[1][0,2] = res[1][2];
+out[1][:,:] = res
 test.testA([out], 2)
 
 
@@ -49,8 +47,7 @@ c0 = C.initVars(c0,'vy', f2, ['x','y'])
 c = C.extractVars(c0, ['vx','vy'])
 res = P.integNorm([m], [c], [])
 out = C.array('resvx,resvy', 3, 1, 1)
-out[1][0,0] = res[0][0]; out[1][0,1] = res[0][1]; out[1][0,2] = res[0][2];
-out[1][0,0] = res[1][0]; out[1][0,1] = res[1][1]; out[1][0,2] = res[1][2];
+out[1][:,:] = res
 test.testA([out], 3)
 
 # TRI NODE / CENTER
@@ -63,6 +60,5 @@ c0 = C.node2Center(c0)
 c = C.extractVars(c0, ['vx','vy'])
 res = P.integNorm([m], [c], [])
 out = C.array('resvx,resvy', 3, 1, 1)
-out[1][0,0] = res[0][0]; out[1][0,1] = res[0][1]; out[1][0,2] = res[0][2];
-out[1][0,0] = res[1][0]; out[1][0,1] = res[1][1]; out[1][0,2] = res[1][2];
+out[1][:,:] = res
 test.testA([out], 4)

--- a/Cassiopee/Post/test/integ_t1.py
+++ b/Cassiopee/Post/test/integ_t1.py
@@ -22,7 +22,7 @@ c0 = C.initVars(c0,'vy', f2, ['x','y'])
 c = C.extractVars(c0, ['vx','vy','vz'])
 res = P.integ([m], [c], [])
 out = C.array('res', 3, 1, 1)
-out[1][0,0] = res[0]; out[1][0,1] = res[1]; out[1][0,2] = res[2];
+out[1][:] = res
 test.testA([out], 1)
 
 # STRUCT 2D NODE / NODE
@@ -34,7 +34,7 @@ c0 = C.initVars(c0,'vy', f2, ['x','y'])
 c = C.extractVars(c0, ['vx','vy','vz'])
 res = P.integ([m], [c], [])
 out = C.array('res', 3, 1, 1)
-out[1][0,0] = res[0]; out[1][0,1] = res[1]; out[1][0,2] = res[2];
+out[1][:] = res
 test.testA([out], 2)
 
 # STRUCT 1D NODE / CENTER
@@ -47,7 +47,7 @@ c0 = C.initVars(c0,'vy', f2, ['x','y'])
 c = C.extractVars(c0, ['vx','vy','vz'])
 res = P.integ([m], [c], [])
 out = C.array('res', 3, 1, 1)
-out[1][0,0] = res[0]; out[1][0,1] = res[1]; out[1][0,2] = res[2];
+out[1][:] = res
 test.testA([out], 3)
 
 # STRUCT 1D NODE / NODE
@@ -59,7 +59,7 @@ c0 = C.initVars(c0,'vy', f2, ['x','y'])
 c = C.extractVars(c0, ['vx','vy','vz'])
 res = P.integ([m], [c], [])
 out = C.array('res', 3, 1, 1)
-out[1][0,0] = res[0]; out[1][0,1] = res[1]; out[1][0,2] = res[2];
+out[1][:] = res
 test.testA([out], 4)
 
 # TRI NODE / NODE
@@ -68,7 +68,7 @@ c = C.array('vx,vy,vz', m[1].shape[1], m[2].shape[1], 'TRI')
 c = C.initVars(c, 'vx,vy,vz', 1.)
 res = P.integ([m], [c], [])
 out = C.array('res', 3, 1, 1)
-out[1][0,0] = res[0]; out[1][0,1] = res[1]; out[1][0,2] = res[2];
+out[1][:] = res
 test.testA([out], 5)
 
 # TRI NODE / CENTER
@@ -78,7 +78,7 @@ c = C.initVars(c, 'vx,vy,vz', 1.)
 c = C.node2Center(c)
 res = P.integ([m], [c], [])
 out = C.array('res', 3, 1, 1)
-out[1][0,0] = res[0]; out[1][0,1] = res[1]; out[1][0,2] = res[2];
+out[1][:] = res
 test.testA([out], 6)
 
 # BAR NODE / NODE
@@ -88,7 +88,7 @@ c = C.array('vx,vy,vz', m[1].shape[1], m[2].shape[1], 'BAR')
 c = C.initVars(c, 'vx,vy,vz', 1.)
 res = P.integ([m], [c], [])
 out = C.array('res', 3, 1, 1)
-out[1][0,0] = res[0]; out[1][0,1] = res[1]; out[1][0,2] = res[2];
+out[1][:] = res
 test.testA([out], 7)
 
 # BAR NODE / CENTER
@@ -101,5 +101,5 @@ c = C.node2Center(c)
 c = C.extractVars(c,['vx','vy','vz'])
 res = P.integ([m], [c], [])
 out = C.array('res', 3, 1, 1)
-out[1][0,0] = res[0]; out[1][0,1] = res[1]; out[1][0,2] = res[2];
+out[1][:] = res
 test.testA([out], 8)


### PR DESCRIPTION
Fix test cases in Post
Regressions for exteriorEltsPT_t1 and integNorm_t1

In exteriorEltsPT_t1:
function called isn't the right one

In integNorm_t1:

Before
```py
res
[[0.0, 0.0, 1500.0], [0.0, 0.0, 7900.0]]
out
[[   0.    0. 7900.]
 [   0.    0.    0.]]
```

After
```py
res
[[0.0, 0.0, 1500.0], [0.0, 0.0, 7900.0]]
out
[[   0.    0. 1500.]
 [   0.    0. 7900.]]
```
 
 
 
