### PR TITLE
All: do not use ngonType and api interchangeably

### DIFF
--- a/Cassiopee/Connector/Connector/getInterpolatedPoints.cpp
+++ b/Cassiopee/Connector/Connector/getInterpolatedPoints.cpp
@@ -1162,7 +1162,7 @@ PyObject* K_CONNECTOR::getOversetHolesInterpNodes(PyObject* self, PyObject* args
       else if (cellNp[ind] == 0.) { blankedCells[ind] = -1; cellNatFld[ind] = -1;}
     }
     // WARNING: NGON is array1 type here !!! 
-    if (K_STRING::cmp(eltType, "NGON") == 0) cn->setNGon(1);
+    if (K_STRING::cmp(eltType, "NGON") == 0) cn->setNGonType(1);
  
     searchMaskInterpolatedNodesUnstr(depth, *cn, blankedCells, cellNatFld);
     for (E_Int ind = 0; ind < npts; ind++)

--- a/Cassiopee/Converter/Converter/Adapter/adaptSurfaceNGon.cpp
+++ b/Cassiopee/Converter/Converter/Adapter/adaptSurfaceNGon.cpp
@@ -113,7 +113,7 @@ PyObject* K_CONVERTER::adaptSurfaceNGon(PyObject* self, PyObject* args)
                                "NGON", sizeNGonA, sizeNFaceA, isNGon, false, 3);
     K_FLD::FldArrayF* fo; K_FLD::FldArrayI* co;
     K_ARRAY::getFromArray3(tpl, fo, co);
-    // co->setNGon(isNGon); // force NGonType
+    // co->setNGonType(isNGon); // force NGonType
 
     E_Int* ngonA = co->getNGon();
     E_Int* nfaceA = co->getNFace();
@@ -213,7 +213,7 @@ PyObject* K_CONVERTER::adaptSurfaceNGon(PyObject* self, PyObject* args)
                                "NGON", sizeNGonB, sizeNFaceB, isNGon, false, 3);
     K_FLD::FldArrayF* fo; K_FLD::FldArrayI* co;
     K_ARRAY::getFromArray3(tpl, fo, co);
-    // co->setNGon(isNGon); // force NGonType
+    // co->setNGonType(isNGon); // force NGonType
 
     E_Int* ngonB = co->getNGon();
     E_Int* indPGB = co->getIndPG(); 

--- a/Cassiopee/Converter/Converter/IO/GenIO_bintp.cpp
+++ b/Cassiopee/Converter/Converter/IO/GenIO_bintp.cpp
@@ -384,7 +384,7 @@ E_Int K_IO::GenIO::tecread(
         if (nfldCenters > 0) fc = new FldArrayF(nelts, nfldCenters);
         else fc = NULL;
         c = new FldArrayI(1); // ne peut pas etre dimensionne
-        c->setNGon(1);
+        c->setNGonType(1);
         unstructField.push_back(f);
         centerUnstructField.push_back(fc);
         connectivity.push_back(c);

--- a/Cassiopee/Converter/Converter/IO/GenIO_fmtcedre.cpp
+++ b/Cassiopee/Converter/Converter/IO/GenIO_fmtcedre.cpp
@@ -238,7 +238,7 @@ E_Int K_IO::GenIO::cedreread(
       cp[pt+2+i] = connect3[i];
     }
     connect3.malloc(0); connect1.malloc(0);
-    cn->setNGon(1);
+    cn->setNGonType(1);
 
     // Lit les frontieres
     //printf("Lecture frontieres " SF_D_ "\n", nboundaryfaces);

--- a/Cassiopee/Converter/Converter/IO/GenIO_fmttp.cpp
+++ b/Cassiopee/Converter/Converter/IO/GenIO_fmttp.cpp
@@ -1120,13 +1120,11 @@ E_Int K_IO::GenIO::tpread(
       FldArrayI cEF;
       K_CONNECT::connectFE2EF(cFE, ne, cEF);
       // Fusionne les connectivites
-      E_Int shift = 1; if (api == 3) shift = 0;
-      E_Int ngonType = 1; // CGNSv3 compact array1
-      if (api == 2) ngonType = 2; // CGNSv3, array2
-      else if (api == 3) ngonType = 3; // force CGNSv4, array3 
+      E_Int ngonType = api; // TODO
+      E_Int shift = 1; if (ngonType == 3) shift = 0;
       E_Int sizeFN = faces.getSize(); // size in api 1
       E_Int sizeEF = cEF.getSize(); // size in api 1
-      if (api == 3) { sizeFN -= nfaces; sizeEF -= ne; }
+      if (ngonType == 3) { sizeFN -= nfaces; sizeEF -= ne; }
       PyObject* tpl = K_ARRAY::buildArray3(3, varString, np, ne, nfaces, 
                                            "NGON", sizeFN, sizeEF, ngonType,
                                            false, api);
@@ -1135,7 +1133,7 @@ E_Int K_IO::GenIO::tpread(
       E_Int* ngon2 = cn2->getNGon();
       E_Int* nface2 = cn2->getNFace();
       E_Int *indPG2 = NULL, *indPH2 = NULL; 
-      if (api == 2 || api == 3) // array2 ou array3
+      if (ngonType == 2 || ngonType == 3) // set offsets
       {
         indPG2 = cn2->getIndPG(); indPH2 = cn2->getIndPH();
         indPG2[0] = 0; indPH2[0] = 0;
@@ -1146,8 +1144,8 @@ E_Int K_IO::GenIO::tpread(
       for (E_Int i = 0; i < nfaces; i++)
       {
         nv = faces[c2]; ngon2[c1] = nv;
-        if (api == 3) indPG2[i+1] = indPG2[i] + nv;
-        if ((api == 2) and (i+1 < nfaces)) indPG2[i+1] = indPG2[i] + nv;
+        if (ngonType == 3) indPG2[i+1] = indPG2[i] + nv;
+        if ((ngonType == 2) and (i+1 < nfaces)) indPG2[i+1] = indPG2[i] + nv;
         for (E_Int j = 0; j < nv; j++)
         {
           ind1 = c1+j+shift; ind2 = c2+j+1;
@@ -1160,8 +1158,8 @@ E_Int K_IO::GenIO::tpread(
       for (E_Int i = 0; i < ne; i++)
       {
         nf = cEF[c2]; nface2[c1] = nf;
-        if (api == 3) indPH2[i+1] = indPH2[i] + nf;
-        if ((api == 2) and (i+1 < ne)) indPH2[i+1] = indPH2[i] + nf;
+        if (ngonType == 3) indPH2[i+1] = indPH2[i] + nf;
+        if ((ngonType == 2) and (i+1 < ne)) indPH2[i+1] = indPH2[i] + nf;
         for (E_Int j = 0; j < nf; j++)
         {
           ind1 = c1+j+shift; ind2 = c2+j+1;

--- a/Cassiopee/Converter/Converter/addGhostCellsNGon.cpp
+++ b/Cassiopee/Converter/Converter/addGhostCellsNGon.cpp
@@ -135,7 +135,7 @@ PyObject* K_CONVERTER::addGhostCellsNGonNodes(PyObject* self, PyObject* args)
   else addGhostCellsNGon3D(depth, *f, *cn, neltsAdd, sizeFN2, sizeEF2, facesExt, fout, cnout);
 
   // Sortie
-  cnout->setNGon(cn->getNGonType());
+  cnout->setNGonType(cn->getNGonType());
   PyObject* tpl = K_ARRAY::buildArray3(*fout, varString, *cnout, eltType, api);
   delete cnout; delete fout;
   RELEASESHAREDU(arrayN, f, cn);

--- a/Cassiopee/Converter/Converter/conformizeNGon1.cpp
+++ b/Cassiopee/Converter/Converter/conformizeNGon1.cpp
@@ -388,11 +388,12 @@ void K_CONVERTER::conformizeNGon(
   E_Int* indPH = cn.getIndPH();
   E_Int sizeFN = cn.getSizeNGon();
   E_Int nelts = cn.getNElts();
+  E_Int ngonType = cn.getNGonType();
 
   E_Int nf; 
   E_Int* addr;
   E_Int api = f.getApi();
-  E_Int shift = 1; if (api == 3) shift = 0;
+  E_Int shift = 1; if (ngonType == 3) shift = 0;
   E_Int sizeEF = 0;
   if (api == 1 || api == 2) sizeEF = nelts;
 
@@ -411,7 +412,6 @@ void K_CONVERTER::conformizeNGon(
   // Create new NGON connectivity
   E_Int npts = f.getSize();
   E_Int nfld = f.getNfld();
-  E_Int ngonType = cn.getNGonType();
   E_Bool center = false;
   PyObject* tpl = K_ARRAY::buildArray3(nfld, "x,y,z", npts, nelts, nfaces, "NGON",
                                        sizeFN, sizeEF, ngonType, center, api);
@@ -422,20 +422,20 @@ void K_CONVERTER::conformizeNGon(
   E_Int* ngon2 = cno->getNGon();
   E_Int* nface2 = cno->getNFace();
   E_Int *indPG2 = NULL, *indPH2 = NULL;
-  if (api == 2 || api == 3) // array2 ou array3
+  if (ngonType == 2 || ngonType == 3) // set offsets
   {
     indPG2 = cno->getIndPG(); indPH2 = cno->getIndPH();
   }
 
   // Recopie la connectivite faces/noeuds
-#pragma omp parallel
+  #pragma omp parallel
   {
-#pragma omp for
+    #pragma omp for nowait
     for (E_Int i = 0; i < sizeFN; i++) ngon2[i] = ngon[i];
 
     if (api == 2 || api == 3)
     {
-#pragma omp for
+      #pragma omp for
       for (E_Int i = 0; i < nfaces; i++) indPG2[i] = indPG[i];
     }
   }
@@ -467,15 +467,5 @@ void K_CONVERTER::conformizeNGon(
     if (indir[i] != NULL) delete [] indir[i];
   }
   delete [] indir;
-
   RELEASESHAREDS(tpl, f2); // cno is returned
-
-  // DEBUG
-  /*
-  FldArrayI cFE;
-  K_CONNECT::connectNG2FE(*cno, cFE);
-  printf("final %d %d\n", cFE(16649,1), cFE(16649,2));
-  printf("final2 %d %d\n", cFE(13971,1), cFE(13971,2));
-  printf("final3 %d %d\n", cFE(13969,1), cFE(13969,2));
-  */
 }

--- a/Cassiopee/Converter/Converter/conformizeNGon1.cpp
+++ b/Cassiopee/Converter/Converter/conformizeNGon1.cpp
@@ -433,7 +433,7 @@ void K_CONVERTER::conformizeNGon(
     #pragma omp for nowait
     for (E_Int i = 0; i < sizeFN; i++) ngon2[i] = ngon[i];
 
-    if (api == 2 || api == 3)
+    if (ngonType == 2 || ngonType == 3)
     {
       #pragma omp for
       for (E_Int i = 0; i < nfaces; i++) indPG2[i] = indPG[i];
@@ -444,7 +444,7 @@ void K_CONVERTER::conformizeNGon(
   E_Int nf2 = 0, c = 0;
   for (E_Int i = 0; i < nelts; i++)
   {
-    if (api == 2 || api == 3) indPH2[i] = nf2;
+    if (ngonType == 2 || ngonType == 3) indPH2[i] = nf2;
     nf2 = 0;
     E_Int* elem = cn.getElt(i, nf, nface, indPH);
     for (E_Int j = 0; j < nf; j++)
@@ -457,7 +457,7 @@ void K_CONVERTER::conformizeNGon(
         { nface2[c+shift+nf2] = addr[k+1]+1; nf2++; }
       }
     }
-    if (api == 1 || api == 2) nface2[c] = nf2;
+    if (ngonType != 3) nface2[c] = nf2;
     c += nf2+shift;
   }
   

--- a/Cassiopee/Converter/Converter/convertStruct2NGon.cpp
+++ b/Cassiopee/Converter/Converter/convertStruct2NGon.cpp
@@ -30,8 +30,8 @@ using namespace K_FLD;
 PyObject* K_CONVERTER::convertStruct2NGon(PyObject* self, PyObject* args)
 {
   PyObject* array;
-  E_Int api = 1;
-  if (!PYPARSETUPLE_(args, O_ I_, &array, &api)) return NULL;
+  E_Int ngonType = 1;
+  if (!PYPARSETUPLE_(args, O_ I_, &array, &ngonType)) return NULL;
 
   // Check array
   E_Int ni, nj, nk, res;
@@ -39,7 +39,7 @@ PyObject* K_CONVERTER::convertStruct2NGon(PyObject* self, PyObject* args)
   char* varString; char* dummy;
   res = K_ARRAY::getFromArray3(array, varString, 
                                f, ni, nj, nk, cnl, dummy);
-  E_Int shift = 1; if (api == 3) shift = 0;
+  E_Int shift = 1; if (ngonType == 3) shift = 0;
 
   if (res == 2)
   {
@@ -102,9 +102,7 @@ PyObject* K_CONVERTER::convertStruct2NGon(PyObject* self, PyObject* args)
   }
 
   // Build an empty NGON array
-  E_Int ngonType = 1; // CGNSv3 compact array1
-  if (api == 2) ngonType = 2; // CGNSv3, array2
-  else if (api == 3) ngonType = 3; // force CGNSv4, array3 
+  E_Int api = 3; if (ngonType == 1) api = 1;
   E_Bool center = false;
   PyObject* tpl = K_ARRAY::buildArray3(nfld, varString, npts, ncells, nfaces, 
                                        "NGON", sizeFN, sizeEF, ngonType,
@@ -116,7 +114,7 @@ PyObject* K_CONVERTER::convertStruct2NGon(PyObject* self, PyObject* args)
   E_Int* ngon2 = cn2->getNGon();
   E_Int* nface2 = cn2->getNFace();
   E_Int *indPG2 = NULL, *indPH2 = NULL; 
-  if (api == 2 || api == 3) // array2 ou array3
+  if (ngonType == 2 || ngonType == 3) // set offsets
   {
     indPG2 = cn2->getIndPG(); indPH2 = cn2->getIndPH();
   }
@@ -361,7 +359,7 @@ PyObject* K_CONVERTER::convertStruct2NGon(PyObject* self, PyObject* args)
     }
 
     // Start offset indices
-    if (api == 2 || api == 3) // array2 ou array3
+    if (ngonType == 2 || ngonType == 3) // set offsets
     {
 #pragma omp for nowait
       for (E_Int i = 0; i < nfaces; i++) indPG2[i] = (pow(2,dim0-1)+shift)*i;

--- a/Cassiopee/Converter/Converter/convertUnstruct2NGon.cpp
+++ b/Cassiopee/Converter/Converter/convertUnstruct2NGon.cpp
@@ -30,8 +30,8 @@ using namespace K_FLD;
 PyObject* K_CONVERTER::convertUnstruct2NGon(PyObject* self, PyObject* args)
 {
   PyObject* array;
-  E_Int api = 1;
-  if (!PYPARSETUPLE_(args, O_ I_, &array, &api)) return NULL;
+  E_Int ngonType = 1;
+  if (!PYPARSETUPLE_(args, O_ I_, &array, &ngonType)) return NULL;
 
   // Check array
   E_Int ni, nj, nk, res;
@@ -65,8 +65,7 @@ PyObject* K_CONVERTER::convertUnstruct2NGon(PyObject* self, PyObject* args)
   // Total number of elements and faces for all connectivities
   E_Int ntotelts = 0, ntotfaces = 0;
   E_Int sizeFN = 0, sizeEF = 0;
-
-  E_Int shift = 1; if (api == 3) shift = 0;
+  E_Int shift = 1; if (ngonType == 3) shift = 0;
 
   // Boucle sur toutes les connectivites une premiere fois pour savoir si elles
   // sont valides et calcule les quantites totales (elements, faces, etc)
@@ -146,10 +145,7 @@ PyObject* K_CONVERTER::convertUnstruct2NGon(PyObject* self, PyObject* args)
 
   // Build an empty NGON connectivity
   E_Int npts = f->getSize(); E_Int nfld = f->getNfld();
-  E_Int ngonType = 1;
-  if (api == 1) ngonType = 1; // CGNSv3 compact array1
-  else if (api == 3) ngonType = 3; // force CGNSv4, array3
-  else if (api == 2) ngonType = 2; // CGNSv3, array2
+  E_Int api = 3; if (ngonType == 1) api = 1;
   E_Bool center = false;
 
   PyObject* tpl = K_ARRAY::buildArray3(nfld, varString, npts, ntotelts,
@@ -162,7 +158,7 @@ PyObject* K_CONVERTER::convertUnstruct2NGon(PyObject* self, PyObject* args)
   E_Int* ngon2 = cn2->getNGon();
   E_Int* nface2 = cn2->getNFace();
   E_Int *indPG2 = NULL, *indPH2 = NULL; 
-  if (api == 2 || api == 3) // array2 ou array3
+  if (ngonType == 2 || ngonType == 3) // set offsets
   {
     indPG2 = cn2->getIndPG(); indPH2 = cn2->getIndPH();
   }
@@ -314,7 +310,7 @@ PyObject* K_CONVERTER::convertUnstruct2NGon(PyObject* self, PyObject* args)
       }
 
       // Start offset indices
-      if (api == 2 || api == 3) // array2 ou array3
+      if (ngonType == 2 || ngonType == 3) // set offsets
       {
         E_Int c = 0, d = 0;
         if (strcmp(eltTypConn, "PENTA") == 0)

--- a/Cassiopee/Generator/Generator/cartNGon.cpp
+++ b/Cassiopee/Generator/Generator/cartNGon.cpp
@@ -36,9 +36,9 @@ PyObject* K_GENERATOR::cartNGon(PyObject* self, PyObject* args)
   E_Int ni, nj, nk;
   E_Float xo, yo, zo;
   E_Float hi, hj, hk;
-  E_Int api = 1;
+  E_Int ngonType = 1;
   if (!PYPARSETUPLE_(args, TRRR_ TRRR_ TIII_ I_,
-                    &xo, &yo, &zo, &hi, &hj, &hk, &ni, &nj, &nk, &api))
+                    &xo, &yo, &zo, &hi, &hj, &hk, &ni, &nj, &nk, &ngonType))
     {
     return NULL;
   }
@@ -76,7 +76,7 @@ PyObject* K_GENERATOR::cartNGon(PyObject* self, PyObject* args)
   E_Int nk1 = E_max(1, E_Int(nk)-1);  
   E_Int ncells = ni1*nj1*nk1; // nb de cellules structurees
   E_Int shift = 1;
-  if (api == 3) shift = 0;
+  if (ngonType == 3) shift = 0;
 
   E_Int nfaces = 0; E_Int sizeFN = 0; E_Int sizeEF = 0;
   if (dim0 == 1)
@@ -94,10 +94,7 @@ PyObject* K_GENERATOR::cartNGon(PyObject* self, PyObject* args)
     sizeFN = (4+shift)*nfaces; sizeEF = (6+shift)*ncells;
   }
 
-  E_Int ngonType = 1;
-  if (api == 1) ngonType = 1; // CGNSv3 compact array1
-  else if (api == 3) ngonType = 3; // force CGNSv4, array3
-  else if (api == 2) ngonType = 2; // CGNSv3, array2
+  E_Int api = 3; if (ngonType == 1) api = 1;
   PyObject* tpl = K_ARRAY::buildArray3(3, "x,y,z", npts, ncells, nfaces, "NGON", 
                                        sizeFN, sizeEF, ngonType, false, api);
 
@@ -107,7 +104,7 @@ PyObject* K_GENERATOR::cartNGon(PyObject* self, PyObject* args)
   E_Int* cFN = cn->getNGon();
   E_Int* cEF = cn->getNFace();
   E_Int *indPG = NULL, *indPH = NULL; 
-  if (api == 2 || api == 3) // array2 ou array3
+  if (ngonType == 2 || ngonType == 3) // set offsets
   {
     indPG = cn->getIndPG(); indPH = cn->getIndPH();
   }
@@ -369,7 +366,7 @@ PyObject* K_GENERATOR::cartNGon(PyObject* self, PyObject* args)
     }
 
     // Start offset indices
-    if (api == 2 || api == 3) // array2 ou array3
+    if (ngonType == 2 || ngonType == 3) // set offsets
     {
 #pragma omp for nowait
       for (E_Int i = 0; i < nfaces; i++) indPG[i] = (pow(2,dim0-1)+shift)*i;

--- a/Cassiopee/Generator/Generator/cartNGon.cpp
+++ b/Cassiopee/Generator/Generator/cartNGon.cpp
@@ -75,8 +75,7 @@ PyObject* K_GENERATOR::cartNGon(PyObject* self, PyObject* args)
   E_Int nj1 = E_max(1, E_Int(nj)-1);
   E_Int nk1 = E_max(1, E_Int(nk)-1);  
   E_Int ncells = ni1*nj1*nk1; // nb de cellules structurees
-  E_Int shift = 1;
-  if (ngonType == 3) shift = 0;
+  E_Int shift = 1; if (ngonType == 3) shift = 0;
 
   E_Int nfaces = 0; E_Int sizeFN = 0; E_Int sizeEF = 0;
   if (dim0 == 1)

--- a/Cassiopee/KCore/KCore/Array/getFromArray.cpp
+++ b/Cassiopee/KCore/KCore/Array/getFromArray.cpp
@@ -227,7 +227,7 @@ E_Int K_ARRAY::getFromArray(PyObject* o,
       return -7;
     }
 
-    // if (K_STRING::cmp(eltType, "NGON") == 0 || K_STRING::cmp(eltType, "NGON*") == 0) c->setNGon(1);
+    // if (K_STRING::cmp(eltType, "NGON") == 0 || K_STRING::cmp(eltType, "NGON*") == 0) c->setNGonType(1);
     Py_DECREF(a); Py_DECREF(ac);
     return 2;
   }

--- a/Cassiopee/KCore/KCore/Array/getFromArray2.cpp
+++ b/Cassiopee/KCore/KCore/Array/getFromArray2.cpp
@@ -186,7 +186,7 @@ E_Int K_ARRAY::getFromArray2(PyObject* o,
       { s = PyArray_DIMS(ac)[1]; nfld = PyArray_DIMS(ac)[0]; }
       else { s = PyArray_DIMS(ac)[0]; nfld = 1; }
       c = new FldArrayI(s, nfld, (E_Int*)PyArray_DATA(ac), true);
-      // c->setNGon(1);
+      // c->setNGonType(1);
     }
     else if (PyList_Check(tpl) == true) // -- Array2 --
     {
@@ -206,7 +206,7 @@ E_Int K_ARRAY::getFromArray2(PyObject* o,
         { s = PyArray_DIMS(ac)[0]; nfld = PyArray_DIMS(ac)[1]; }
         else { s = PyArray_DIMS(ac)[0]; nfld = 1; }
         c = new FldArrayI(s, nfld, (E_Int*)PyArray_DATA(ac), true, false);
-        // c->setNGon(2);
+        // c->setNGonType(2);
       }
       else // suppose NGON
       {

--- a/Cassiopee/KCore/KCore/Array/getFromArray3.cpp
+++ b/Cassiopee/KCore/KCore/Array/getFromArray3.cpp
@@ -210,7 +210,7 @@ E_Int K_ARRAY::getFromArray3(PyObject* o,
       { s = PyArray_DIMS(ac)[1]; nfld = PyArray_DIMS(ac)[0]; }
       else { s = PyArray_DIMS(ac)[0]; nfld = 1; }
       c = new FldArrayI(s, nfld, (E_Int*)PyArray_DATA(ac), true);
-      if (K_STRING::cmp(eltType, 4, "NGON") == 0) c->setNGon(1);
+      if (K_STRING::cmp(eltType, 4, "NGON") == 0) c->setNGonType(1);
     }
     else if (PyList_Check(tpl) == true) // -- Array2 or Array3 --
     {
@@ -239,7 +239,7 @@ E_Int K_ARRAY::getFromArray3(PyObject* o,
           if (nfaces > 0 && pt[nfaces-1] == sizeNGon) { nfaces -= 1; nelts -= 1; ngon = 3; }
           c = new FldArrayI(nfaces, nelts, (E_Int*)PyArray_DATA(ac1), (E_Int*)PyArray_DATA(ac2),
                             (E_Int*)PyArray_DATA(ac3), (E_Int*)PyArray_DATA(ac4), sizeNGon, sizeNFace);
-          c->setNGon(ngon);
+          c->setNGonType(ngon);
         }
         else if (nc == 3) // NGON/SO/PE Array3
         {
@@ -258,7 +258,7 @@ E_Int K_ARRAY::getFromArray3(PyObject* o,
           c = new FldArrayI(nfaces, nelts, (E_Int*)PyArray_DATA(ac1), NULL,
                             (E_Int*)PyArray_DATA(ac2), NULL, 
                             sizeNGon, sizeNFace, (E_Int*)PyArray_DATA(ac3));
-          c->setNGon(3);
+          c->setNGonType(3);
         }
         else if (nc == 5) // NGON/NFACE/SONGON/SONFACE/PE Array2 ou 3
         {
@@ -277,7 +277,7 @@ E_Int K_ARRAY::getFromArray3(PyObject* o,
           c = new FldArrayI(nfaces, nelts, (E_Int*)PyArray_DATA(ac1), (E_Int*)PyArray_DATA(ac2),
                             (E_Int*)PyArray_DATA(ac3), (E_Int*)PyArray_DATA(ac4), 
                             sizeNGon, sizeNFace, (E_Int*)PyArray_DATA(ac5));
-          c->setNGon(ngon);
+          c->setNGonType(ngon);
         }
       }
       else // suppose BE => compact + stride (Array2 ou Array3)

--- a/Cassiopee/KCore/KCore/Connect/v_cleanConnectivity.cpp
+++ b/Cassiopee/KCore/KCore/Connect/v_cleanConnectivity.cpp
@@ -93,9 +93,10 @@ PyObject* K_CONNECT::V_cleanConnectivityNGon(
   E_Int sizeFN = cn.getSizeNGon(), sizeEF = cn.getSizeNFace();
   E_Int nfaces = cn.getNFaces(), nelts = cn.getNElts();
   E_Int nfld = f.getNfld(), npts = f.getSize(), api = f.getApi();
-  E_Bool array23 = false;
-  if (api == 2 || api == 3) array23 = true;
-  E_Int shift = 1; if (api == 3) shift = 0;
+  E_Int ngonType = cn.getNGonType();
+  E_Bool hasCnOffsets = false;
+  if (ngonType == 2 || ngonType == 3) hasCnOffsets = true;
+  E_Int shift = 1; if (ngonType == 3) shift = 0;
 
   // Get dimensionality
   E_Int dim = 3;
@@ -253,7 +254,7 @@ PyObject* K_CONNECT::V_cleanConnectivityNGon(
         }
         if (shift == 1) ngon[k] = nvins;
       }
-      if (array23) // array2 or array3
+      if (hasCnOffsets) // array2 or array3
       {
         indPG[j] = k; j += 1;
       }
@@ -308,7 +309,7 @@ PyObject* K_CONNECT::V_cleanConnectivityNGon(
         if (shift == 1) nface[k] = nfins;
       }
       
-      if (rmDirtyElts && array23) // array2 or array3
+      if (rmDirtyElts && hasCnOffsets) // array2 or array3
       {
         indPH[j] = k; j += 1;
       }
@@ -325,9 +326,6 @@ PyObject* K_CONNECT::V_cleanConnectivityNGon(
   // --- 5. Create resized connectivity ---
   if (rmOverlappingPts || rmDuplicatedFaces || rmDuplicatedElts)
   {  
-    E_Int ngonType = 1; // CGNSv3 compact array1
-    if (api == 2) ngonType = 2; // CGNSv3, array2
-    else if (api == 3) ngonType = 3; // force CGNSv4, array3
     E_Bool center = false;
     tpl = K_ARRAY::buildArray3(nfld, varString, nuniquePts, nuniqueElts,
                                nuniqueFaces, "NGON", sizeFN2, sizeEF2,
@@ -336,7 +334,7 @@ PyObject* K_CONNECT::V_cleanConnectivityNGon(
     K_ARRAY::getFromArray3(tpl, f2, cn2);
     E_Int *ngon2 = cn2->getNGon(), *nface2 = cn2->getNFace();
     E_Int *indPG2 = NULL, *indPH2 = NULL;
-    if (array23)
+    if (hasCnOffsets)
     {
       indPG2 = cn2->getIndPG(); indPH2 = cn2->getIndPH();
     }
@@ -358,7 +356,7 @@ PyObject* K_CONNECT::V_cleanConnectivityNGon(
       #pragma omp for nowait
       for (E_Int i = 0; i < sizeEF2; i++) nface2[i] = nface[i];
 
-      if (array23) // array2 or array3
+      if (hasCnOffsets) // array2 or array3
       {
         #pragma omp for nowait
         for (E_Int i = 0; i < nuniqueFaces; i++) indPG2[i] = indPG[i];

--- a/Cassiopee/KCore/KCore/Fld/FldArray.h
+++ b/Cassiopee/KCore/KCore/Fld/FldArray.h
@@ -173,7 +173,7 @@ class FldArray
     inline E_Int getNGonType() const { return _ngon; }
     inline E_Bool isNGon() const { return _ngon > 0; }
     // 1: compact array1 NGONv3, 2: rake NGONv3, 3: rake NGONv4
-    void setNGon(E_Int ngon) { _ngon = ngon; };
+    void setNGonType(E_Int ngon) { _ngon = ngon; };
     /** Only if NGon */
     inline E_Int getNFaces();
     inline E_Int* getNGon();

--- a/Cassiopee/Post/Post/selectCellCenters.cpp
+++ b/Cassiopee/Post/Post/selectCellCenters.cpp
@@ -489,7 +489,7 @@ PyObject* K_POST::selectCellCenters(PyObject* self, PyObject* args)
     if (cleanConnectivity == 1 && posx > 0 && posy > 0 && posz > 0)
       K_CONNECT::cleanConnectivityNGon(posx, posy, posz, 1.e-10, *fout, *cout);
 
-    cout->setNGon(cnp->getNGonType());
+    cout->setNGonType(cnp->getNGonType());
     tpl = K_ARRAY::buildArray3(*fout, varString, *cout, "NGON", api);
     delete cout; delete fout;     
   }
@@ -1037,7 +1037,7 @@ PyObject* K_POST::selectCellCentersBoth(PyObject* self, PyObject* args)
       
     }
 
-    cout->setNGon(1);
+    cout->setNGonType(1);
     tpl  = K_ARRAY::buildArray3(*fout,  varString, *cout, eltType, api);
     tplc = K_ARRAY::buildArray3(*foutC, varStringC, *cout, eltType, api);
     delete cout; delete fout; delete foutC; 

--- a/Cassiopee/Post/Post/selectCells.cpp
+++ b/Cassiopee/Post/Post/selectCells.cpp
@@ -793,7 +793,7 @@ PyObject* K_POST::selectCellsBoth(PyObject* self, PyObject* args)
     if (cleanConnectivity == 1 && posx > 0 && posy > 0 && posz > 0)
       K_CONNECT::cleanConnectivityNGon(posx, posy, posz, 1.e-10, *fout, *cout);
     
-    cout->setNGon(1);
+    cout->setNGonType(1);
     tpl = K_ARRAY::buildArray3(*fout, varString, *cout, eltType, api);
     tplc = K_ARRAY::buildArray3(*foutC, varStringC, *cout, eltType, api);
     
@@ -1602,7 +1602,7 @@ PyObject* K_POST::selectCells(PyObject* self, PyObject* args)
     // close
     if (cleanConnectivity == 1 && posx > 0 && posy > 0 && posz > 0)
       K_CONNECT::cleanConnectivityNGon(posx, posy, posz, 1.e-10, *fout, *cout);
-    cout->setNGon(1);
+    cout->setNGonType(1);
     tpl = K_ARRAY::buildArray3(*fout, varString, *cout, eltType, api);
     delete fout; delete cout;
   }

--- a/Cassiopee/Post/Post/selectExteriorElts.cpp
+++ b/Cassiopee/Post/Post/selectExteriorElts.cpp
@@ -370,14 +370,14 @@ PyObject* K_POST::selectExteriorEltsNGon(FldArrayF& f, FldArrayI& cn,
   E_Int sizeFN = cn.getSizeNGon(); E_Int sizeEF = cn.getSizeNFace();
   E_Int ngonType = cn.getNGonType();
   E_Int shift = 1; if (ngonType == 3) shift = 0;
-  E_Bool array23 = (ngonType == 2 || ngonType == 3);
+  E_Bool hasCnOffsets = (ngonType == 2 || ngonType == 3);
   
   E_Int nf, nv, extElt, indface;
   E_Int pos, e1, e2;
 
   FldArrayI indirFaces(nfaces); indirFaces.setAllValuesAt(-1);
   FldArrayI nface2Temp(sizeEF), indPH2Temp(0);
-  if (array23) { indPH2Temp.resize(nelts+1); indPH2Temp[0] = 0; }
+  if (hasCnOffsets) { indPH2Temp.resize(nelts+1); indPH2Temp[0] = 0; }
 
   E_Int indFaceExt;
   std::vector<E_Int> origIndicesOfExtFaces;
@@ -407,7 +407,7 @@ PyObject* K_POST::selectExteriorEltsNGon(FldArrayF& f, FldArrayI& cn,
     {
       // construction de la connectivite Elts/Faces des elts externes
       nface2Temp[sizeEF2] = nf;
-      if (array23) indPH2Temp[nExtElts+1] = indPH2Temp[nExtElts] + nf;
+      if (hasCnOffsets) indPH2Temp[nExtElts+1] = indPH2Temp[nExtElts] + nf;
       for (E_Int f = 0; f < nf; f++)
       {
         indface = elt[f] - 1;
@@ -436,7 +436,7 @@ PyObject* K_POST::selectExteriorEltsNGon(FldArrayF& f, FldArrayI& cn,
   E_Int indnode, indface2;
   FldArrayI indirNodes(npts); indirNodes.setAllValuesAt(-1);
   FldArrayI ngon2Temp(sizeFN), indPG2Temp(0);
-  if (array23) { indPG2Temp.resize(nExtFaces+1); indPG2Temp[0] = 0; }
+  if (hasCnOffsets) { indPG2Temp.resize(nExtFaces+1); indPG2Temp[0] = 0; }
 
   pos = 0;
   for (E_Int f = 0; f < nExtFaces; f++)
@@ -444,7 +444,7 @@ PyObject* K_POST::selectExteriorEltsNGon(FldArrayF& f, FldArrayI& cn,
     indface2 = origIndicesOfExtFaces[f];  // starts at 0
     E_Int* face = cn.getFace(indface2, nv, ngon, indPG);
     ngon2Temp[pos] = nv;
-    if (array23) indPG2Temp[f+1] = indPG2Temp[f] + nv;
+    if (hasCnOffsets) indPG2Temp[f+1] = indPG2Temp[f] + nv;
     for (E_Int p = 0; p < nv; p++)
     {
       indnode = face[p] - 1;
@@ -470,7 +470,7 @@ PyObject* K_POST::selectExteriorEltsNGon(FldArrayF& f, FldArrayI& cn,
 
   E_Int *ngon2 = cn2->getNGon(), *nface2 = cn2->getNFace();
   E_Int *indPG2 = NULL, *indPH2 = NULL;
-  if (array23) { indPG2 = cn2->getIndPG(); indPH2 = cn2->getIndPH(); }
+  if (hasCnOffsets) { indPG2 = cn2->getIndPG(); indPH2 = cn2->getIndPH(); }
 
   #pragma omp parallel
   {
@@ -494,7 +494,7 @@ PyObject* K_POST::selectExteriorEltsNGon(FldArrayF& f, FldArrayI& cn,
     #pragma omp for nowait
     for (E_Int i = 0; i < sizeEF2; i++) nface2[i] = nface2Temp[i];
 
-    if (array23)
+    if (hasCnOffsets)
     {
       #pragma omp for nowait
       for (E_Int i = 0; i < nExtFaces; i++) indPG2[i] = indPG2Temp[i];

--- a/Cassiopee/Post/Post/sharpEdges.cpp
+++ b/Cassiopee/Post/Post/sharpEdges.cpp
@@ -594,7 +594,7 @@ PyObject* K_POST::sharpEdges(PyObject* self, PyObject* args)
       for (E_Int i = 0; i < sizeco2; i++) cnep[i] = newptrEF[i];
       K_CONNECT::cleanConnectivityNGon(posx, posy, posz, 1.e-10,
                                        *f, *cne);
-      cne->setNGon(1);
+      cne->setNGonType(1);
       tpl = K_ARRAY::buildArray3(*f, varString0, *cne, "NGON", api);
       delete fe; delete cne;
       RELEASESHAREDU(array, f, cn);

--- a/Cassiopee/Transform/Transform/breakNGonElements.cpp
+++ b/Cassiopee/Transform/Transform/breakNGonElements.cpp
@@ -105,7 +105,8 @@ void K_TRANSFORM::breakNGonElements(
 {
   E_Int nfld = field.getNfld();
   E_Int api = field.getApi();
-  E_Int shift = 1; if (api == 3) shift = 0;
+  E_Int ngonType = cNG.getNGonType();
+  E_Int shift = 1; if (ngonType == 3) shift = 0;
 
   E_Int* ngon = cNG.getNGon(); E_Int* nface = cNG.getNFace();
   E_Int* indPG = cNG.getIndPG(); E_Int* indPH = cNG.getIndPH();
@@ -389,16 +390,13 @@ void K_TRANSFORM::breakNGonElements(
   E_Int *indPG2 = NULL; E_Int* indPH2 = NULL;
   if (netngon)
   {
-    E_Int ngonType = 1; // CGNSv3 compact array1
-    if (api == 2) ngonType = 2; // CGNSv3, array2
-    else if (api == 3) ngonType = 3; // force CGNSv4, array3
     PyObject* tpl = K_ARRAY::buildArray3(nfld, varString, nptsngon, netngon,
                                          nfacesngon, "NGON", sizeFN2, sizeEF2,
                                          ngonType, false, api);
     K_ARRAY::getFromArray3(tpl, f2, cn2);
     ngon2 = cn2->getNGon();
     nface2 = cn2->getNFace();
-    if (api == 2 || api == 3)
+    if (ngonType == 2 || ngonType == 3)
     {
       indPG2 = cn2->getIndPG(); indPH2 = cn2->getIndPH();
     }

--- a/Cassiopee/Transform/Transform/dual.cpp
+++ b/Cassiopee/Transform/Transform/dual.cpp
@@ -73,7 +73,7 @@ PyObject* K_TRANSFORM::dualNGon(PyObject* self, PyObject* args)
   E_Int* ngon = cn->getNGon();
   E_Int* indPG = cn->getIndPG();
   cn->getFace(0, nvpf0, ngon, indPG);
-  cNGD.setNGon(1);
+  cNGD.setNGonType(1);
   if (nvpf0 == 1) dualNGON1D(*f, *cn, extraPoints, fd, cNGD);
   else if (nvpf0 == 2) dualNGON2D(*f, *cn, extraPoints, fd, cNGD);
   else if (nvpf0 > 2)
@@ -504,7 +504,7 @@ void K_TRANSFORM::dualNGON2D(FldArrayF& f, FldArrayI& cn, E_Int extraPoints,
   E_Int sizeFN0 = sizeFNp; E_Int sizeEF0 = sizeEFp;
   sizeFNp += cFNp2.getSize(); sizeEFp += cEFp2.getSize();
   FldArrayI cNGon(4+sizeFNp+sizeEFp);
-  cNGon.setNGon(1);
+  cNGon.setNGonType(1);
   cNGon[0] = nfacesp; cNGon[1] = sizeFNp;
   cNGon[2+sizeFNp] = neltsp; cNGon[3+sizeFNp] = sizeEFp;
   E_Int* ptrFN0 = cNGp+2;
@@ -819,7 +819,7 @@ E_Int K_TRANSFORM::createDegeneratedPrimalMesh3D(
 
   for (E_Int i = 0; i < sizeEF2; i++)
   { ptr1[0] = ptrEF2[i]; ptr1++;}
-  cNGD.setNGon(1);
+  cNGD.setNGonType(1);
 
   return nfacesExt;
 }

--- a/Cassiopee/Transform/Transform/join.cpp
+++ b/Cassiopee/Transform/Transform/join.cpp
@@ -781,7 +781,7 @@ PyObject* K_TRANSFORM::joinUnstructured(FldArrayF& f1, FldArrayI& cn1,
    + cleanConnectivity
    Il faut que les champs soient ranges dans le meme ordre */
 //=============================================================================
-PyObject* K_TRANSFORM::joinNGON(FldArrayF& f1, FldArrayI&  cn1,
+PyObject* K_TRANSFORM::joinNGON(FldArrayF& f1, FldArrayI& cn1,
                                 FldArrayF& f2, FldArrayI& cn2,
                                 E_Int posx, E_Int posy, E_Int posz,
                                 char* varString, E_Float tol)
@@ -803,9 +803,7 @@ PyObject* K_TRANSFORM::joinNGON(FldArrayF& f1, FldArrayI&  cn1,
   E_Int npts = npts1 + npts2;
 
   E_Int api = f1.getApi();
-  E_Int ngonType = 1; // CGNSv3 compact array1
-  if (api == 2) ngonType = 2; // CGNSv3, array2
-  else if (api == 3) ngonType = 3; // force CGNSv4, array3
+  E_Int ngonType = cn1.getNGonType();
   PyObject* tpl = K_ARRAY::buildArray3(nfld, varString, npts, nelts,
                                        nfaces, "NGON", sizeFN, sizeEF,
                                        ngonType, false, api);
@@ -817,7 +815,7 @@ PyObject* K_TRANSFORM::joinNGON(FldArrayF& f1, FldArrayI&  cn1,
   E_Int *nface1 = cn1.getNFace(), *nface2 = cn2.getNFace(), *nface = cn->getNFace();
   E_Int *indPG1 = NULL, *indPG2 = NULL, *indPG = NULL;
   E_Int *indPH1 = NULL, *indPH2 = NULL, *indPH = NULL;
-  if (api == 2 || api == 3)
+  if (ngonType == 2 || ngonType == 3)
   {
     indPG1 = cn1.getIndPG(); indPG2 = cn2.getIndPG(); indPG = cn->getIndPG();
     indPH1 = cn1.getIndPH(); indPH2 = cn2.getIndPH(); indPH = cn->getIndPH();
@@ -849,7 +847,7 @@ PyObject* K_TRANSFORM::joinNGON(FldArrayF& f1, FldArrayI&  cn1,
     #pragma omp for
     for (E_Int i = 0; i < sizeEF2; i++) nface[i+sizeEF1] = nface2[i] + nfaces1;
 
-    if (api == 2 || api == 3)
+    if (ngonType == 2 || ngonType == 3)
     {
         #pragma omp for
         for (E_Int i = 0; i < nfaces1; i++) indPG[i] = indPG1[i];

--- a/Cassiopee/Transform/Transform/joinAll.cpp
+++ b/Cassiopee/Transform/Transform/joinAll.cpp
@@ -133,9 +133,7 @@ PyObject* K_TRANSFORM::joinAll(PyObject* self, PyObject* args)
   if (strcmp(eltRef, "NGON") == 0)
   {
     strcat(newEltType, "NGON");
-    E_Int ngonType = 1; // CGNSv3 compact array1
-    if (api == 2) ngonType = 2; // CGNSv3, array2
-    else if (api == 3) ngonType = 3; // force CGNSv4, array3
+    E_Int ngonType = cn[0]->getNGonType();
     tpl = K_ARRAY::buildArray3(nfld, unstructVarString[0], npts, neltsNGON,
                                nfaces, newEltType, sizeFN, sizeEF,
                                ngonType, false, api);
@@ -197,10 +195,11 @@ PyObject* K_TRANSFORM::joinAll(PyObject* self, PyObject* args)
 
   // Acces non universel sur les ptrs NGON
   E_Int *ngon = NULL, *nface = NULL, *indPG = NULL, *indPH = NULL;
+  E_Int ngonType = cno->getNGonType();
   if (strcmp(eltRef, "NGON") == 0)
   {
     ngon = cno->getNGon(); nface = cno->getNFace();
-    if (api == 2 || api == 3)
+    if (ngonType == 2 || ngonType == 3)
     {
       indPG = cno->getIndPG(); indPH = cno->getIndPH();
     }
@@ -245,7 +244,7 @@ PyObject* K_TRANSFORM::joinAll(PyObject* self, PyObject* args)
         for (E_Int i = 0; i < sizeEFk; i++)
           nface[i+offsetSizeEF] = nfacek[i] + offsetFaces;
 
-        if (api == 2 || api == 3)
+        if (ngonType == 2 || ngonType == 3)
         {
           indPGk = cn[k]->getIndPG(); indPHk = cn[k]->getIndPH();
           #pragma omp for
@@ -472,9 +471,7 @@ PyObject* K_TRANSFORM::joinAllBoth(PyObject* self, PyObject* args)
   {
     strcpy(newEltType, "NGON");
     neltstot = neltsNGON;
-    E_Int ngonType = 1; // CGNSv3 compact array1
-    if (api == 2) ngonType = 2; // CGNSv3, array2
-    else if (api == 3) ngonType = 3; // force CGNSv4, array3
+    E_Int ngonType = cn[0]->getNGonType();
     tpln = K_ARRAY::buildArray3(nfld, unstructVarString[0], npts, neltsNGON,
                                 nfaces, newEltType, sizeFN, sizeEF,
                                 ngonType, false, api);
@@ -528,10 +525,11 @@ PyObject* K_TRANSFORM::joinAllBoth(PyObject* self, PyObject* args)
 
   // Acces non universel sur les ptrs NGON
   E_Int *ngon = NULL, *nface = NULL, *indPG = NULL, *indPH = NULL;
+  E_Int ngonType = cno->getNGonType();
   if (strcmp(eltRef, "NGON") == 0)
   {
     ngon = cno->getNGon(); nface = cno->getNFace();
-    if (api == 2 || api == 3)
+    if (ngonType == 2 || ngonType == 3)
     {
       indPG = cno->getIndPG(); indPH = cno->getIndPH();
     }
@@ -554,7 +552,7 @@ PyObject* K_TRANSFORM::joinAllBoth(PyObject* self, PyObject* args)
       {
         E_Float* fkn = unstructF[k]->begin(n);
         E_Float* fn = f->begin(n);
-        #pragma omp for
+        #pragma omp for nowait
         for (E_Int i = 0; i < nptsk; i++) fn[i+offsetPts] = fkn[i];
       }
 
@@ -563,7 +561,7 @@ PyObject* K_TRANSFORM::joinAllBoth(PyObject* self, PyObject* args)
       {
         E_Float* fckn = unstructFc[k]->begin(n);
         E_Float* fcn = fc->begin(n);
-        #pragma omp for
+        #pragma omp for nowait
         for (E_Int i = 0; i < unstructFc[k]->getSize(); i++)
           fcn[i+offsetElts] = fckn[i];
       }
@@ -579,17 +577,17 @@ PyObject* K_TRANSFORM::joinAllBoth(PyObject* self, PyObject* args)
         E_Int *ngonk = cn[k]->getNGon(), *nfacek = cn[k]->getNFace();
         E_Int *indPGk = NULL, *indPHk = NULL;
 
-        #pragma omp for
+        #pragma omp for nowait
         for (E_Int i = 0; i < sizeFNk; i++)
           ngon[i+offsetSizeFN] = ngonk[i] + offsetPts;
-        #pragma omp for
+        #pragma omp for nowait
         for (E_Int i = 0; i < sizeEFk; i++)
           nface[i+offsetSizeEF] = nfacek[i] + offsetFaces;
 
-        if (api == 2 || api == 3)
+        if (ngonType == 2 || ngonType == 3)
         {
           indPGk = cn[k]->getIndPG(); indPHk = cn[k]->getIndPH();
-          #pragma omp for
+          #pragma omp for nowait
           for (E_Int i = 0; i < nfacesk; i++)
             indPG[i+offsetFaces] = indPGk[i] + offsetFaces;
           #pragma omp for

--- a/Cassiopee/Transform/Transform/joinBoth.cpp
+++ b/Cassiopee/Transform/Transform/joinBoth.cpp
@@ -1005,9 +1005,7 @@ PyObject* K_TRANSFORM::joinBothNGON(FldArrayF& f1, FldArrayF& fc1,
   E_Int npts = npts1 + npts2;
 
   E_Int api = f1.getApi();
-  E_Int ngonType = 1; // CGNSv3 compact array1
-  if (api == 2) ngonType = 2; // CGNSv3, array2
-  else if (api == 3) ngonType = 3; // force CGNSv4, array3
+  E_Int ngonType = cn1.getNGonType();
   PyObject* tpln = K_ARRAY::buildArray3(nfld, varString, npts, nelts,
                                         nfaces, "NGON", sizeFN, sizeEF,
                                         ngonType, false, api);
@@ -1024,7 +1022,7 @@ PyObject* K_TRANSFORM::joinBothNGON(FldArrayF& f1, FldArrayF& fc1,
   E_Int *nface1 = cn1.getNFace(), *nface2 = cn2.getNFace(), *nface = cn->getNFace();
   E_Int *indPG1 = NULL, *indPG2 = NULL, *indPG = NULL;
   E_Int *indPH1 = NULL, *indPH2 = NULL, *indPH = NULL;
-  if (api == 2 || api == 3)
+  if (ngonType == 2 || ngonType == 3)
   {
     indPG1 = cn1.getIndPG(); indPG2 = cn2.getIndPG(); indPG = cn->getIndPG();
     indPH1 = cn1.getIndPH(); indPH2 = cn2.getIndPH(); indPH = cn->getIndPH();
@@ -1038,9 +1036,9 @@ PyObject* K_TRANSFORM::joinBothNGON(FldArrayF& f1, FldArrayF& fc1,
       E_Float* f1n = f1.begin(n);
       E_Float* f2n = f2.begin(n);
       E_Float* fn = f->begin(n);
-      #pragma omp for
+      #pragma omp for nowait
       for (E_Int i = 0; i < npts1; i++) fn[i] = f1n[i];
-      #pragma omp for
+      #pragma omp for nowait
       for (E_Int i = 0; i < npts2; i++) fn[i+npts1] = f2n[i];
     }
 
@@ -1050,32 +1048,32 @@ PyObject* K_TRANSFORM::joinBothNGON(FldArrayF& f1, FldArrayF& fc1,
       E_Float* fc1n = fc1.begin(n);
       E_Float* fc2n = fc2.begin(n);
       E_Float* fcn = fc->begin(n);
-      #pragma omp for
+      #pragma omp for nowait
       for (E_Int i = 0; i < nelts1; i++) fcn[i] = fc1n[i];
-      #pragma omp for
+      #pragma omp for nowait
       for (E_Int i = 0; i < nelts2; i++) fcn[i+nelts1] = fc2n[i];
     }
 
     // Copie des connectivites (add offset to all elements of the second
     // connectivity and correct outside the parallel block)
-    #pragma omp for
+    #pragma omp for nowait
     for (E_Int i = 0; i < sizeFN1; i++) ngon[i] = ngon1[i];
-    #pragma omp for
+    #pragma omp for nowait
     for (E_Int i = 0; i < sizeFN2; i++) ngon[i+sizeFN1] = ngon2[i] + npts1;
 
-    #pragma omp for
+    #pragma omp for nowait
     for (E_Int i = 0; i < sizeEF1; i++) nface[i] = nface1[i];
-    #pragma omp for
+    #pragma omp for nowait
     for (E_Int i = 0; i < sizeEF2; i++) nface[i+sizeEF1] = nface2[i] + nfaces1;
 
-    if (api == 2 || api == 3)
+    if (ngonType == 2 || ngonType == 3)
     {
-      #pragma omp for
+      #pragma omp for nowait
       for (E_Int i = 0; i < nfaces1; i++) indPG[i] = indPG1[i];
-      #pragma omp for
+      #pragma omp for nowait
       for (E_Int i = 0; i < nfaces2; i++) indPG[i+nfaces1] = indPG2[i] + nfaces1;
 
-      #pragma omp for
+      #pragma omp for nowait
       for (E_Int i = 0; i < nelts1; i++) indPH[i] = indPH1[i];
       #pragma omp for
       for (E_Int i = 0; i < nelts2; i++) indPH[i+nelts1] = indPH2[i] + nelts1;

--- a/Cassiopee/Transform/Transform/splitConnexity.cpp
+++ b/Cassiopee/Transform/Transform/splitConnexity.cpp
@@ -285,7 +285,7 @@ PyObject* K_TRANSFORM::splitConnexityNGon(
 
     K_CONNECT::cleanConnectivityNGon(posx, posy, posz, 1.e-10,
                                      fp, cnp);
-    cnp.setNGon(cn->getNGonType());
+    cnp.setNGonType(cn->getNGonType());
     tpl = K_ARRAY::buildArray3(fp, varString, cnp, "NGON", api);
     delete &fp; delete components[i];
     PyList_Append(l, tpl);

--- a/Cassiopee/Transform/Transform/splitSharpEdges.cpp
+++ b/Cassiopee/Transform/Transform/splitSharpEdges.cpp
@@ -449,7 +449,7 @@ PyObject* K_TRANSFORM::splitSharpEdgesNGon(
     if (dim == 1) // il semble que dans ce cas, il faut l'appeler 2 fois
       K_CONNECT::cleanConnectivityNGon(posx, posy, posz, 1.e-10,
                                        fp, cnp);
-    cnp.setNGon(1);
+    cnp.setNGonType(1);
     tpl = K_ARRAY::buildArray3(fp, varString, cnp, "NGON", api);
     delete &fp; delete components[i];
     PyList_Append(l, tpl);

--- a/Cassiopee/Transform/Transform/subzone.cpp
+++ b/Cassiopee/Transform/Transform/subzone.cpp
@@ -669,10 +669,8 @@ PyObject* K_TRANSFORM::subzoneElements(PyObject* self, PyObject* args)
 
   if (K_STRING::cmp(eltType, "NGON") == 0) // NGON
   {
-    E_Int shift = 1; if (api == 3) shift = 0;
-    E_Int ngonType = 1; // CGNSv3 compact array1
-    if (api == 2) ngonType = 2; // CGNSv3, array2
-    else if (api == 3) ngonType = 3; // force CGNSv4, array3
+    E_Int ngonType = cn->getNGonType();
+    E_Int shift = 1; if (ngonType == 3) shift = 0;
 
     E_Int *ngon = cn->getNGon(), *indPG = cn->getIndPG();
     E_Int *nface = cn->getNFace(), *indPH = cn->getIndPH();
@@ -749,7 +747,7 @@ PyObject* K_TRANSFORM::subzoneElements(PyObject* self, PyObject* args)
     K_ARRAY::getFromArray3(tpl, f2, cn2);
     E_Int *ngon2 = cn2->getNGon(), *nface2 = cn2->getNFace();
     E_Int *indPG2 = NULL, *indPH2 = NULL;
-    if (api == 2 || api == 3)
+    if (ngonType == 2 || ngonType == 3)
     {
       indPG2 = cn2->getIndPG(); indPH2 = cn2->getIndPH();
     }
@@ -775,7 +773,7 @@ PyObject* K_TRANSFORM::subzoneElements(PyObject* self, PyObject* args)
       #pragma omp for nowait
       for (E_Int i = 0; i < sizeEF2; i++) nface2[i] = cEFTemp[i];
 
-      if (api == 2 || api == 3) // array2 or array3
+      if (ngonType == 2 || ngonType == 3) // set offsets
       {
         #pragma omp for nowait
         for (E_Int i = 0; i < nbFacesOut; i++) indPG2[i] = cPGTemp[i];
@@ -965,10 +963,8 @@ PyObject* K_TRANSFORM::subzoneElementsBoth(PyObject* self, PyObject* args)
 
   if (K_STRING::cmp(eltType, "NGON") == 0) // NGON
   {
-    E_Int shift = 1; if (api == 3) shift = 0;
-    E_Int ngonType = 1; // CGNSv3 compact array1
-    if (api == 2) ngonType = 2; // CGNSv3, array2
-    else if (api == 3) ngonType = 3; // force CGNSv4, array3
+    E_Int ngonType = cn->getNGonType();
+    E_Int shift = 1; if (ngonType == 3) shift = 0;
 
     E_Int *ngon = cn->getNGon(), *indPG = cn->getIndPG();
     E_Int *nface = cn->getNFace(), *indPH = cn->getIndPH();
@@ -1046,7 +1042,7 @@ PyObject* K_TRANSFORM::subzoneElementsBoth(PyObject* self, PyObject* args)
     K_ARRAY::getFromArray3(tpln, f2, cn2);
     E_Int *ngon2 = cn2->getNGon(), *nface2 = cn2->getNFace();
     E_Int *indPG2 = NULL, *indPH2 = NULL;
-    if (api == 2 || api == 3)
+    if (ngonType == 2 || ngonType == 3)
     {
       indPG2 = cn2->getIndPG(); indPH2 = cn2->getIndPH();
     }
@@ -1059,7 +1055,7 @@ PyObject* K_TRANSFORM::subzoneElementsBoth(PyObject* self, PyObject* args)
       #pragma omp for nowait
       for (E_Int i = 0; i < sizeEF2; i++) nface2[i] = cEFTemp[i];
 
-      if (api == 2 || api == 3) // array2 or array3
+      if (ngonType == 2 || ngonType == 3) // set offsets
       {
         #pragma omp for nowait
         for (E_Int i = 0; i < nbFacesOut; i++) indPG2[i] = cPGTemp[i];
@@ -1285,10 +1281,10 @@ PyObject* K_TRANSFORM::subzoneFaces(PyObject* self, PyObject* args)
     E_Int npts2 = 0; E_Int sizeEF2 = 0;
 
     // Acces non universel sur les ptrs
+    E_Int ngonType = cn->getNGonType();
     E_Int* ngon = cn->getNGon();
     E_Int* indPG = cn->getIndPG();
-    E_Int shift = 1;
-    if (api == 3) shift = 0;
+    E_Int shift = 1; if (ngonType == 3) shift = 0;
 
     // Calcul du nombre de points et aretes uniques dans la nouvelle
     // connectivite
@@ -1334,9 +1330,6 @@ PyObject* K_TRANSFORM::subzoneFaces(PyObject* self, PyObject* args)
     E_Int sizeFN2 = (2+shift)*nfaces2;
     E_Int nelts2 = n;
 
-    E_Int ngonType = 1; // CGNSv3 compact array1
-    if (api == 2) ngonType = 2; // CGNSv3, array2
-    else if (api == 3) ngonType = 3; // force CGNSv4, array3
     E_Bool center = false;
     PyObject* tpl = K_ARRAY::buildArray3(nfld, varString, npts2, nelts2,
                                          nfaces2, "NGON", sizeFN2, sizeEF2,
@@ -1346,7 +1339,7 @@ PyObject* K_TRANSFORM::subzoneFaces(PyObject* self, PyObject* args)
     E_Int* ngon2 = cn2->getNGon();
     E_Int* nface2 = cn2->getNFace();
     E_Int *indPG2 = NULL, *indPH2 = NULL;
-    if (api == 2 || api == 3)
+    if (ngonType == 2 || ngonType == 3)
     {
       indPG2 = cn2->getIndPG(); indPH2 = cn2->getIndPH();
     }
@@ -1357,7 +1350,7 @@ PyObject* K_TRANSFORM::subzoneFaces(PyObject* self, PyObject* args)
       fidx = faceListp[i]-1;
       E_Int* face = cn->getFace(fidx, nbnodes, ngon, indPG);
       nface2[c2] = nbnodes;
-      if (api == 2 || api == 3) indPH2[i] = nbnodes;
+      if (ngonType == 2 || ngonType == 3) indPH2[i] = nbnodes;
 
       for (E_Int p = 0; p < nbnodes; p++)
       {
@@ -1381,7 +1374,7 @@ PyObject* K_TRANSFORM::subzoneFaces(PyObject* self, PyObject* args)
     #pragma omp parallel
     {
       E_Int indv;
-      if (api == 2 || api == 3)
+      if (ngonType == 2 || ngonType == 3)
       {
         #pragma omp for
         for(E_Int i = 0; i < nfaces2; i++) indPG2[i] = 2;
@@ -1631,11 +1624,12 @@ PyObject* K_TRANSFORM::subzoneFacesBoth(PyObject* self, PyObject* args)
     E_Int npts2 = 0; E_Int sizeEF2 = 0;
 
     // Acces non universel sur les ptrs
+    E_Int ngonType = cn->getNGonType();
+    E_Int shift = 1; if (ngonType == 3) shift = 0;
+
     E_Int* ngon = cn->getNGon(); E_Int* nface = cn->getNFace();
     E_Int* indPG = cn->getIndPG(); E_Int* indPH = cn->getIndPH();
-    E_Int shift = 1;
     E_Int nelts = cn->getNElts(); E_Int nfaces = cn->getNFaces();
-    if (api == 3) shift = 0;
 
     // Calcul du nombre de points et aretes uniques dans la nouvelle
     // connectivite
@@ -1681,9 +1675,6 @@ PyObject* K_TRANSFORM::subzoneFacesBoth(PyObject* self, PyObject* args)
     E_Int sizeFN2 = (2+shift)*nfaces2;
     E_Int nelts2 = n;
 
-    E_Int ngonType = 1; // CGNSv3 compact array1
-    if (api == 2) ngonType = 2; // CGNSv3, array2
-    else if (api == 3) ngonType = 3; // force CGNSv4, array3
     E_Bool center = false;
     PyObject* tpl = K_ARRAY::buildArray3(nfld, varString, npts2, nelts2,
                                          nfaces2, "NGON", sizeFN2, sizeEF2,
@@ -1693,7 +1684,7 @@ PyObject* K_TRANSFORM::subzoneFacesBoth(PyObject* self, PyObject* args)
     E_Int* ngon2 = cn2->getNGon();
     E_Int* nface2 = cn2->getNFace();
     E_Int *indPG2 = NULL, *indPH2 = NULL;
-    if (api == 2 || api == 3)
+    if (ngonType == 2 || ngonType == 3)
     {
       indPG2 = cn2->getIndPG(); indPH2 = cn2->getIndPH();
     }
@@ -1704,7 +1695,7 @@ PyObject* K_TRANSFORM::subzoneFacesBoth(PyObject* self, PyObject* args)
       fidx = faceListp[i]-1;
       E_Int* face = cn->getFace(fidx, nbnodes, ngon, indPG);
       nface2[c2] = nbnodes;
-      if (api == 2 || api == 3) indPH2[i] = nbnodes;
+      if (ngonType == 2 || ngonType == 3) indPH2[i] = nbnodes;
 
       for (E_Int p = 0; p < nbnodes; p++)
       {
@@ -1744,7 +1735,7 @@ PyObject* K_TRANSFORM::subzoneFacesBoth(PyObject* self, PyObject* args)
     #pragma omp parallel
     {
       E_Int indv, indf, etg, etd;
-      if (api == 2 || api == 3)
+      if (ngonType == 2 || ngonType == 3)
       {
         #pragma omp for
         for(E_Int i = 0; i < nfaces2; i++) indPG2[i] = 2;


### PR DESCRIPTION
Continuation of #422

Fixes a long-standing issue in G.close / v_cleanConnectivity

`FldArrayI`'s method `setNGon` renamed to `setNGonType`

- No regressions
- Please do stash commits