### PR TITLE
Generator: Expert Expert Mode: clip the upper limit on the number of offset level to the input value. Important for tests & devs [AMRIBM]

### DIFF
--- a/Cassiopee/Generator/Generator/AMR.py
+++ b/Cassiopee/Generator/Generator/AMR.py
@@ -139,7 +139,7 @@ def generateSkeletonMesh__(tb, snears=0.01, dfars=10., dim=3, levelSkel=7, octre
     # This clips the upper limit on the number of offset level to the input value. Important for tests & devs.
     # This is an expert expert parameter & should be used with (a lot of) caution.
     # This is needed to bypass G.adaptOctree that can be very expensive when we need a fine background (outside the offset levels) grid.
-    forceUpperLimitOffset = True
+    forceUpperLimitOffset = False
 
     # list of dfars
     bodies = Internal.getZones(tb)

--- a/Cassiopee/Generator/Generator/AMR.py
+++ b/Cassiopee/Generator/Generator/AMR.py
@@ -23,7 +23,7 @@ __TOL__ = 1e-9
 def generateListOfOffsets__(tb, offsetValues=[], dim=3, opt=False):
     if offsetValues==[]: return []
 
-    if Cmpi.rank==0: print('Generating list of offsets...start',flush=True)
+    if Cmpi.master: print('Generating list of offsets...start',flush=True)
 
     dir_sym = getSymmetryPlaneInfo__(tb,dim=dim)
     baseSYM = Internal.getNodesFromName1(tb,"SYM")
@@ -43,7 +43,7 @@ def generateListOfOffsets__(tb, offsetValues=[], dim=3, opt=False):
                 # hausd is a length and must be adapted to the dimensions of each case
                 hausd = max(bbz[3]-bbz[0], bbz[4]-bbz[1], bbz[5]-bbz[2])/10000.
                 hmax = hausd*1000
-                if Cmpi.rank == 0: print(hausd, hmax, flush=True)
+                if Cmpi.master: print(hausd, hmax, flush=True)
                 # exteriorFaces currently crashes if the surface is closed
                 try:
                     fixedConstraints = P.exteriorFaces(z)
@@ -136,9 +136,10 @@ def generateListOfOffsets__(tb, offsetValues=[], dim=3, opt=False):
 # Generates an isotropic skeleton mesh to be adapted then by AMR
 def generateSkeletonMesh__(tb, snears=0.01, dfars=10., dim=3, levelSkel=7, octreeMode=0):
     surfaces=[]; dfarList=[]; snearsList=[]
-    # this clips the upper limit on the number of offset level to the input value. Important for tests & devs.
-    # This is an expert expert parameter & should be used with caution
-    forceUpperLimitOffset = False
+    # This clips the upper limit on the number of offset level to the input value. Important for tests & devs.
+    # This is an expert expert parameter & should be used with (a lot of) caution.
+    # This is needed to bypass G.adaptOctree that can be very expensive when we need a fine background (outside the offset levels) grid.
+    forceUpperLimitOffset = True
 
     # list of dfars
     bodies = Internal.getZones(tb)
@@ -195,21 +196,16 @@ def generateSkeletonMesh__(tb, snears=0.01, dfars=10., dim=3, levelSkel=7, octre
     if dir_sym > 0: o = P.selectCells(o,'{%s}>%g'%(coordsym,valsym-__TOL__),strict=1)
 
     if forceUpperLimitOffset:
-        if Cmpi.master:
-            box = G.bbox(o)
-            dxdydz_local      = min(snearsList)
-            nCellsCartesian_x = int((box[3]-box[0])/dxdydz_local)
-            nCellsCartesian_y = int((box[4]-box[1])/dxdydz_local)
-            nCellsCartesian_z = 1
-            dz_local          = box[5]-box[2]
-            if dim == 3:
-                nCellsCartesian_z = int((box[5]-box[2])/dxdydz_local)
-                dz_local          = dxdydz_local
-            o = G.cart((box[0],box[1],box[2]), (dxdydz_local, dxdydz_local, dz_local), (nCellsCartesian_x+1, nCellsCartesian_y+1,nCellsCartesian_z+1))
-            C.convertPyTree2File(o, 'octreeTmpToBeDeleted.cgns')
-        Cmpi.barrier()
-        o = C.convertFile2PyTree('octreeTmpToBeDeleted.cgns')
-        Cmpi.barrier()
+        box = G.bbox(o)
+        dxdydz_local      = min(snearsList)
+        nCellsCartesian_x = int((box[3]-box[0])/dxdydz_local)
+        nCellsCartesian_y = int((box[4]-box[1])/dxdydz_local)
+        nCellsCartesian_z = 1
+        dz_local          = box[5]-box[2]
+        if dim == 3:
+            nCellsCartesian_z = int((box[5]-box[2])/dxdydz_local)
+            dz_local          = dxdydz_local
+        o = G.cart((box[0],box[1],box[2]), (dxdydz_local, dxdydz_local, dz_local), (nCellsCartesian_x+1, nCellsCartesian_y+1,nCellsCartesian_z+1))
     else:
         # adapt the mesh to get a single refinement level - uniform grid
         refined=True
@@ -217,10 +213,8 @@ def generateSkeletonMesh__(tb, snears=0.01, dfars=10., dim=3, levelSkel=7, octre
         volminAll = C.getMinValue(o,"centers:vol")
         tol_vol = 1e-2*volminAll
         while refined:
-            Cmpi.barrier()
             C._initVars(o,'{centers:indicator}=({centers:vol}>%g)'%(volminAll+tol_vol))
             if C.getMaxValue(o,"centers:indicator")==1.:
-                Cmpi.barrier()
                 o = G.adaptOctree(o, 'centers:indicator', balancing=1)
                 G._getVolumeMap(o)
             else:

--- a/Cassiopee/Generator/Generator/AMR.py
+++ b/Cassiopee/Generator/Generator/AMR.py
@@ -136,6 +136,9 @@ def generateListOfOffsets__(tb, offsetValues=[], dim=3, opt=False):
 # Generates an isotropic skeleton mesh to be adapted then by AMR
 def generateSkeletonMesh__(tb, snears=0.01, dfars=10., dim=3, levelSkel=7, octreeMode=0):
     surfaces=[]; dfarList=[]; snearsList=[]
+    # this clips the upper limit on the number of offset level to the input value. Important for tests & devs.
+    # This is an expert expert parameter & should be used with caution
+    forceUpperLimitOffset = False
 
     # list of dfars
     bodies = Internal.getZones(tb)
@@ -160,7 +163,8 @@ def generateSkeletonMesh__(tb, snears=0.01, dfars=10., dim=3, levelSkel=7, octre
         if dfars[c] > -1: #body snear is only considered if dfar_loc > -1
             surfaces.append(z)
             levelSkelLoc = int(math.log2(0.2*dfars[c]/snears[c]))
-            levelSkel = max(levelSkel, levelSkelLoc) # security so that levelSkel is not too small
+            if forceUpperLimitOffset: levelSkel = levelSkel
+            else:                     levelSkel = max(levelSkel, levelSkelLoc) # security so that levelSkel is not too small
 
             dfarloc = dfars[c]
             snearloc = 2**levelSkel*snears[c]
@@ -190,20 +194,39 @@ def generateSkeletonMesh__(tb, snears=0.01, dfars=10., dim=3, levelSkel=7, octre
         valsym = 0.5*(zmin+zmax)
     if dir_sym > 0: o = P.selectCells(o,'{%s}>%g'%(coordsym,valsym-__TOL__),strict=1)
 
-    # adapt the mesh to get a single refinement level - uniform grid
-    refined=True
-    G._getVolumeMap(o)
-    volminAll = C.getMinValue(o,"centers:vol")
-    tol_vol = 1e-2*volminAll
-    while refined:
-        C._initVars(o,'{centers:indicator}=({centers:vol}>%g)'%(volminAll+tol_vol))
-        if C.getMaxValue(o,"centers:indicator")==1.:
-            o = G.adaptOctree(o, 'centers:indicator', balancing=1)
-            G._getVolumeMap(o)
-        else:
-            refined=False
-            break
-    C._rmVars(o, ['centers:indicator','centers:vol'])
+    if forceUpperLimitOffset:
+        if Cmpi.master:
+            box = G.bbox(o)
+            dxdydz_local      = min(snearsList)
+            nCellsCartesian_x = int((box[3]-box[0])/dxdydz_local)
+            nCellsCartesian_y = int((box[4]-box[1])/dxdydz_local)
+            nCellsCartesian_z = 1
+            dz_local          = box[5]-box[2]
+            if dim == 3:
+                nCellsCartesian_z = int((box[5]-box[2])/dxdydz_local)
+                dz_local          = dxdydz_local
+            o = G.cart((box[0],box[1],box[2]), (dxdydz_local, dxdydz_local, dz_local), (nCellsCartesian_x+1, nCellsCartesian_y+1,nCellsCartesian_z+1))
+            C.convertPyTree2File(o, 'octreeTmpToBeDeleted.cgns')
+        Cmpi.barrier()
+        o = C.convertFile2PyTree('octreeTmpToBeDeleted.cgns')
+        Cmpi.barrier()
+    else:
+        # adapt the mesh to get a single refinement level - uniform grid
+        refined=True
+        G._getVolumeMap(o)
+        volminAll = C.getMinValue(o,"centers:vol")
+        tol_vol = 1e-2*volminAll
+        while refined:
+            Cmpi.barrier()
+            C._initVars(o,'{centers:indicator}=({centers:vol}>%g)'%(volminAll+tol_vol))
+            if C.getMaxValue(o,"centers:indicator")==1.:
+                Cmpi.barrier()
+                o = G.adaptOctree(o, 'centers:indicator', balancing=1)
+                G._getVolumeMap(o)
+            else:
+                refined=False
+                break
+        C._rmVars(o, ['centers:indicator','centers:vol'])
 
     if dim==2: T._addkplane(o)
     o = C.convertArray2NGon(o)

--- a/Cassiopee/Generator/Generator/AMR.py
+++ b/Cassiopee/Generator/Generator/AMR.py
@@ -164,8 +164,7 @@ def generateSkeletonMesh__(tb, snears=0.01, dfars=10., dim=3, levelSkel=7, octre
         if dfars[c] > -1: #body snear is only considered if dfar_loc > -1
             surfaces.append(z)
             levelSkelLoc = int(math.log2(0.2*dfars[c]/snears[c]))
-            if forceUpperLimitOffset: levelSkel = levelSkel
-            else:                     levelSkel = max(levelSkel, levelSkelLoc) # security so that levelSkel is not too small
+            if not forceUpperLimitOffset: levelSkel = max(levelSkel, levelSkelLoc) # security so that levelSkel is not too small
 
             dfarloc = dfars[c]
             snearloc = 2**levelSkel*snears[c]


### PR DESCRIPTION
see title.
When trying to set a grid to get a fine far-field mesh (for the fscgns converter thingy) the current settings didn't permit it. I am hereby suggesting an expert expert parameter to be able to clip the upper limit of the number of offset. It uses the bounding box of the generated octree to create an G.cart. This way we bypass the G.adaptOctree that can be very expensive for these types of meshes that are primarily used for debugging and expert expert mode devs. see below.

There are no non-regression test cases as it is an _expert_ _expert_ parameter that requires a recompilation of the code. There are, however, local valid test cases to check the behavior.
<img width="400" src="https://github.com/user-attachments/assets/29233a1b-aadb-4309-921a-15bf33e6f657" />
