### PR TITLE
CPlot: Add missing <unistd.h> for C99 compliance

### DIFF
--- a/Cassiopee/CPlot/CPlot/GLUT/freeglut_input_devices.c
+++ b/Cassiopee/CPlot/CPlot/GLUT/freeglut_input_devices.c
@@ -45,6 +45,7 @@
 #include <string.h>
 #include <termios.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 typedef struct {
    int fd;

--- a/Cassiopee/CPlot/CPlot/GLUT/freeglut_joystick.c
+++ b/Cassiopee/CPlot/CPlot/GLUT/freeglut_joystick.c
@@ -75,6 +75,7 @@
 #    ifdef HAVE_FCNTL_H
 #        include <fcntl.h>
 #    endif
+#    include <unistd.h>
 #    ifdef HAVE_ERRNO_H
 #        include <errno.h>
 #        include <string.h>


### PR DESCRIPTION
## Summary

Add missing `#include <unistd.h>` to two freeglut source files that use POSIX functions `close()`, `read()`, and `write()`.

## Problem

Building CPlot with strict C99 compilers (e.g., Intel icx/icpx) fails with:

```
error: call to undeclared function 'close'; ISO C99 and later do not support implicit function declarations
error: call to undeclared function 'read'; ISO C99 and later do not support implicit function declarations  
error: call to undeclared function 'write'; ISO C99 and later do not support implicit function declarations
```

GCC permits implicit function declarations with only a warning, but C99-strict compilers treat this as an error.

## Solution

Add `#include <unistd.h>` to the `TARGET_HOST_POSIX_X11` sections of:
- `CPlot/CPlot/GLUT/freeglut_input_devices.c`
- `CPlot/CPlot/GLUT/freeglut_joystick.c`

This is a minimal fix (2 lines total) that enables compilation with Intel oneAPI compilers while maintaining compatibility with GCC and Clang.

## Testing

Verified successful build of CPlot and all Cassiopee modules using Intel oneAPI 2024.2 (icx/icpx/ifort) on Linux.