### PR TITLE
Connector/Post: update setInterpData2 and probe functions

### DIFF
--- a/Cassiopee/Connector/Connector/Mpi.py
+++ b/Cassiopee/Connector/Connector/Mpi.py
@@ -856,10 +856,10 @@ def _transfer2(t, tc, variables, graph, intersectionDict, dictOfADT,
 # memes arguments que setInterpData
 #=========================================================================
 def setInterpData(aR, aD, order=2, penalty=1, nature=0, extrap=1,
-                   method='lagrangian', loc='nodes', storage='direct',
-                   interpDataType=1, hook=None, cartesian=False, sameBase=0,
-                   topTreeRcv=None, topTreeDnr=None, sameName=1, verbose=2,
-                   dim=3, itype='abutting'):
+                  method='lagrangian', loc='nodes', storage='direct',
+                  interpDataType=1, hook=None, cartesian=False, sameBase=0,
+                  topTreeRcv=None, topTreeDnr=None, sameName=1, verbose=2,
+                  dim=3, itype='abutting'):
     """Compute interpolation data for abutting or chimera intergrid connectivity."""
     tR = Internal.copyRef(aR)
     tD = Internal.copyRef(aD)
@@ -1056,7 +1056,7 @@ def _setInterpData2(aR, aD, order=2, loc='centers', cartesian=False, extrap=1, n
 
     if cartesian: interpDataType = 0 # 0 if tc is cartesian
     else: interpDataType = 1
-    
+
     # Compute BBoxTrees
     tsBB = Cmpi.createBBoxTree(aR)
     procDicts = Cmpi.getProcDict(tsBB)
@@ -1085,9 +1085,9 @@ def _setInterpData2(aR, aD, order=2, loc='centers', cartesian=False, extrap=1, n
         if dnrZones != []:
             X._setInterpData(zs, dnrZones, nature=nature, penalty=penalty, order=order, loc=loc, storage='inverse',
                              extrap=extrap, sameName=0, interpDataType=interpDataType, itype='chimera', verbose=verbose)
-        
+
         if cellNPresent == -1: C._rmVars(zs, [varcelln])
-        
+
         for zd in dnrZones:
             zdname = zd[0]
             destProc = procDictD[zdname]

--- a/Cassiopee/Connector/Connector/OversetData.py
+++ b/Cassiopee/Connector/Connector/OversetData.py
@@ -1105,7 +1105,7 @@ def _setInterpData2(aR, aD, order=2, loc='centers', cartesian=False, extrap=1, n
     _setInterpData(aR, aD, order=order, penalty=penalty, nature=nature, extrap=extrap,
                    method='lagrangian', loc=loc, storage='inverse', verbose=verbose,
                    interpDataType=interpDataType, sameName=0, itype="chimera")
-    
+
     if cellNPresent == -1: C._rmVars(aR, [varcelln])
 
     return None
@@ -1174,8 +1174,8 @@ def _setInterpData(aR, aD, order=2, penalty=1, nature=0, extrap=1,
 
     if itype != 'abutting': # chimera
         _setInterpDataChimera__(aR, aD, order=order, penalty=penalty, nature=nature, extrap=extrap, verbose=verbose,
-                              method=method, loc=loc, storage=storage, interpDataType=interpDataType, hook=hook,
-                              topTreeRcv=topTreeRcv, topTreeDnr=topTreeDnr, sameName=sameName, dim=dim, itype=itype, dictOfModels=dictOfModels)
+                                method=method, loc=loc, storage=storage, interpDataType=interpDataType, hook=hook,
+                                topTreeRcv=topTreeRcv, topTreeDnr=topTreeDnr, sameName=sameName, dim=dim, itype=itype, dictOfModels=dictOfModels)
 
     # SP: pour l'instant adaptForRANSLES est appele 2 fois: pour les ghost cells et pour le chimere
     # peut on ne le mettre qu ici ?
@@ -1183,9 +1183,9 @@ def _setInterpData(aR, aD, order=2, penalty=1, nature=0, extrap=1,
     return None
 
 def _setInterpDataChimera__(aR, aD, order=2, penalty=1, nature=0, extrap=1,
-                          method='lagrangian', loc='nodes', storage='direct',
-                          interpDataType=1, hook=None, verbose=2,
-                          topTreeRcv=None, topTreeDnr=None, sameName=1, dim=3, itype='both', dictOfModels=None):
+                            method='lagrangian', loc='nodes', storage='direct',
+                            interpDataType=1, hook=None, verbose=2,
+                            topTreeRcv=None, topTreeDnr=None, sameName=1, dim=3, itype='both', dictOfModels=None):
     locR = loc
 
     # Si pas de cellN receveur, on retourne

--- a/Cassiopee/Connector/Connector/OversetData.py
+++ b/Cassiopee/Connector/Connector/OversetData.py
@@ -868,7 +868,6 @@ def _setIBCDataForZone2__(z, zonesDnr, correctedPts, wallPts, interpPts, interpP
 
     return None
 
-
 def _addIBCCoords__(z, zname, correctedPts, wallPts, interpolatedPts, bcType, bcName=None, ReferenceState=None, prefix='IBCD_',model='NSLaminar'):
     nameSubRegion = prefix+zname
     zsr = Internal.getNodeFromName1(z, nameSubRegion)
@@ -1080,24 +1079,35 @@ def _addIBCCoords2__(z, zname, correctedPts, wallPts, interpolatedPts, bcType, b
 
     return None
 
-def setInterpData2(aR, aD, order=2, loc='centers', cartesian=False):
-    aD = Internal.copyRef(aD)
-    aR = Internal.copyRef(aR)
-    _setInterpData2(aR, aD, order=order, loc=loc, cartesian=cartesian)
-    return aD
+def setInterpData2(aR, aD, order=2, loc='centers', cartesian=False, extrap=1, nature=1, penalty=1, verbose=2):
+    """Compute interpolation data for 2 different trees."""
+    tD = Internal.copyRef(aD)
+    tR = Internal.copyRef(aR)
+    _setInterpData2(tR, tD, order=order, loc=loc, cartesian=cartesian, extrap=extrap, nature=nature, penalty=penalty, verbose=verbose)
+    return tD
 
-def _setInterpData2(aR, aD, order=2, loc='centers', cartesian=False):
-    if cartesian: interpDataType = 0
-    else: interpDataType = 1
+def _setInterpData2(aR, aD, order=2, loc='centers', cartesian=False, extrap=1, nature=1, penalty=1, verbose=2):
+    """Compute interpolation data for 2 different trees."""
 
     if loc == 'nodes': varcelln = 'cellN'
     else: varcelln = 'centers:cellN'
+
+    # Clean previous IDs if necessary
+    Internal._rmNodesFromType(aD, 'ZoneSubRegion_t')
+    Internal._rmNodesFromName(aD, 'GridCoordinates#Init')
+
+    if cartesian: interpDataType = 0
+    else: interpDataType = 1
+
     cellNPresent = C.isNamePresent(aR, varcelln)
-    if cellNPresent==-1: C._initVars(aR, varcelln, 2.) # interp all
-    _setInterpData(aR, aD, order=order, penalty=1, nature=1, extrap=1,
-                   method='lagrangian', loc=loc, storage='inverse',
+    if cellNPresent == -1: C._initVars(aR, varcelln, 2.) # interp all
+
+    _setInterpData(aR, aD, order=order, penalty=penalty, nature=nature, extrap=extrap,
+                   method='lagrangian', loc=loc, storage='inverse', verbose=verbose,
                    interpDataType=interpDataType, sameName=0, itype="chimera")
-    if cellNPresent==-1: C._rmVars(aR, [varcelln])
+    
+    if cellNPresent == -1: C._rmVars(aR, [varcelln])
+
     return None
 
 #==============================================================================
@@ -1130,24 +1140,25 @@ def _setInterpData2(aR, aD, order=2, loc='centers', cartesian=False):
 # verbose: 0 (rien), 1 (bilan interpolation), 2 (ecrit les indices de pts orphelins),
 # RMQ: method='conservative' -> tout le domaine receveur est pour l'instant considere a interpoler (maquette)
 #==============================================================================
-def setInterpData(tR, tD, order=2, penalty=1, nature=0, extrap=1,
+def setInterpData(aR, aD, order=2, penalty=1, nature=0, extrap=1,
                   method='lagrangian', loc='nodes', storage='direct',
                   interpDataType=1, hook=None, verbose=2,
                   topTreeRcv=None, topTreeDnr=None, sameName=1, dim=3, itype='both', dictOfModels=None):
-    """Compute and store overset interpolation data."""
-    aR = Internal.copyRef(tR)
-    aD = Internal.copyRef(tD)
-    _setInterpData(aR, aD, order=order, penalty=penalty, nature=nature, extrap=extrap,
+    """Compute interpolation data for abutting or chimera intergrid connectivity."""
+    tR = Internal.copyRef(aR)
+    tD = Internal.copyRef(aD)
+    _setInterpData(tR, tD, order=order, penalty=penalty, nature=nature, extrap=extrap,
                    method=method, loc=loc, storage=storage, interpDataType=interpDataType,
                    hook=hook, verbose=verbose,
                    topTreeRcv=topTreeRcv, topTreeDnr=topTreeDnr, sameName=sameName, dim=dim, itype=itype, dictOfModels=dictOfModels)
-    if storage == 'direct': return aR
-    else: return aD
+    if storage == 'direct': return tR
+    else: return tD
 
 def _setInterpData(aR, aD, order=2, penalty=1, nature=0, extrap=1,
                    method='lagrangian', loc='nodes', storage='direct',
                    interpDataType=1, hook=None, verbose=2,
                    topTreeRcv=None, topTreeDnr=None, sameName=1, dim=3, itype='both', dictOfModels=None):
+    """Compute interpolation data for abutting or chimera intergrid connectivity."""
 
     # Recherche pour les pts coincidents (base sur les GridConnectivity)
     if itype != 'chimera': # abutting
@@ -1162,7 +1173,7 @@ def _setInterpData(aR, aD, order=2, penalty=1, nature=0, extrap=1,
             _adaptForRANSLES__(aR, aD, dictOfModels=dictOfModels)
 
     if itype != 'abutting': # chimera
-        _setInterpDataChimera(aR, aD, order=order, penalty=penalty, nature=nature, extrap=extrap, verbose=verbose,
+        _setInterpDataChimera__(aR, aD, order=order, penalty=penalty, nature=nature, extrap=extrap, verbose=verbose,
                               method=method, loc=loc, storage=storage, interpDataType=interpDataType, hook=hook,
                               topTreeRcv=topTreeRcv, topTreeDnr=topTreeDnr, sameName=sameName, dim=dim, itype=itype, dictOfModels=dictOfModels)
 
@@ -1171,7 +1182,7 @@ def _setInterpData(aR, aD, order=2, penalty=1, nature=0, extrap=1,
     #if storage=='inverse': _adaptForRANSLES__(aR, aD)
     return None
 
-def _setInterpDataChimera(aR, aD, order=2, penalty=1, nature=0, extrap=1,
+def _setInterpDataChimera__(aR, aD, order=2, penalty=1, nature=0, extrap=1,
                           method='lagrangian', loc='nodes', storage='direct',
                           interpDataType=1, hook=None, verbose=2,
                           topTreeRcv=None, topTreeDnr=None, sameName=1, dim=3, itype='both', dictOfModels=None):
@@ -1541,7 +1552,6 @@ def _setInterpDataForGhostCellsNGon__(aR, aD, storage='inverse', loc='centers'):
                                           RotationAngle=RotationAngle, RotationCenter=RotationCenter)
 
     return None
-
 
 def _setInterpDataForGhostCellsStruct__(aR, aD, storage='direct', loc='nodes'):
 

--- a/Cassiopee/Post/Post/Probe.py
+++ b/Cassiopee/Post/Post/Probe.py
@@ -261,47 +261,46 @@ class Probe:
         elif self._mode == 2  and source is not None:
             zones = Internal.getZones(source)
             self._probeZones = []
+            loc = self.getFieldLoc(self._fields)
             for z in zones:
-                npts = C.getNPts(z)
-                ncells = C.getNCells(z)
                 dimz = Internal.getZoneDim(z)
                 ni = dimz[1]; nj = dimz[2]; nk = dimz[3]
-                if self.getFieldLoc(self._fields) == 'centers': # attention!
+                if loc == 'centers': # attention!
                     zp = G.cart((0,0,0), (1,1,1), (self._bsize+1,ni,nj))
                 else: zp = G.cart((0,0,0), (1,1,1), (self._bsize,ni,nj))
                 zp[0] = '%s'%z[0] # name of probe zone is identical to name of source
                 D2._addProcNode(zp, Cmpi.rank)
                 self._probeZones.append(zp)
-                C._initVars(zp, '{time}=-1.') # time sentinel
+                C._initVars(zp, 'time', -1) # time sentinel
                 for v in self._fields: C._initVars(zp, v, 0.)
 
         elif self._mode == 3 and source is not None: # surface permeable
             zones = Internal.getZones(source)
             self._probeZones = []
+            loc = self.getFieldLoc(self._fields)
             for z in zones:
                 dimz = Internal.getZoneDim(z)
                 if dimz[0] == 'Structured':
                     ni = dimz[1]; nj = dimz[2]; nk = dimz[3]
-                    zp = G.cart((0,0,0), (1,1,1), (self._bsize,ni,nj))
+                    if loc == 'centers': # attention!
+                        zp = G.cart((0,0,0), (1,1,1), (self._bsize+1,ni,nj))
+                    else: zp = G.cart((0,0,0), (1,1,1), (self._bsize,ni,nj))
                 else: # en non structure, c'est surement pas la bonne solution
                     npts = C.getNPts(z)
-                    zp = G.cart((0,0,0), (1,1,1), (self._bsize,npts,1))
+                    if loc == 'centers': # attention!
+                        zp = G.cart((0,0,0), (1,1,1), (self._bsize+1,npts,1))
+                    else: zp = G.cart((0,0,0), (1,1,1), (self._bsize,npts,1))
                 zp[0] = '%s'%z[0] # name of probe zone is identical to name of source
                 D2._addProcNode(zp, Cmpi.rank)
                 self._probeZones.append(zp)
-                C._initVars(zp, '{time}=-1.') # time sentinel
-
-                for v in self._fields:
-                    v = v.split(':')
-                    if len(v) == 2: v = v[1]
-                    else: v = v[0]
-                    C._initVars(zp, v, 0.)
+                C._initVars(zp, 'time', -1) # time sentinel
+                for v in self._fields: C._initVars(zp, v, 0.)
         return None
 
     # Prepare for mode=3
-    def prepare(self, tc, cartesian=False):
+    def prepare(self, tc, loc='nodes', cartesian=False, extrap=1, nature=1, penalty=1, verbose=2):
         tcs = Internal.copyRef(tc)
-        Xmpi._setInterpData2(self._ts, tcs, loc='nodes', cartesian=cartesian)
+        Xmpi._setInterpData2(self._ts, tcs, loc=loc, cartesian=cartesian, extrap=extrap, nature=nature, penalty=penalty, verbose=verbose)
         return tcs
 
     # Check file, if it doesnt exist, write probe zone in it
@@ -590,7 +589,8 @@ class Probe:
             self._graph = Cmpi.computeGraph(tcsBB, type='bbox3', intersectionsDict=interDictD2R,
                                             procDict=procDictc, procDict2=self._procDicts, t2=tsBB, reduction=True)
 
-        Xmpi._setInterpTransfers(self._ts, tcs, variables=self._fields, graph=self._graph, procDict=self._procDicts)
+        variables = [var.split(':')[-1] for var in self._fields] # self._fields can be located at centers
+        Xmpi._setInterpTransfers(self._ts, tcs, variables=variables, graph=self._graph, procDict=self._procDicts)
         if onlyTransfer: return None
         #Cmpi.convertPyTree2File(self._ts, 'out.cgns')
         #Internal.printTree(self._probeZones)
@@ -641,7 +641,6 @@ class Probe:
         self._icur += 1
         if self._icur >= self._bsize: self.flush()
         return None
-
 
     def share(self, tcs, tc):
         """Share coordinates and fields between tcs and tc."""
@@ -702,27 +701,27 @@ class Probe:
         if self._icur >= self._bsize: # because buffer is out
             for pzone in self._probeZones:
                 nodes = []; paths = []
-                gc = Internal.getNodeFromName1(pzone, 'GridCoordinates')
+                gc = Internal.getNodeFromName1(pzone, Internal.__GridCoordinates__)
                 if gc is not None:
                     gc = Internal.copyNode(gc)
                     gc[0] = 'GridCoordinates#%d'%self._filecur
                     nodes += [gc]
                     paths += ['CGNSTree/Base/%s'%pzone[0]]
-                fc = Internal.getNodeFromName1(pzone, 'FlowSolution')
+                fc = Internal.getNodeFromName1(pzone, Internal.__FlowSolutionNodes__)
                 if fc is not None:
                     fc = Internal.copyNode(fc)
                     fc[0] = 'FlowSolution#%d'%self._filecur
                     nodes += [fc]
                     paths += ['CGNSTree/Base/%s'%pzone[0]]
-                fcc = Internal.getNodeFromName1(pzone, 'FlowSolution#Centers')
+                fcc = Internal.getNodeFromName1(pzone, Internal.__FlowSolutionCenters__)
                 if fcc is not None:
                     fcc = Internal.copyNode(fcc)
                     fcc[0] = 'FlowSolution#Centers#%d'%self._filecur
                     nodes += [fcc]
                     paths += ['CGNSTree/Base/%s'%pzone[0]]
                 Distributed.writeNodesFromPaths(self._fileName, paths, nodes, None, -1, 0)
-                C._initVars(pzone, '{time}=-1.') # time sentinel
-                for v in self._fields:C._initVars(pzone, '{%s}=0.'%v)
+                C._initVars(pzone, 'time', -1) # time sentinel
+                for v in self._fields: C._initVars(pzone, v, 0.)
             #print('self._filecur=',self._filecur)
             self._filecur += 1
             self._icur = 0


### PR DESCRIPTION
No regression. 

These modifications are linked to Danny's OpenFan case.
New options are passed to the setInterpData2 function in both Connector.OversetData and Connector.Mpi.py.
Probe mode 3 is updated to have the capability to interpolate at centers instead of nodes, hence the modification of setInterpData2. Additionally, hardcoded FlowSolution container names were replaced with their internal values in probe.flush() in case they have been modified by the user (as in Danny's case).