### PR TITLE
Transform: reorder: option arg. for BE/ME

### DIFF
--- a/Cassiopee/Converter/Converter/convertUnstruct2Hexa.cpp
+++ b/Cassiopee/Converter/Converter/convertUnstruct2Hexa.cpp
@@ -46,13 +46,12 @@ PyObject* K_CONVERTER::convertUnstruct2Hexa(PyObject* self, PyObject* args)
 
   // Acces universel sur BE/ME
   E_Int nc = cnl->getNConnect();
-  // Acces universel aux eltTypes
   vector<char*> eltTypes;
   K_ARRAY::extractVars(eltType, eltTypes);
 
   E_Int npts = f->getSize(), api = f->getApi(), nfld = f->getNfld();
   E_Int nelts, loc = 0;
-  vector<E_Int> neltsConn(nc);
+  vector<E_Int> nepc(nc);
   E_Bool center = false;
 
   // Boucle sur toutes les connectivites pour determiner les types des
@@ -81,7 +80,7 @@ PyObject* K_CONVERTER::convertUnstruct2Hexa(PyObject* self, PyObject* args)
     }
 
     if (strchr(eltTypConn,'*') != NULL) loc += 1;
-    neltsConn[ic] = cm.getSize();
+    nepc[ic] = cm.getSize();
   }
 
   if (loc != 0 and loc != nc)
@@ -94,7 +93,7 @@ PyObject* K_CONVERTER::convertUnstruct2Hexa(PyObject* self, PyObject* args)
   else if (loc == nc) center = true;
 
   // Build empty ME connectivity
-  PyObject* tpl = K_ARRAY::buildArray3(nfld, varString, npts, neltsConn,
+  PyObject* tpl = K_ARRAY::buildArray3(nfld, varString, npts, nepc,
                                        eltType2.c_str(), center, api);
   FldArrayF* f2; FldArrayI* cnl2;
   K_ARRAY::getFromArray3(tpl, f2, cnl2);

--- a/Cassiopee/Post/Post/selectExteriorElts.cpp
+++ b/Cassiopee/Post/Post/selectExteriorElts.cpp
@@ -547,18 +547,18 @@ PyObject* K_POST::selectExteriorEltsME(FldArrayF& f, FldArrayI& cn,
   // Uniform chunks (schedule: static) with at most 'net' elements per thread
   E_Int nthreads = __NUMTHREADS__;
   E_Int net = ntotElts/nthreads + nc;
-  // For each thread:
-  //  - indir: maps element indices from new to old ME
-  E_Int** indir = new E_Int* [nthreads];
-  //  - nextepc: number of exterior elements found in each connectivity
-  E_Int** nextepc = new E_Int* [nthreads];
-  //  - offset: cumulative number of exterior elements found in each connectivity
-  E_Int** offset = new E_Int* [nthreads];
+  // Thread-related arrays are prefixed with 't'. For each thread:
+  //  - tindir: maps element indices from new to old ME
+  E_Int** tindir = new E_Int* [nthreads];
+  //  - tnextepc: number of exterior elements found in each connectivity
+  E_Int** tnextepc = new E_Int* [nthreads];
+  //  - toffset: cumulative number of exterior elements found in each connectivity
+  E_Int** toffset = new E_Int* [nthreads];
   for (E_Int i = 0; i < nthreads; i++)
   {
-    indir[i] = new E_Int [net];
-    nextepc[i] = new E_Int [nc];
-    offset[i] = new E_Int [nc];
+    tindir[i] = new E_Int [net];
+    tnextepc[i] = new E_Int [nc];
+    toffset[i] = new E_Int [nc];
   }
 
   // Number of elements per connectivity of the output ME
@@ -572,14 +572,14 @@ PyObject* K_POST::selectExteriorEltsME(FldArrayF& f, FldArrayI& cn,
   {
     E_Int indv;
     E_Int eidx;  // global element index
-    E_Int nneis;  // number of neighbours of element e
+    E_Int nneis;  // number of neighbours of element eidx
     E_Int nextElts = 0;  // number of exterior elements found in all conn. of that thread
     E_Int nextEltsIc;  // number of exterior elements found in a given conn. of that thread
-    E_Int ithread = __CURRENT_THREAD__;
-    // Thread-related variables are prefixed with 't'
-    E_Int* tindir = indir[ithread];
-    E_Int* tnextepc = nextepc[ithread];
-    std::vector<E_Int> ttmp_nepc2(nc, 0);
+    // Local thread-related arrays are prefixed with 'loc_t'
+    E_Int tid = __CURRENT_THREAD__;
+    E_Int* loc_tindir = tindir[tid];
+    E_Int* loc_tnextepc = tnextepc[tid];
+    std::vector<E_Int> loc_ttmp_nepc2(nc, 0);
 
     for (E_Int ic = 0; ic < nc; ic++)
     {
@@ -594,8 +594,8 @@ PyObject* K_POST::selectExteriorEltsME(FldArrayF& f, FldArrayI& cn,
         nneis = cENN[eidx];
         if (nneis != nfpe[ic])  // exterior element found
         {
-          tindir[nextElts] = i; nextElts++; nextEltsIc++;
-          ttmp_nepc2[ic]++;
+          loc_tindir[nextElts] = i; nextElts++; nextEltsIc++;
+          loc_ttmp_nepc2[ic]++;
 
           // Tag vertices as exterior vertices
           for (E_Int j = 1; j <= nvpe; j++)
@@ -606,12 +606,12 @@ PyObject* K_POST::selectExteriorEltsME(FldArrayF& f, FldArrayI& cn,
         }
       }
 
-      tnextepc[ic] = nextEltsIc;
+      loc_tnextepc[ic] = nextEltsIc;
     }
 
     #pragma omp critical
     {
-      for (E_Int ic = 0; ic < nc; ic++) tmp_nepc2[ic] += ttmp_nepc2[ic];
+      for (E_Int ic = 0; ic < nc; ic++) tmp_nepc2[ic] += loc_ttmp_nepc2[ic];
     }
   }
 
@@ -621,20 +621,20 @@ PyObject* K_POST::selectExteriorEltsME(FldArrayF& f, FldArrayI& cn,
   E_Int npts2 = K_CONNECT::prefixSum(vindir);
 
   // Compute thread element offsets in the output ME for each connectivity
-  // offset is a cumulative nextepc over all conns
+  // toffset is a cumulative tnextepc over all conns
   // Used to build cm2 using multiple threads
   {
-    E_Int* toffset = offset[0];
-    for (E_Int ic = 0; ic < nc; ic++) toffset[ic] = 0;
+    E_Int* loc_toffset = toffset[0];
+    for (E_Int ic = 0; ic < nc; ic++) loc_toffset[ic] = 0;
   }
   
   for (E_Int i = 1; i < nthreads; i++)
   {
-    E_Int* tnextepcm1 = nextepc[i-1];
-    E_Int* toffset = offset[i];
-    E_Int* toffsetm1 = offset[i-1];
+    E_Int* tnextepcm1 = tnextepc[i-1];
+    E_Int* loc_toffset = toffset[i];
+    E_Int* toffsetm1 = toffset[i-1];
     for (E_Int ic = 0; ic < nc; ic++)
-      toffset[ic] = toffsetm1[ic] + tnextepcm1[ic];
+      loc_toffset[ic] = toffsetm1[ic] + tnextepcm1[ic];
   }
 
   // Free memory
@@ -678,10 +678,10 @@ PyObject* K_POST::selectExteriorEltsME(FldArrayF& f, FldArrayI& cn,
     E_Int ic2, indv, inde, nelts, nvpe;
     E_Int offR;  // cumulative element offset of a given conn. to Read from cm
     E_Int offW;  // cumulative element offset of a given conn. to Write into cm2
-    E_Int ithread = __CURRENT_THREAD__;
-    E_Int* tindir = indir[ithread];
-    E_Int* tnextepc = nextepc[ithread];
-    E_Int* toffset = offset[ithread];
+    E_Int tid = __CURRENT_THREAD__;
+    E_Int* loc_tindir = tindir[tid];
+    E_Int* loc_tnextepc = tnextepc[tid];
+    E_Int* loc_toffset = toffset[tid];
 
     // Fields
     for (E_Int n = 1; n <= nfld; n++)
@@ -704,12 +704,12 @@ PyObject* K_POST::selectExteriorEltsME(FldArrayF& f, FldArrayI& cn,
       if (tmp_nepc2[ic] == 0) continue;  // no exterior elements in this conn, skip
       FldArrayI& cm = *(cn.getConnect(ic));
       FldArrayI& cm2 = *(cn2->getConnect(ic2));
-      nelts = tnextepc[ic];
-      offW = toffset[ic];
+      nelts = loc_tnextepc[ic];
+      offW = loc_toffset[ic];
       nvpe = cm.getNfld();
       for (E_Int i = 0; i < nelts; i++)
       {
-        inde = tindir[i+offR];
+        inde = loc_tindir[i+offR];
         for (E_Int j = 1; j <= nvpe; j++)
         {
           indv = cm(inde, j) - 1;
@@ -724,11 +724,11 @@ PyObject* K_POST::selectExteriorEltsME(FldArrayF& f, FldArrayI& cn,
   // Free memory
   for (E_Int i = 0; i < nthreads; i++)
   {
-    delete [] indir[i];
-    delete [] nextepc[i];
-    delete [] offset[i];
+    delete [] tindir[i];
+    delete [] tnextepc[i];
+    delete [] toffset[i];
   }
-  delete [] indir; delete [] nextepc; delete [] offset;
+  delete [] tindir; delete [] tnextepc; delete [] toffset;
 
   RELEASESHAREDU(tpl, f2, cn2);
   delete [] eltType2;

--- a/Cassiopee/Transform/Transform/Transform.py
+++ b/Cassiopee/Transform/Transform/Transform.py
@@ -881,9 +881,10 @@ def split(a, dir, index):
         a2 = subzone(a, (1,1,index), (ni,nj,nk))
     return a1, a2
 
-def reorder(a, order):
+def reorder(a, order=None):
     """Reorder the numerotation of mesh.
     Usage: reorder(a, (2,1,-3))"""
+    if order is None: order = tuple()
     if isinstance(a[0], list):
         b = []
         for i in a:

--- a/Cassiopee/Transform/Transform/reorder.cpp
+++ b/Cassiopee/Transform/Transform/reorder.cpp
@@ -63,7 +63,7 @@ PyObject* K_TRANSFORM::reorder(PyObject* self, PyObject* args)
     }
     else
     {
-      PyErr_SetString(PyExc_TypeError,
+      PyErr_SetString(PyExc_ValueError,
                       "reorder: order tuple must be of size 3, eg, (1,2,3).");
       RELEASESHAREDS(array, f);
       return NULL;
@@ -85,16 +85,22 @@ PyObject* K_TRANSFORM::reorder(PyObject* self, PyObject* args)
     FldArrayI* cn2;
     if (strncmp(eltType, "NGON", 4) == 0)
     {
-      if (size == 1)
+      if (size == 0)
       {
-        tplo = PyTuple_GetItem(order, 0); oi = PyLong_AsLong(tplo);
+        PyErr_WarnEx(PyExc_UserWarning,
+                      "reorder: order tuple should be (1,) or (-1,) for NGON. "
+                      "Setting order to (1,)", 1);
+        oi = 1;
       }
       else
       {
-        PyErr_SetString(PyExc_TypeError,
-                        "reorder: order tuple must be (1,) or (-1,) for NGONs.");
-        RELEASESHAREDU(array, f, cn);
-        return NULL;
+        if (size > 1)
+        {
+          PyErr_WarnEx(PyExc_UserWarning,
+                        "reorder: order tuple should be (1,) or (-1,) for NGON. "
+                        "Selecting first element of the tuple.", 1);
+        }
+        tplo = PyTuple_GetItem(order, 0); oi = PyLong_AsLong(tplo);
       }
   
       // check si le NGON est surfacique
@@ -128,17 +134,22 @@ PyObject* K_TRANSFORM::reorder(PyObject* self, PyObject* args)
       K_ARRAY::getFromArray3(tpl, f2, cn2);
       if (dim == 2)
       {
-        if (size == 1)
+        if (size == 0)
         {
-          tplo = PyTuple_GetItem(order, 0); oi = PyLong_AsLong(tplo);
+          PyErr_WarnEx(PyExc_UserWarning,
+                       "reorder: order tuple should be (1,) or (-1,) for TRI "
+                       "or QUAD. Setting order to (1,)", 1);
+          oi = 1;
         }
         else
         {
-          PyErr_SetString(PyExc_TypeError,
-                          "reorder: order tuple must be (1,) or (-1,) for TRI or QUAD.");
-          RELEASESHAREDU(tpl, f2, cn2);
-          RELEASESHAREDU(array, f, cn);
-          return NULL;
+          if (size > 1)
+          {
+            PyErr_WarnEx(PyExc_UserWarning,
+                         "reorder: order tuple should be (1,) or (-1,) for TRI "
+                         "or QUAD. Selecting first element of the tuple.", 1);
+          }
+          tplo = PyTuple_GetItem(order, 0); oi = PyLong_AsLong(tplo);
         }
         K_CONNECT::reorderUnstruct2D(*f2, *cn2, E_Int(oi));
       }


### PR DESCRIPTION
No regressions

- Argument order of T. reorder for 2D BE,ME is now optional and will default to (1,). (taken from #532 )
- Renaming var names in P.post.selectExteriorElements for consistency