### PR TITLE
Converter: reorder added after T.breakElements in C.convertArray2Hexa

### DIFF
--- a/Cassiopee/Converter/Converter/Converter.py
+++ b/Cassiopee/Converter/Converter/Converter.py
@@ -1352,16 +1352,11 @@ def convertArray2Hexa1__(array):
     if isinstance(sub, str): t = sub
     else: t = 'STRUCT'
     if t == 'STRUCT': return converter.convertStruct2Hexa(array)
-    elif t == 'HEXA' or t == 'QUAD' or t == 'BAR' or t == 'NODE':
-        return array
-    elif t == 'HEXA*' or t == 'QUAD*' or t == 'BAR*' or t == 'NODE*':
-        return array
-    elif t == 'TRI' or t == 'TETRA' or t == 'PENTA':
-        return converter.convertUnstruct2Hexa(array)
     elif t == 'NGON':
         try: import Transform as T
         except: raise ImportError("convertArray2Hexa: requires Transform for NGONs.")
         tmp = T.breakElements(array)
+        tmp = T.reorder(tmp)
         brd = []
         for i in tmp:
             if i[3] != 'NGON': brd.append(convertArray2Hexa1__(i))


### PR DESCRIPTION
reorder added after T.breakElements NGON in C.convertArray2Hexa
and rearranging C.convertArray2Hexa for ME

Regression - **topological only**:

```
Converter       : convertArray2Hexa_t1.py                 : 0m0.26s   : 0m0.25s   : 16/07/25 10h31  : 92%  :   :  FAILED    
```

(taken from #532)

