### PR TITLE
Probe: update module and doc

### DIFF
--- a/Cassiopee/Post/Post/Probe.py
+++ b/Cassiopee/Post/Post/Probe.py
@@ -96,13 +96,13 @@ class Probe:
 
             if t is not None and loc is not None:
                 self.locateProbeXYZ(t, X, loc)
-            else: raise ValueError("Probe: missing PyTree argument (t) for mode %s"%0) 
+            else: raise ValueError("Probe: missing PyTree argument (t) for mode %s"%0)
 
         # Localisation a partir de ind,blockName (mode=1)
         elif ind is not None and blockName is not None:
             self._mode = 1
             if t is not None: self.locateProbeInd(t, ind, blockName)
-            else: raise ValueError("Probe: missing PyTree argument (t) for mode %s"%1) 
+            else: raise ValueError("Probe: missing PyTree argument (t) for mode %s"%1)
 
         elif tPermeable is not None:
             self._mode = 3
@@ -770,11 +770,11 @@ class Probe:
     def read(self, cont=None, ind=None, probeName=None):
         """Read data from existing probe file."""
         if cont is not None:
-            if ind is not None: 
+            if ind is not None:
                 print('Warning: Probe (read): both cont and ind arguments were provided. Only cont argument is considered.')
             return self.readCont(cont)
         elif ind is not None:
-            if probeName is None: 
+            if probeName is None:
                 print('Warning: Probe (read): no probeName argument was provided with index value(s). Reading the first probe zone by default.')
                 probeName = 0
             return self.readInd(ind, probeName)
@@ -794,7 +794,7 @@ class Probe:
         for z in zones:
             paths = []
             isGC = False; isFS = False; isFC = False
-            
+
             if Internal.getNodeFromName1(z, 'GridCoordinates#0') is not None:
                 isGC = True
                 paths += ['CGNSTree/Base/%s/GridCoordinates#%d'%(z[0], cont)]

--- a/Cassiopee/Post/Post/Probe.py
+++ b/Cassiopee/Post/Post/Probe.py
@@ -13,7 +13,7 @@ import numpy, os
 
 # Probe class
 class Probe:
-    """Probe for extracting data from fields during computations."""
+    """Create Probe object to extract and save data during simulations."""
     # defaullt initialization
     def init0(self):
         # probe mode:
@@ -96,26 +96,24 @@ class Probe:
 
             if t is not None and loc is not None:
                 self.locateProbeXYZ(t, X, loc)
-            else: print("Warning: probe: need t for probe with point coordinates.")
+            else: raise ValueError("Probe: missing PyTree argument (t) for mode %s"%0) 
 
         # Localisation a partir de ind,blockName (mode=1)
         elif ind is not None and blockName is not None:
             self._mode = 1
             if t is not None: self.locateProbeInd(t, ind, blockName)
-            else: print("Warning: probe: need t for probe with index and blockName.")
+            else: raise ValueError("Probe: missing PyTree argument (t) for mode %s"%1) 
 
         elif tPermeable is not None:
             self._mode = 3
             self._ts = tPermeable
 
-        elif modeForce == 4:
+        elif t is None or modeForce == 4:
             self._mode = 4
 
         # Empilement de zones
         else:
             self._mode = 2
-
-        if Cmpi.rank == 0: print('Info: probe is in mode ', self._mode)
 
         # Cree la probe et on relit le fichier uniquement en mode=0 et 1
         if self._mode == 0 or self._mode == 1 or self._mode == 4:
@@ -126,6 +124,14 @@ class Probe:
                 self.checkFile(append=self._append)
             #if t is not None and fields is not None:
             #    self.checkVariables(t, fields)
+        elif self._mode == 3:
+            for z in Internal.getZones(tPermeable):
+                dimz = Internal.getZoneDim(z)
+                if dimz[0] != 'Structured': raise TypeError("Probe: tPermeable must be structured (mode %s)."%self._mode)
+        else: # mode 2
+            for z in Internal.getZones(t):
+                dimz = Internal.getZoneDim(z)
+                if dimz[0] != 'Structured': raise TypeError("Probe: t must be structured (mode %s)."%self._mode)
 
     # examine la localisation des champs
     # IN: fields
@@ -135,10 +141,10 @@ class Probe:
             vs = v.split(':')
             if len(vs) == 2 and vs[0] == 'centers':
                 if loc is None: loc = 'centers'
-                elif loc != 'centers': raise ValueError("probe: fields must have the same loc.")
+                elif loc != 'centers': raise ValueError("Probe: fields must have the same loc.")
             else:
                 if loc is None: loc = 'nodes'
-                elif loc != 'nodes': raise ValueError("probe: fields must have the same loc.")
+                elif loc != 'nodes': raise ValueError("Probe: fields must have the same loc.")
         return loc
 
     # locate probe in t from position X
@@ -227,8 +233,9 @@ class Probe:
 
     # print information on probe
     def printInfo(self):
-        """Print information on probe."""
+        """Print information about a new probe."""
         if Cmpi.rank == 0:
+            print('Info: probe is in mode %s'%self._mode)
             if self._mode == 0 or self._mode == 1:
                 print('Info: probe: position X: ', self._posX, self._posY, self._posZ)
                 print('Info: probe: on block:', self._blockName)
@@ -301,8 +308,13 @@ class Probe:
         return None
 
     # Prepare for mode=3
-    def prepare(self, tc, loc='nodes', cartesian=False, extrap=1, nature=1, penalty=1, verbose=2):
-        tcs = Internal.copyRef(tc)
+    def prepare(self, t, loc='nodes', cartesian=False, extrap=1, nature=1, penalty=1, verbose=2):
+        """Prepare the interpolation data for probe extraction in mode 3."""
+        for z in Internal.getZones(t):
+            dimz = Internal.getZoneDim(z)
+            if dimz[0] != 'Structured': raise TypeError("Probe: donor tree (t) must be structured (mode %s)."%self._mode)
+
+        tcs = Internal.copyRef(t)
         Xmpi._setInterpData2(self._ts, tcs, loc=loc, cartesian=cartesian, extrap=extrap, nature=nature, penalty=penalty, verbose=verbose)
         return tcs
 
@@ -443,10 +455,10 @@ class Probe:
                 v = vs[1]
             cont = Internal.getNodeFromName1(block, contName)
             if cont is None:
-                raise ValueError("probe: can not find solution container in t.")
+                raise ValueError("Probe: cannot find solution container in t.")
             var = Internal.getNodeFromName1(cont, v)
             if var is None:
-                raise ValueError("probe: can not find field %s in t."%v)
+                raise ValueError("Probe: cannot find field %s in t."%v)
             self._fields.append(v)
         return None
 
@@ -456,8 +468,11 @@ class Probe:
     # IN: _ind: index of probe (static)
     # IN: _fields: nom des champs a extraire
     # si onlyTransfer=True, les champs ne sont pas stockes dans la probe
-    def extract(self, t, time, onlyTransfer=False, list_vals=[]):
-        """Extract XYZ or Ind fields from t."""
+    def extract(self, t=None, time=0, value=[], onlyTransfer=False):
+        """Extract probe information."""
+
+        if t is None and self._mode != 4:
+            raise ValueError("Probe: missing PyTree argument (t) for extract with mode %s"%self._mode)
 
         if self._mode == 0 or self._mode == 1: # single point
             self.extract1(t, time)
@@ -470,7 +485,7 @@ class Probe:
             self.extract3(t, time, onlyTransfer)
 
         elif self._mode == 4: # store values that are given
-            self.extract4(t, time, list_vals)
+            self.extract4(time, value)
         return None
 
     def extract1(self, t, time):
@@ -632,7 +647,7 @@ class Probe:
 
         return None
 
-    def extract4(self, t, time,list_vals):
+    def extract4(self, time, value):
         """Extract for mode=4."""
         # time is in "time" of probe zone
         pzone = self._probeZones[0]
@@ -640,7 +655,7 @@ class Probe:
         pt[self._icur] = time
         for c,v in enumerate(self._fields):
             pf = Internal.getNodeFromName2(pzone, v)[1]
-            pf[self._icur] = list_vals[c]
+            pf[self._icur] = value[c]
         self._icur += 1
         if self._icur >= self._bsize: self.flush()
         return None
@@ -688,7 +703,7 @@ class Probe:
     # IN: _probeZones: zone de la probe
     # IN: _fileName: nom du fichier
     def flush(self):
-        """Flush probe to file."""
+        """Flush buffered data to probe file."""
         if self._mode == 0 or self._mode == 1:
             if Cmpi.rank != self._proc: return None
             print('Info: probe: flush #%d [%s].'%(self._filecur, self._fileName))
@@ -753,13 +768,19 @@ class Probe:
     # IN: cont: container a extraire -> all points
     # IN: index: point a extraire -> all times
     def read(self, cont=None, ind=None, probeName=None):
-        """Reread all data from probe file."""
+        """Read data from existing probe file."""
         if cont is not None:
+            if ind is not None: 
+                print('Warning: Probe (read): both cont and ind arguments were provided. Only cont argument is considered.')
             return self.readCont(cont)
         elif ind is not None:
+            if probeName is None: 
+                print('Warning: Probe (read): no probeName argument was provided with index value(s). Reading the first probe zone by default.')
+                probeName = 0
             return self.readInd(ind, probeName)
         else:
-            return self.readInd(0, probeName)
+            print('Warning: Probe (read): no ind or cont arguments provided. Reading the first point of the first probe zone by default.')
+            return self.readInd(0, 0)
 
     # Retourne tous les indices de tous les blocs d'un seul instant
     def readCont(self, cont):
@@ -773,21 +794,21 @@ class Probe:
         for z in zones:
             paths = []
             isGC = False; isFS = False; isFC = False
-            if Internal.getNodeFromName1(z, 'GridCoordinates') is not None:
+            
+            if Internal.getNodeFromName1(z, 'GridCoordinates#0') is not None:
                 isGC = True
                 paths += ['CGNSTree/Base/%s/GridCoordinates#%d'%(z[0], cont)]
-            if Internal.getNodeFromName1(z, 'FlowSolution') is not None:
+            if Internal.getNodeFromName1(z, 'FlowSolution#0') is not None:
                 isFS = True
                 paths += ['CGNSTree/Base/%s/FlowSolution#%d'%(z[0], cont)]
-            if Internal.getNodeFromName1(z, 'FlowSolution#Centers') is not None:
+            if Internal.getNodeFromName1(z, 'FlowSolution#Centers#0') is not None:
                 isFC = True
                 paths += ['CGNSTree/Base/%s/FlowSolution#Centers#%d'%(z[0], cont)]
             nodes2 = Distributed.readNodesFromPaths(self._fileName, paths)
 
             dimz = Internal.getZoneDim(z)
             nrec = dimz[1]; ni = dimz[2]; nj = dimz[3]
-            if self.getFieldLoc(self._fields) == 'centers': # attention!
-                nrec = nrec-1
+            if isFC: nrec = nrec-1 # if data is stored at the centers
             if nj == 1: zsize = [[ni,ni-1,0]]
             else: zsize = [[ni,ni-1,0],[nj,nj-1,0]]
             for nr in range(nrec):
@@ -831,39 +852,57 @@ class Probe:
         return out
 
     # Retourne tous les temps d'un seul indice d'un bloc
-    def readInd(self, ind=None, probeName=None):
+    def readInd(self, ind, probeName):
         tl = Cmpi.convertFile2SkeletonTree(self._fileName)
 
         # Recupere la probe a recuperer
         zones = Internal.getZones(tl)
-        if probeName is not None:
-            if isinstance(probeName, int): pz = zones[probeName]
-            else: pz = Internal.getNodeFromName2(tl, probeName)
-        else: pz = zones[0]
+        if isinstance(probeName, int): pz = zones[probeName]
+        else: pz = Internal.getNodeFromName2(tl, probeName)
         dim = Internal.getZoneDim(pz)
         sizeNPts = dim[2]
 
-        if ind is not None:
-            if isinstance(ind, int): ind = [ind]
-            sizeNPts = min(len(ind), sizeNPts)
+        if isinstance(ind, int) or isinstance(ind, tuple): ind = [ind]
+        sizeNPts = min(len(ind), sizeNPts)
 
         # recupere le sizeTime (nbre d'instants dans le fichier)
-        nodes = Internal.getNodesFromName(pz, 'FlowSolution#*')
-        ncont = len(nodes) # nbre de containers pleins
-        paths = ['CGNSTree/Base/%s/FlowSolution'%pz[0]]
+        isFC = False
+        if Internal.getNodeFromName1(pz, 'FlowSolution#Centers#0') is not None: isFC = True
+        ncont = 0 # nbre de containers pleins
+        while Internal.getNodeFromName1(pz, 'FlowSolution#%s'%ncont) is not None: ncont += 1
+
+        ##################################################################################################
+        # The following are meant to replicate previous (wrong) behaviors.
+        # To be deleted in a future commit
+        ##################################################################################################
+        isFC = False
+        ncont2 = 0
+        while Internal.getNodeFromName1(pz, 'FlowSolution#Centers#%s'%ncont2) is not None: ncont2 += 1
+        if Internal.getNodeFromName1(pz, Internal.__FlowSolutionCenters__) is not None: ncont2 += 1
+        ncont += ncont2
+        ##################################################################################################
+
+        paths = ['CGNSTree/Base/%s/%s'%(pz[0], Internal.__FlowSolutionNodes__)]
         nodesTime = Distributed.readNodesFromPaths(self._fileName, paths)
         pt = Internal.getNodeFromName1(nodesTime[0], 'time')[1]
         if pt.ndim == 2: pt = pt[:,0]
         elif pt.ndim == 3: pt = pt[:,0,0]
-        a = pt > -0.5
-        csize = numpy.count_nonzero(a)
+        csize = numpy.count_nonzero(pt > -0.5)
         sizeTimeCont = pt.shape[0]
-        sizeTime = csize + ncont*sizeTimeCont
-        #print('sizeTime', sizeTime)
-        #print('sizeNPts', sizeNPts)
-        #print('sizeTimeCont', sizeTimeCont)
-        #print('ncont', ncont)
-        #print('csize', csize)
+        if isFC: sizeTimeCont -= 1 # if data is stored at the centers
+        sizeTime = csize + ncont*sizeTimeCont # +1 to take into account template cont
+        sizeArray = (sizeTime) if sizeNPts == 1 else (sizeTime,sizeNPts)
+        # print('sizeTime', sizeTime)
+        # print('sizeNPts', sizeNPts)
+        # print('sizeTimeCont', sizeTimeCont)
+        # print('ncont', ncont)
+        # print('csize', csize)
+
+        ##################################################################################################
+        # same.
+        ##################################################################################################
+        ncont -= ncont2
+        ##################################################################################################
 
         # Rebuild full 1D zone (time only)
         out = G.cart((0,0,0), (1,1,1), (sizeTime,sizeNPts,1))
@@ -874,62 +913,81 @@ class Probe:
         fcont = Internal.createUniqueChild(out, 'FlowSolution', 'FlowSolution_t')
 
         # load GCs
-        nodes = Internal.getNodesFromName(pz, 'GridCoordinates#*')
         cur = 0
+        nodes = [Internal.getNodeFromName(pz, 'GridCoordinates#%s'%i) for i in range(ncont)]
         for n in nodes:
             paths = ['CGNSTree/Base/%s/%s'%(pz[0],n[0])]
             nodesX = Distributed.readNodesFromPaths(self._fileName, paths)[0]
             ptx2 = Internal.getNodeFromName2(nodesX, 'CoordinateX')[1]
             pty2 = Internal.getNodeFromName2(nodesX, 'CoordinateY')[1]
             ptz2 = Internal.getNodeFromName2(nodesX, 'CoordinateZ')[1]
-            self.slice(ptx, ptx2, cur, sizeTimeCont, ind, dim[2])
-            self.slice(pty, pty2, cur, sizeTimeCont, ind, dim[2])
-            self.slice(ptz, ptz2, cur, sizeTimeCont, ind, dim[2])
+            self.slice__(ptx, ptx2, cur, sizeTimeCont, ind, dim[2])
+            self.slice__(pty, pty2, cur, sizeTimeCont, ind, dim[2])
+            self.slice__(ptz, ptz2, cur, sizeTimeCont, ind, dim[2])
             cur += sizeTimeCont
 
-        paths = ['CGNSTree/Base/%s/GridCoordinates'%pz[0]]
+        paths = ['CGNSTree/Base/%s/%s'%(pz[0], Internal.__GridCoordinates__)]
         nodesX = Distributed.readNodesFromPaths(self._fileName, paths)[0]
         ptx2 = Internal.getNodeFromName2(nodesX, 'CoordinateX')[1]
         pty2 = Internal.getNodeFromName2(nodesX, 'CoordinateY')[1]
         ptz2 = Internal.getNodeFromName2(nodesX, 'CoordinateZ')[1]
-        self.slice(ptx, ptx2, cur, csize, ind, dim[2])
-        self.slice(pty, pty2, cur, csize, ind, dim[2])
-        self.slice(ptz, ptz2, cur, csize, ind, dim[2])
+        self.slice__(ptx, ptx2, cur, csize, ind, dim[2])
+        self.slice__(pty, pty2, cur, csize, ind, dim[2])
+        self.slice__(ptz, ptz2, cur, csize, ind, dim[2])
 
-        # load FS containers
+        # load FSs
         cur = 0
-        nodes = Internal.getNodesFromName(pz, 'FlowSolution#*')
+        nodes = [Internal.getNodeFromName(pz, 'FlowSolution#%s'%i) for i in range(ncont)]
         for n in nodes:
-            if "Center" in n[0]: continue
             paths = ['CGNSTree/Base/%s/%s'%(pz[0],n[0])]
             nodesF = Distributed.readNodesFromPaths(self._fileName, paths)[0]
             for i in nodesF[2]:
                 if i[3] == 'DataArray_t':
-                    pf = Internal.getNodeFromName2(fcont, i[0])
-                    if pf is None:
-                        if sizeNPts == 1:
-                            pf = Internal.newDataArray(i[0], value=numpy.zeros( (sizeTime), dtype=numpy.float64, order='F'), parent=fcont)
-                        else:
-                            pf = Internal.newDataArray(i[0], value=numpy.zeros( (sizeTime,sizeNPts), dtype=numpy.float64, order='F'), parent=fcont)
-                    pf = pf[1]
-                    self.slice(pf, i[1], cur, sizeTimeCont, ind, dim[2])
+                    varname, ptf2 = i[0], i[1]
+                    pf = Internal.getNodeFromName2(fcont, varname)
+                    if pf is None: pf = Internal.newDataArray(varname, value=numpy.zeros(sizeArray, dtype=numpy.float64, order='F'), parent=fcont)
+                    ptf = pf[1]
+                    self.slice__(ptf, ptf2, cur, sizeTimeCont, ind, dim[2])
             cur += sizeTimeCont
 
-        paths = ['CGNSTree/Base/%s/FlowSolution'%pz[0]]
+        paths = ['CGNSTree/Base/%s/%s'%(pz[0], Internal.__FlowSolutionNodes__)]
         nodesF = Distributed.readNodesFromPaths(self._fileName, paths)[0]
         for i in nodesF[2]:
             if i[3] == 'DataArray_t':
-                pf = Internal.getNodeFromName2(fcont, i[0])[1]
-                self.slice(pf, i[1], cur, csize, ind, dim[2])
+                varname, ptf2 = i[0], i[1]
+                ptf = Internal.getNodeFromName2(fcont, varname)[1]
+                self.slice__(ptf, ptf2, cur, csize, ind, dim[2])
+
+        # load FCs (if any)
+        if isFC:
+            cur = 0
+            nodes = [Internal.getNodeFromName(pz, 'FlowSolution#Centers#%s'%i) for i in range(ncont)]
+            for n in nodes:
+                paths = ['CGNSTree/Base/%s/%s'%(pz[0],n[0])]
+                nodesF = Distributed.readNodesFromPaths(self._fileName, paths)[0]
+                for i in nodesF[2]:
+                    if i[3] == 'DataArray_t':
+                        varname, ptf2 = i[0], i[1]
+                        pf = Internal.getNodeFromName2(fcont, varname)
+                        if pf is None: pf = Internal.newDataArray(varname, value=numpy.zeros(sizeArray, dtype=numpy.float64, order='F'), parent=fcont)
+                        ptf = pf[1]
+                        self.slice__(ptf, ptf2, cur, sizeTimeCont, ind, dim[2])
+                cur += sizeTimeCont
+
+            paths = ['CGNSTree/Base/%s/%s'%(pz[0], Internal.__FlowSolutionCenters__)]
+            nodesF = Distributed.readNodesFromPaths(self._fileName, paths)[0]
+            for i in nodesF[2]:
+                if i[3] == 'DataArray_t':
+                    varname, ptf2 = i[0], i[1]
+                    ptf = Internal.getNodeFromName2(fcont, varname)[1]
+                    self.slice__(ptf, ptf2, cur, csize, ind, dim[2])
+
         return out
 
     # slice from ptx2 a list of indices
-    def slice(self, ptx, ptx2, start, size, ind, ni):
+    def slice__(self, ptx, ptx2, start, size, ind, ni):
         if ptx2.ndim == 1:
             ptx[start:start+size] = ptx2[0:size]
-        elif ind is None: # take all
-            if ptx2.ndim == 2: ptx[start:start+size,:] = ptx2[0:size,:]
-            else: raise ValueError('not implemented')
         elif len(ind) == 1:
             i = ind[0]
             if ptx2.ndim == 2: ptx[start:start+size] = ptx2[0:size,i]

--- a/Cassiopee/Post/doc/install
+++ b/Cassiopee/Post/doc/install
@@ -66,6 +66,8 @@ then
     [ $? != 0 ] && exit 1;
     pdflatex ExtraVariables2
     [ $? != 0 ] && exit 1;
+    pdflatex Probe
+    [ $? != 0 ] && exit 1;
     pdflatex Post_IBM
     [ $? != 0 ] && exit 1;
     cd ..
@@ -87,6 +89,11 @@ then
     sed -i 's/Post\.pdf/ExtraVariables2\.pdf/g' build/ExtraVariables2.html
     cp build/ExtraVariables2.html $DEST
     cp build/ExtraVariables2.pdf $DEST
+
+    sed -i 's/Post.Probe.Post.Probe/Post.Probe/g' build/Probe.html
+    sed -i 's/Post\.pdf/Probe\.pdf/g' build/Probe.html
+    cp build/Probe.html $DEST
+    cp build/Probe.pdf $DEST
 
     sed -i 's/Post.Post_IBM.Post.Post_IBM/Post.Post_IBM/g' build/Post_IBM.html
     sed -i 's/Post\.pdf/Post_IBM\.pdf/g' build/Post_IBM.html

--- a/Cassiopee/Post/doc/source/Post.rst
+++ b/Cassiopee/Post/doc/source/Post.rst
@@ -84,11 +84,6 @@ List of functions
     Post.zipper
     Post.usurp
 
-    Post.Probe.Probe
-    Post.Probe.Probe.extract
-    Post.Probe.Probe.flush
-    Post.Probe.Probe.read
-
 **-- Streams/Isos**
 
 .. autosummary::
@@ -1088,87 +1083,6 @@ Solution extraction
 
     .. literalinclude:: ../build/Examples/Post/usurpPT.py
 
-
-
----------------------------------------
-
-.. py:function:: Post.Probe.Probe(fileName, t=None, X=(x,y,z), ind=None, blockName=None, tPermeable=None, fields=None, append=True, bufferSize=100)
-
-    Create a probe. 4 modes are possible :
-    
-    * mode 0 : if t and (x,y,z) are provided, the probe will extract given fields from t at single position (x,y,z).
-    
-    * mode 1 : if t and (ind, blockName) are provided, the probe will extract given fields from block of t at single index ind of blockName.
-
-    * mode 2 : if t, (x,y,z) and ind are not provided, the probe will store the zones given at extract.
-
-    * mode 3 : if tPermeable is provided, the probe will interpolate on tPermeable.
-
-    Result is periodically flush to file when buffer size exceeds bufferSize.
-
-
-    :param fileName: name of file to dump to
-    :type fileName: string
-    :param t: pyTree containing solution
-    :type t: pyTree
-    :param (x,y,z): position of single probe (mode 0) 
-    :type  (x,y,z): tuple of 3 floats
-    :param ind: index of single probe in blockName (mode 1)
-    :type ind: integer
-    :param blockName: name of block containing probe (mode 1)
-    :type blockName: string
-    :param tPermeable: surface to interpolate to.
-    :type tPermeable: pyTree, zone or list of zones
-    :param fields: list of fields to extract
-    :type fields: list of strings or None 
-    :param append: if True, append result to existing file
-    :type append: Boolean
-    :param bufferSize: size of internal buffer
-    :type bufferSize: int
-    
-    :rtype: probe instance
-
-    *Example of use:*
-
-    * `Probe extraction (pyTree) <Examples/Post/probePT.py>`_:
-
-    .. literalinclude:: ../build/Examples/Post/probePT.py
-
----------------------------------------
-
-.. py:function:: Post.Probe.Probe.extract(t, time=0.)
-
-    Extract probe at given time from t.
-
-    :param t: pyTree containing solution
-    :type t: pyTree
-    :param time: extraction time
-    :type time: float
-    
----------------------------------------
-
-.. py:function:: Post.Probe.Probe.flush()
-
-    Force probe flush to disk.
-
----------------------------------------
-
-
-.. py:function:: Post.Probe.Probe.read(cont=None, ind=None, probeName=None)
-
-    Read all data stored in probe file and return a zone. 
-    Can be used in two ways:
-
-    * cont: extract the given time container (all probe points)
-
-    * ind, probeName: extract the given index, zone (all times)
-
-    :param cont: number of time container
-    :type cont: integer
-    :param ind: index to extract
-    :type ind: integer
-    :param probeName: name of probe zone to extract
-    :type probeName: string
 
 ---------------------------------------
 

--- a/Cassiopee/Post/doc/source/Probe.rst
+++ b/Cassiopee/Post/doc/source/Probe.rst
@@ -1,0 +1,260 @@
+for i in range(ncont).. Probe documentation master file
+
+:tocdepth: 2
+
+
+Post.Probe: Probe extraction
+===========================================================
+
+Specific probe extraction module.
+
+This page describes how the object-oriented Probe module operates. The various methods presented below should be used after instantiating a Probe object of the same-named class. 
+
+All of these methods and functions can be executed in both sequential and parallel contexts.
+
+.. py:module:: Post.Probe
+
+List of functions
+#################
+
+
+**-- Probe creation**
+
+.. autosummary::
+    :nosignatures:
+
+    Post.Probe.Probe
+
+**-- Probe methods**
+
+.. autosummary::
+    :nosignatures:
+
+    Probe.printInfo
+    Probe.prepare
+    Probe.extract
+    Probe.flush
+    Probe.read
+
+Contents
+########
+
+Probe creation
+---------------------------------------------------------------------------
+
+.. py:function:: Post.Probe.Probe(fileName, t=None, X=None, ind=None, blockName=None, tPermeable=None, fields=None, append=False, bufferSize=100)
+
+    Create a Python object from the Probe class. Five modes are possible:
+    
+    + **mode 0**: if t and X are provided, the probe will extract the fields from t at the absolute position X=(x,y,z).
+    + **mode 1**: if t and (ind, blockName) are provided, the probe will extract the fields from t at the given index of the specified block.
+    + **mode 2**: if t is provided without a specific location (index or position), the probe will store all zones of t with both coordinates and fields. t must be 1D or 2D.
+    + **mode 3**: if t and tPermeable are provided, the probe will interpolate the fields on tPermeable using t as the donor tree. tPermeable must be 1D or 2D.
+    + **mode 4**: if t is not provided, the probe will simply store specified values over time.
+
+    Data are periodically flushed to probe file when the buffer size exceeds the user input bufferSize.
+
+    For Probe objects in modes 0, 1, or 4, all data are stored in 1D numpy arrays of size bufferSize.
+
+    For Probe objects in modes 2 or 3, the data are stored in 2D/3D numpy arrays of size (bufferSize,ni,nj) where (ni,nj) are the original dimensions of the receiver tree zones (t for mode 2 or tPermeable for mode 3).
+
+    .. note:: Modes 2 and 3 only operates with structured meshes.
+
+    :param fileName: name of the probe file
+    :type fileName: string
+    :param t: pyTree containing the flow solution
+    :type t: pyTree
+    :param X: absolute position of a single probe (mode 0 only) 
+    :type  X: tuple of 3 floats (x,y,z)
+    :param ind: index of a single probe located in blockName (mode 1 only)
+    :type ind: integer or tuple of 3 integers (i,j,k)
+    :param blockName: name of the block containing the probe index (mode 1 only)
+    :type blockName: string
+    :param tPermeable: interpolated tree (mode 3 only)
+    :type tPermeable: pyTree, zone or list of zones
+    :param fields: list of fields to extract (located at the mesh nodes OR the mesh centers)
+    :type fields: list of strings 
+    :param append: if True, append result to existing file
+    :type append: Boolean
+    :param bufferSize: size of internal buffer
+    :type bufferSize: int
+    
+    :rtype: probe instance
+
+    *Example of use:*
+
+    * `Probe - mode 0 (pyTree) <Examples/Post/probeMode0PT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Post/probeMode0PT.py
+
+    * `Probe - mode 1 (pyTree) <Examples/Post/probeMode1PT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Post/probeMode1PT.py
+
+    * `Probe - mode 2 (pyTree) <Examples/Post/probeMode2PT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Post/probeMode2PT.py
+
+    * `Probe - mode 3 (pyTree) <Examples/Post/probeMode3PT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Post/probeMode3PT.py
+
+    * `Probe - mode 4 (pyTree) <Examples/Post/probeMode4PT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Post/probeMode4PT.py
+
+---------------------------------------
+
+Probe methods
+---------------------------------------------------------------------------
+
+.. py:function:: Probe.printInfo()
+
+    **printInfo** is a method of the Probe class.
+
+    Print all the information about a probe object.
+
+    *Example of use:*
+
+    * `Print information about a given probe (pyTree) <Examples/Post/probePrintInfoPT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Post/probePrintInfoPT.py
+
+---------------------------------------
+
+.. py:function:: Probe.prepare(t, loc='nodes', extrap=1, nature=1, penalty=1, verbose=2)
+
+    **prepare** is a method of the Probe class.
+
+    Only for mode 3. Prepare the interpolation data for probe extraction from a donor computational tree to a 1D or 2D receiver mesh.
+
+    The arguments are mostly the same as those for Connector.setInterpData2(). Donor tree flow fields must be located at the nodes. Receiver tree flow fields can be located at the nodes (loc='nodes') or at the centers (loc='centers').
+
+    If the cellN field (cell nature field) is not found in the donor tree, the function assumes that all cells are computed cells (cellN = 1). Similarly, if the cellN field is not found in the receiver tree, the function assumes that all cells are interpolated cells (cellN = 2).
+
+    extrap options:
+
+    + **0**: extrapolation is disabled. Extrapolated cells are flagged as orphans.
+    + **1**: extrapolation is enabled.
+
+    nature options:
+
+    + **0**: candidate donors can be everything but blanked cells (cellN = 0).
+    + **1**: candidate donors can only be computed cells (cellN = 1).
+
+    penalty options: 
+
+    + **0**: all candidates have the same weight.
+    + **1**: donor cell candidates located at a zone border are penalized against interior cells.
+
+    verbose options:
+
+    + **0**: no information is printed.
+    + **1**: print only the summary of the interpolation data search.
+    + **2**: print the summary and indices of the orphan points (if any).
+
+    :param t: pyTree containing the flow solution
+    :type t: pyTree
+    :param loc: extraction location
+    :type loc: string ('centers' or 'nodes')
+    :param extrap: extrapolation parameter
+    :type extrap: integer (0 or 1)
+    :param nature: donor cell nature parameter 
+    :type nature: integer (0 or 1)
+    :param penalty: penalization parameter
+    :type penalty: integer (0 or 1)
+    :param verbose: print parameter
+    :type verbose: integer (0, 1, or 2)
+
+    *Example of use:*
+
+    * `Probe (mode 3) prepare operation for receiver flow fields located at centers (pyTree) <Examples/Post/probePrepareCenterPT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Post/probePrepareCenterPT.py
+
+    * `Probe (mode 3) prepare operation for receiver flow fields located at nodes (pyTree) <Examples/Post/probePrepareNodePT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Post/probePrepareNodePT.py
+
+---------------------------------------
+
+.. py:function:: Probe.extract(t=None, time=-1., value=[], onlyTransfer=False)
+
+    **extract** is a method of the Probe class.
+
+    Extract the probe information (coordinates and field) at a given time from t.
+
+    Flow solution and grid coordinate extractions from the donor tree t are based on the information located in the Internal.__FlowSolutionNodes__, Internal.__FlowSolutionCenters, and Internal.__FlowSolutionCenters__ containers. Users can modify these container names by editing the constant names in the Internal module. New containers are created each time the local buffer size exceeds the bufferSize limits specified by the user.
+
+    Probe information data is then stored in the following fixed container names: GridCoordinates#i, FlowSolution#i, and FlowSolution#Centers#i, where i is an iterator that is automatically set and handled by the Probe class.
+
+    To extract the receiver tree interpolated data at a given time without stacking the information (coordinates and field) in the probe, set onlyTransfer to True for mode 3. This option is useful when users only want to monitor integral quantities instead of monitoring all solution fields over time.
+
+    :param t: pyTree containing the flow solution
+    :type t: pyTree
+    :param time: extraction time
+    :type time: float
+    :param value: list of values to be stored in probe (only for mode 4)
+    :type value: list of floats
+    :param onlyTransfer: deactivate information stacking in the probe object (only for mode 3)
+    :type onlyTransfer: boolean
+
+    *Example of use:*
+
+    .. note:: for simpler examples of each mode, see the Post.Probe.Probe function definition.
+
+    * `Probe extraction using both mode 3 and mode 4 to monitor integral quantities (pyTree) <Examples/Post/probeExtractPT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Post/probeExtractPT.py
+    
+---------------------------------------
+
+.. py:function:: Probe.flush()
+
+    **flush** is a method of the Probe class.
+
+    Force buffered data to be written in the associated probe file before reaching the user input bufferSize limit.
+
+    *Example of use:*
+
+    * `Flush unsaved probe data to disk. (pyTree) <Examples/Post/probeFlushPT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Post/probeFlushPT.py
+
+---------------------------------------
+
+.. py:function:: Probe.read(cont=None, ind=None, probeName=None)
+
+    Read the data stored in the probe file and return either a zone or a list of zones.
+
+    The Probe object must already be instantiated with the desired probe file name. Otherwise, use Post.Probe.Probe(fileName) to create a new probe object from an existing probe file for reading purposes only.
+
+    Can be used in two ways:
+
+    + **extract all points**: if cont is provided, this function extracts all data from the given time container. 
+    + **extract all times**: if ind and probeName are provided, this function now extracts the given index value(s) of the given zone at all times.
+
+    If ind is provided but probeName is not, the function will automatically selects the first zone in the probe.
+
+    When extracting all points, the output is a list of zones. Each zone corresponds to a probe zone at a single time included in the loaded container.
+
+    When extracting all times, the output is a single zone. This zone contains numpy arrays of size (ntime,npoints) depending on the number of point indices provided.
+
+    .. note:: For modes 0, 1, and 4, probes consist of only one zone named 'probe'. For modes 2 and 3, probes contain the same number of zones as the original tree (t for mode 2 or tPermeable for mode 3).
+
+    :param cont: time container number
+    :type cont: integer
+    :param ind: index (or indices) of probe point(s) located in probeName
+    :type ind: integer, tuple of 3 integers (i,j,k), list of integers, or list of tuples of 3 integers [(i1,j1,k1), (i2,j2,k2), ...]
+    :param probeName: only used when ind is provided. Name or number of the probe zone to extract
+    :type probeName: string or int
+
+    :rtype: zone or list of zones
+
+    *Example of use:*
+
+    * `Read data from probe file. (pyTree) <Examples/Post/probeReadPT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Post/probeReadPT.py
+
+---------------------------------------

--- a/Cassiopee/Post/doc/source/Probe.rst
+++ b/Cassiopee/Post/doc/source/Probe.rst
@@ -1,4 +1,4 @@
-for i in range(ncont).. Probe documentation master file
+.. Probe documentation master file
 
 :tocdepth: 2
 

--- a/Cassiopee/Post/doc/source/conf.py
+++ b/Cassiopee/Post/doc/source/conf.py
@@ -221,6 +221,8 @@ latex_documents = [
         u'/ELSA/MU-10019/V'+__version__, 'manual'),
     ('Rotor', 'Rotor.tex', u'Post.Rotor Documentation',
         u'/ELSA/MU-10019/V'+__version__, 'manual'),
+    ('Probe', 'Probe.tex', u'Post.Probe Documentation',
+        u'/ELSA/MU-10019/V'+__version__, 'manual'),
     ('Post_IBM', 'Post_IBM.tex', u'Post.IBM Documentation',
         u'/ELSA/MU-10019/V'+__version__, 'manual'),
 ]

--- a/Cassiopee/Post/test/probeExtractPT.py
+++ b/Cassiopee/Post/test/probeExtractPT.py
@@ -1,0 +1,47 @@
+# - Probe extract (pyTree) -
+import Post.Probe as Probe
+import Converter.Internal as Internal
+import Converter.PyTree as C
+import Generator.PyTree as G
+import Post.PyTree as P
+
+# test case
+a = G.cart((0,0,0), (0.1,0.1,0.1), (51,11,11))
+t = C.newPyTree(['Base', a])
+C._initVars(t, '{Density} = 1.')
+C._initVars(t, '{VelocityX} = {CoordinateX}-1')
+C._initVars(t, '{VelocityY} = {CoordinateY}-1')
+C._initVars(t, '{VelocityZ} = {CoordinateZ}-1')
+
+b1 = G.cart((0,0,0), (0.,0.1,0.1), (1,11,11)); b1[0] = 'upstream'
+b2 = G.cart((5,0,0), (0.,0.1,0.1), (1,11,11)); b2[0] = 'downstream'
+tR = C.newPyTree(['Base', [b1,b2]])
+G._getSmoothNormalMap(tR)
+
+tD = Internal.copyRef(t)
+
+# create a first probe using mode 3
+fields = ['Density', 'VelocityX', 'VelocityY', 'VelocityZ']
+p3 = Probe.Probe('probe3.cgns', tPermeable=tR, fields=fields, append=False, bufferSize=100)
+tD = p3.prepare(tD, loc='nodes')
+
+# create a second probe using mode 4
+p4 = Probe.Probe('probe4.cgns', fields=['massflow_upstream', 'massflow_downstream'], bufferSize=100, append=False)
+
+# extract flow information on the receiver surface tree
+for varname in fields: C._cpVars(t, varname , tD, varname)
+p3.extract(tD, onlyTransfer=True)
+
+# tR interpolated data are now updated: integral quantities can be computed on each surface
+C._initVars(tR, '{massflow}={Density}*({sx}*{VelocityX}+{sy}*{VelocityY}+{sz}*{VelocityZ})')
+
+z_upstream = Internal.getNodeFromName(tR, 'upstream')
+massflow_upstream = P.integ(z_upstream, 'massflow')[0]
+
+z_downstream = Internal.getNodeFromName(tR, 'downstream')
+massflow_downstream = P.integ(z_downstream, 'massflow')[0]
+
+# store data information in the p4 probe using single integrated values
+p4.extract(time=1, value=[massflow_upstream, massflow_downstream])
+
+p4.flush()

--- a/Cassiopee/Post/test/probeFlushPT.py
+++ b/Cassiopee/Post/test/probeFlushPT.py
@@ -5,7 +5,7 @@ import Post.Probe as Probe
 p4 = Probe.Probe('probe4.cgns', fields=['Density', 'Mach'], append=False, bufferSize=100)
 
 for i in range(110):
-    p4.extract(time=i*0.1, value=[i, i*10]) 
+    p4.extract(time=i*0.1, value=[i, i*10])
     # p4 will automatically flushed itself when reaching the buffer size limit (100)
 
 # flush current buffered data to disk to save last extractions

--- a/Cassiopee/Post/test/probeFlushPT.py
+++ b/Cassiopee/Post/test/probeFlushPT.py
@@ -1,0 +1,12 @@
+# - Probe flush (pyTree) -
+import Post.Probe as Probe
+
+# create a probe using mode 4
+p4 = Probe.Probe('probe4.cgns', fields=['Density', 'Mach'], append=False, bufferSize=100)
+
+for i in range(110):
+    p4.extract(time=i*0.1, value=[i, i*10]) 
+    # p4 will automatically flushed itself when reaching the buffer size limit (100)
+
+# flush current buffered data to disk to save last extractions
+p4.flush()

--- a/Cassiopee/Post/test/probeMode0PT.py
+++ b/Cassiopee/Post/test/probeMode0PT.py
@@ -1,0 +1,25 @@
+# - Probe mode 0 (pyTree) -
+import Post.Probe as Probe
+import Converter.PyTree as C
+import Generator.PyTree as G
+
+# test case
+a = G.cartRx((0,0,0), (1,1,1), (30,30,30), (5,5,5))
+t = C.newPyTree(['Base', a])
+C._initVars(t, '{centers:Fx} = {centers:CoordinateX}')
+C._initVars(t, '{centers:Fy} = {centers:CoordinateY}')
+
+# create a probe using mode 0
+fields = ['centers:Fx', 'centers:Fy']
+p0 = Probe.Probe('probe0.cgns', t, X=(10.,10.,10.), fields=fields, append=False, bufferSize=100)
+p0.printInfo()
+
+# extract probe information over time
+for i in range(110):
+    time = 0.1*i
+    C._initVars(t, '{centers:Fx} = {centers:Fx} + cos(%f)'%time, isVectorized=True)
+    C._initVars(t, '{centers:Fy} = {centers:Fx} + sin(%f)'%time, isVectorized=True)
+    p0.extract(t, time=time)
+
+# force probe flush
+p0.flush()

--- a/Cassiopee/Post/test/probeMode1PT.py
+++ b/Cassiopee/Post/test/probeMode1PT.py
@@ -1,0 +1,25 @@
+# - Probe mode 1 (pyTree) -
+import Post.Probe as Probe
+import Converter.PyTree as C
+import Generator.PyTree as G
+
+# test case
+a = G.cartRx((0,0,0), (1,1,1), (30,30,30), (5,5,5))
+t = C.newPyTree(['Base', a])
+C._initVars(t, '{centers:Fx} = {centers:CoordinateX}')
+C._initVars(t, '{centers:Fy} = {centers:CoordinateY}')
+
+# create a probe using mode 1
+fields = ['centers:Fx', 'centers:Fy']
+p1 = Probe.Probe('probe1.cgns', t, ind=(10,10,10), blockName='cart1-1-1', fields=fields, append=False, bufferSize=100)
+p1.printInfo()
+
+# extract probe information over time
+for i in range(110):
+    time = 0.1*i
+    C._initVars(t, '{centers:Fx} = {centers:Fx} + cos(%f)'%time, isVectorized=True)
+    C._initVars(t, '{centers:Fy} = {centers:Fx} + sin(%f)'%time, isVectorized=True)
+    p1.extract(t, time=time)
+
+# force probe flush
+p1.flush()

--- a/Cassiopee/Post/test/probeMode2PT.py
+++ b/Cassiopee/Post/test/probeMode2PT.py
@@ -1,0 +1,27 @@
+# - Probe mode 2 (pyTree) -
+import Post.Probe as Probe
+import Converter.PyTree as C
+import Transform.PyTree as T
+import Geom.PyTree as D
+
+# test case
+b = D.cylinder((50,50,50), 10., 40., N=50, ntype='STRUCT')
+tR = C.newPyTree(['Base', b])
+C._initVars(tR, '{centers:Fx} = {centers:CoordinateX}')
+C._initVars(tR, '{centers:Fy} = {centers:CoordinateY}')
+
+# create a probe using mode 2
+fields = ['centers:Fx', 'centers:Fy']
+p2 = Probe.Probe('probe2.cgns', tR, fields=fields, append=False, bufferSize=100)
+p2.printInfo()
+
+# extract probe information over time
+for i in range(110):
+    time = 0.1*i
+    T._rotate(tR, (50.,50.,50.), (0.,0.,1.), 0.1)
+    C._initVars(tR, '{centers:Fx} = {centers:CoordinateX}')
+    C._initVars(tR, '{centers:Fy} = {centers:CoordinateY}')
+    p2.extract(tR, time=time)
+
+# force probe flush
+p2.flush()

--- a/Cassiopee/Post/test/probeMode3PT.py
+++ b/Cassiopee/Post/test/probeMode3PT.py
@@ -1,0 +1,36 @@
+# - Probe mode 3 (pyTree) -
+import Post.Probe as Probe
+import Converter.Internal as Internal
+import Converter.PyTree as C
+import Generator.PyTree as G
+import Geom.PyTree as D
+
+# test case
+a = G.cartRx((0,0,0), (1,1,1), (30,30,30), (5,5,5))
+t = C.newPyTree(['Base', a])
+C._initVars(t, '{centers:Fx} = {centers:CoordinateX}')
+C._initVars(t, '{centers:Fy} = {centers:CoordinateY}')
+
+b = D.cylinder((50,50,50), 10., 40., N=50, ntype='STRUCT')
+tR = C.newPyTree(['Base', b]) # receiver surface tree storing the interpolated flow variable data
+
+tD = Internal.copyRef(t) # donor tree storing the interpolation data (interpolation coefficients)
+
+# create a probe using mode 3
+fields = ['centers:Fx', 'centers:Fy']
+p3 = Probe.Probe('probe3.cgns', tPermeable=tR, fields=fields, append=False, bufferSize=100)
+
+# compute the interpolation data for probe extraction (mode 3 only)
+tD = p3.prepare(tD, loc='centers')
+
+# extract probe information over time
+for i in range(110):
+    time = 0.1*i
+    C._initVars(t, '{centers:Fx} = {centers:Fx} + cos(%f)'%time, isVectorized=True)
+    C._initVars(t, '{centers:Fy} = {centers:Fx} + sin(%f)'%time, isVectorized=True)
+    for varname in fields: C._cpVars(t, varname, tD, varname)
+    tD = C.center2Node(tD, fields) # donor solution is located at the nodes
+    p3.extract(tD, time=time)
+
+# force probe flush
+p3.flush()

--- a/Cassiopee/Post/test/probeMode4PT.py
+++ b/Cassiopee/Post/test/probeMode4PT.py
@@ -1,0 +1,39 @@
+# - Probe mode 4 (pyTree) -
+import Post.Probe as Probe
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+
+import numpy
+
+# test case
+a = G.cartRx((0,0,0), (1,1,1), (30,30,30), (5,5,5))
+t = C.newPyTree(['Base', a])
+C._initVars(t, '{centers:Fx} = {centers:CoordinateX}')
+C._initVars(t, '{centers:Fy} = {centers:CoordinateY}')
+
+# create a probe using mode 4
+p4 = Probe.Probe('probe4.cgns', fields=['minFx', 'maxFx', 'minFy', 'maxFy'], append=False, bufferSize=100)
+p4.printInfo()
+
+# extract probe information over time
+for i in range(110):
+    time = 0.1*i
+    maxFx, minFx = 0., 1.e6
+    maxFy, minFy = 0., 1.e6
+    C._initVars(t, '{centers:Fx} = {centers:Fx} + cos(%f)'%time, isVectorized=True)
+    C._initVars(t, '{centers:Fy} = {centers:Fx} + sin(%f)'%time, isVectorized=True)
+    for z in Internal.getZones(t):
+        Fx = Internal.getNodeFromName(z, 'Fx')[1]
+        Fy = Internal.getNodeFromName(z, 'Fy')[1]
+
+        minFx = min(minFx, numpy.min(Fx))
+        maxFx = max(maxFx, numpy.max(Fx))
+        
+        minFy = min(minFy, numpy.min(Fy))
+        maxFy = max(maxFy, numpy.max(Fy))
+        
+    p4.extract(t, time=time, value=[minFx, maxFx, minFy, maxFy])
+
+# force probe flush
+p4.flush()

--- a/Cassiopee/Post/test/probeMode4PT.py
+++ b/Cassiopee/Post/test/probeMode4PT.py
@@ -29,10 +29,10 @@ for i in range(110):
 
         minFx = min(minFx, numpy.min(Fx))
         maxFx = max(maxFx, numpy.max(Fx))
-        
+
         minFy = min(minFy, numpy.min(Fy))
         maxFy = max(maxFy, numpy.max(Fy))
-        
+
     p4.extract(t, time=time, value=[minFx, maxFx, minFy, maxFy])
 
 # force probe flush

--- a/Cassiopee/Post/test/probePT_m1.py
+++ b/Cassiopee/Post/test/probePT_m1.py
@@ -44,20 +44,19 @@ if Cmpi.rank == 0: test.testT(p2._probeZones, 2)
 Cmpi.barrier()
 
 # create a probe from zones
-p3 = Probe.Probe(LOCAL+'/probe3.cgns', fields=['centers:F'], append=False, bufferSize=15)
+a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
+a[0] = 'cart%d'%Cmpi.rank
+
+p3 = Probe.Probe(LOCAL+'/probe3.cgns', a, fields=['centers:F'], append=False, bufferSize=15)
 for i in range(20):
     time = 0.1*i
-    a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
-    a[0] = 'cart%d'%Cmpi.rank
     C._initVars(a, '{centers:F} = %20.16g'%time)
     p3.extract(a, time=time)
 p3.flush()
 
-p3 = Probe.Probe(LOCAL+'/probe3.cgns', fields=['centers:F'], append=True, bufferSize=15)
+p3 = Probe.Probe(LOCAL+'/probe3.cgns', a, fields=['centers:F'], append=True, bufferSize=15)
 for i in range(20):
     time = 2+0.1*i
-    a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
-    a[0] = 'cart%d'%Cmpi.rank
     C._initVars(a, '{centers:F} = %20.16g'%time)
     p3.extract(a, time=time)
 p3.flush()

--- a/Cassiopee/Post/test/probePT_m4.py
+++ b/Cassiopee/Post/test/probePT_m4.py
@@ -9,21 +9,21 @@ import KCore.test as test
 
 LOCAL = test.getLocal()
 
+# test case
+a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
+a[0] = 'cart%d'%Cmpi.rank
+
 # create a probe from zones
-p3 = Probe.Probe(LOCAL+'/probe3.cgns', fields=['F'], append=False, bufferSize=15)
+p3 = Probe.Probe(LOCAL+'/probe3.cgns', a, fields=['F'], append=False, bufferSize=15)
 for i in range(20):
     time = 0.1*i
-    a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
-    a[0] = 'cart%d'%Cmpi.rank
     C._initVars(a, '{F} = %20.16g'%time)
     p3.extract(a, time=time)
 p3.flush()
 
-p3 = Probe.Probe(LOCAL+'/probe3.cgns', fields=['F'], append=True, bufferSize=15)
+p3 = Probe.Probe(LOCAL+'/probe3.cgns', a, fields=['F'], append=True, bufferSize=15)
 for i in range(20):
     time = 2+0.1*i
-    a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
-    a[0] = 'cart%d'%Cmpi.rank
     C._initVars(a, '{F} = %20.16g'%time)
     p3.extract(a, time=time)
 p3.flush()

--- a/Cassiopee/Post/test/probePT_m5.py
+++ b/Cassiopee/Post/test/probePT_m5.py
@@ -9,21 +9,21 @@ import KCore.test as test
 
 LOCAL = test.getLocal()
 
+# test case
+a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
+a[0] = 'cart%d'%Cmpi.rank
+
 # create a probe from zones
-p3 = Probe.Probe(LOCAL+'/probe3.cgns', fields=['centers:F'], append=False, bufferSize=15)
+p3 = Probe.Probe(LOCAL+'/probe3.cgns', a, fields=['centers:F'], append=False, bufferSize=15)
 for i in range(20):
     time = 0.1*i
-    a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
-    a[0] = 'cart%d'%Cmpi.rank
     C._initVars(a, '{centers:F} = %20.16g'%time)
     p3.extract(a, time=time)
 p3.flush()
 
-p3 = Probe.Probe(LOCAL+'/probe3.cgns', fields=['centers:F'], append=True, bufferSize=15)
+p3 = Probe.Probe(LOCAL+'/probe3.cgns', a, fields=['centers:F'], append=True, bufferSize=15)
 for i in range(20):
     time = 2+0.1*i
-    a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
-    a[0] = 'cart%d'%Cmpi.rank
     C._initVars(a, '{centers:F} = %20.16g'%time)
     p3.extract(a, time=time)
 p3.flush()

--- a/Cassiopee/Post/test/probePT_t1.py
+++ b/Cassiopee/Post/test/probePT_t1.py
@@ -40,18 +40,18 @@ p1.flush()
 test.testT(p1._probeZones, 2)
 
 # create probe from zones
-p1 = Probe.Probe(LOCAL+'/probe3.cgns', fields=['centers:F'], append=False, bufferSize=15)
+a = G.cart((0,0,0), (1,1,1), (5,5,1))
+
+p1 = Probe.Probe(LOCAL+'/probe3.cgns', a, fields=['centers:F'], append=False, bufferSize=15)
 for i in range(20):
     time = 0.1*i
-    a = G.cart((0,0,0), (1,1,1), (5,5,1))
     C._initVars(a, '{centers:F} = %20.16g'%time)
     p1.extract(a, time=time)
 p1.flush()
 
-p1 = Probe.Probe(LOCAL+'/probe3.cgns', fields=['centers:F'], append=True, bufferSize=15)
+p1 = Probe.Probe(LOCAL+'/probe3.cgns', a, fields=['centers:F'], append=True, bufferSize=15)
 for i in range(20):
     time = 2+0.1*i
-    a = G.cart((0,0,0), (1,1,1), (5,5,1))
     C._initVars(a, '{centers:F} = %20.16g'%time)
     p1.extract(a, time=time)
 p1.flush()

--- a/Cassiopee/Post/test/probePT_t3.py
+++ b/Cassiopee/Post/test/probePT_t3.py
@@ -1,4 +1,4 @@
-# - probe (pyTree) -
+# - Probe (pyTree) -
 # Relecture probe mode 2 pour donner un numpy qui concatene toute la solution
 # a tous les instants
 import Converter.PyTree as C
@@ -15,7 +15,7 @@ s = D.sphere((2.5,2.5,2.5), 1.)
 s = T.splitNParts(s, 2)
 
 # Create probe to store surface
-probe = Probe.Probe(LOCAL+'/probe.cgns', t=None, fields=['centers:F'], bufferSize=15)
+probe = Probe.Probe(LOCAL+'/probe.cgns', s, fields=['centers:F'], bufferSize=15)
 
 # Extractions
 for i in range(40):
@@ -25,7 +25,7 @@ for i in range(40):
 probe.flush()
 
 # Relecture par containers
-p2 = Probe.Probe(LOCAL+'/probe.cgns', fields=['centers:F'])
+p2 = Probe.Probe(LOCAL+'/probe.cgns')
 
 out = p2.readCont2(0, 'centers:F', [])
 out = p2.readCont2(1, 'centers:F', out)

--- a/Cassiopee/Post/test/probePrepareCenterPT.py
+++ b/Cassiopee/Post/test/probePrepareCenterPT.py
@@ -1,0 +1,24 @@
+# - Probe prepare - centers (pyTree) -
+import Post.Probe as Probe
+import Converter.Internal as Internal
+import Converter.PyTree as C
+import Generator.PyTree as G
+import Geom.PyTree as D
+
+# test case
+a = G.cart((0,0,0), (0.1,0.1,0.1), (11,11,11))
+t = C.newPyTree(['Base', a])
+C._initVars(t, '{centers:F} = {centers:CoordinateX}')
+
+b = D.box((0.2,0.2,0.2), (0.7,0.7,0.7), 6, ntype='STRUCT')
+tR = C.newPyTree(['Base', b]) # receiver surface tree storing the interpolated flow variable data
+
+tD = Internal.copyRef(t) # donor tree storing the interpolation data (interpolation coefficients)
+
+# create a probe using mode 3
+p3 = Probe.Probe('probe3.cgns', tPermeable=tR, fields=['centers:F'], append=False, bufferSize=100)
+
+# compute the interpolation data for probe extraction (mode 3 only)
+C._initVars(tD, '{cellN} = 1') # donor solution is located at the nodes
+C._initVars(tR, '{centers:cellN} = 2')
+tD = p3.prepare(tD, loc='centers')

--- a/Cassiopee/Post/test/probePrepareNodePT.py
+++ b/Cassiopee/Post/test/probePrepareNodePT.py
@@ -1,0 +1,24 @@
+# - Probe prepare - nodes (pyTree) -
+import Post.Probe as Probe
+import Converter.Internal as Internal
+import Converter.PyTree as C
+import Generator.PyTree as G
+import Geom.PyTree as D
+
+# test case
+a = G.cart((0,0,0), (0.1,0.1,0.1), (11,11,11))
+t = C.newPyTree(['Base', a])
+C._initVars(t, '{F} = {CoordinateX}')
+
+b = D.box((0.2,0.2,0.2), (0.7,0.7,0.7), 6, ntype='QUAD')
+tR = C.newPyTree(['Base', b]) # receiver surface tree storing the interpolated flow variable data
+
+tD = Internal.copyRef(t) # donor tree storing the interpolation data (interpolation coefficients)
+
+# create a probe using mode 3
+p3 = Probe.Probe('probe3.cgns', tPermeable=tR, fields=['F'], append=False, bufferSize=100)
+
+# compute the interpolation data for probe extraction (mode 3 only)
+C._initVars(tD, '{cellN} = 1') # donor solution is located at the nodes
+C._initVars(tR, '{cellN} = 2')
+tD = p3.prepare(tD, loc='nodes')

--- a/Cassiopee/Post/test/probePrintInfoPT.py
+++ b/Cassiopee/Post/test/probePrintInfoPT.py
@@ -1,0 +1,8 @@
+# - Probe printInfo (pyTree) -
+import Post.Probe as Probe
+
+# create a probe using mode 4
+p4 = Probe.Probe('probe4.cgns', fields=['Density', 'Mach'], append=False, bufferSize=100)
+
+# print all relevant information about the p4 probe object
+p4.printInfo()

--- a/Cassiopee/Post/test/probeReadPT.py
+++ b/Cassiopee/Post/test/probeReadPT.py
@@ -1,0 +1,37 @@
+# - Probe read (pyTree) -
+import Post.Probe as Probe
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+
+# test case
+a = G.cartRx((0,0,0), (1,1,1), (30,30,30), (5,5,5))
+t = C.newPyTree(['Base', a])
+C._initVars(t, '{centers:Fx} = {centers:CoordinateX}')
+C._initVars(t, '{centers:Fy} = {centers:CoordinateY}')
+
+# create a probe using mode 1
+fields = ['centers:Fx', 'centers:Fy']
+p1 = Probe.Probe('probe1.cgns', t, ind=(10,10,10), blockName='cart1-1-1', fields=fields, append=False, bufferSize=100)
+p1.printInfo()
+
+# extract probe information over time
+for i in range(210):
+    time = 0.1*i
+    C._initVars(t, '{centers:Fx} = {centers:Fx} + cos(%f)'%time, isVectorized=True)
+    C._initVars(t, '{centers:Fy} = {centers:Fx} + sin(%f)'%time, isVectorized=True)
+    p1.extract(t, time=time)
+
+# flush current buffered data to disk to save last extractions
+p1.flush()
+
+# reread probe from file (not necessary here as the probe object p1 is already loaded)
+p1 = Probe.Probe('probe1.cgns')
+
+# extract all points
+out = p1.read(cont=0) # get all the information located in the first container
+Internal.printTree(out) # list of 100 zones named 'probe@it' where 'it' goes from 0 to 99 (bufferSize-1)
+
+# extract all times
+out = p1.read(ind=0, probeName=0) # get all the information over time of the first point of the first probe zone
+Internal.printTree(out) # mono zone with numpy arrays of size 210

--- a/docs/doc/Examples/Post/probeExtractPT.py
+++ b/docs/doc/Examples/Post/probeExtractPT.py
@@ -1,0 +1,47 @@
+# - Probe extract (pyTree) -
+import Post.Probe as Probe
+import Converter.Internal as Internal
+import Converter.PyTree as C
+import Generator.PyTree as G
+import Post.PyTree as P
+
+# test case
+a = G.cart((0,0,0), (0.1,0.1,0.1), (51,11,11))
+t = C.newPyTree(['Base', a])
+C._initVars(t, '{Density} = 1.')
+C._initVars(t, '{VelocityX} = {CoordinateX}-1')
+C._initVars(t, '{VelocityY} = {CoordinateY}-1')
+C._initVars(t, '{VelocityZ} = {CoordinateZ}-1')
+
+b1 = G.cart((0,0,0), (0.,0.1,0.1), (1,11,11)); b1[0] = 'upstream'
+b2 = G.cart((5,0,0), (0.,0.1,0.1), (1,11,11)); b2[0] = 'downstream'
+tR = C.newPyTree(['Base', [b1,b2]])
+G._getSmoothNormalMap(tR)
+
+tD = Internal.copyRef(t)
+
+# create a first probe using mode 3
+fields = ['Density', 'VelocityX', 'VelocityY', 'VelocityZ']
+p3 = Probe.Probe('probe3.cgns', tPermeable=tR, fields=fields, append=False, bufferSize=100)
+tD = p3.prepare(tD, loc='nodes')
+
+# create a second probe using mode 4
+p4 = Probe.Probe('probe4.cgns', fields=['massflow_upstream', 'massflow_downstream'], bufferSize=100, append=False)
+
+# extract flow information on the receiver surface tree
+for varname in fields: C._cpVars(t, varname , tD, varname)
+p3.extract(tD, onlyTransfer=True)
+
+# tR interpolated data are now updated: integral quantities can be computed on each surface
+C._initVars(tR, '{massflow}={Density}*({sx}*{VelocityX}+{sy}*{VelocityY}+{sz}*{VelocityZ})')
+
+z_upstream = Internal.getNodeFromName(tR, 'upstream')
+massflow_upstream = P.integ(z_upstream, 'massflow')[0]
+
+z_downstream = Internal.getNodeFromName(tR, 'downstream')
+massflow_downstream = P.integ(z_downstream, 'massflow')[0]
+
+# store data information in the p4 probe using single integrated values
+p4.extract(time=1, value=[massflow_upstream, massflow_downstream])
+
+p4.flush()

--- a/docs/doc/Examples/Post/probeFlushPT.py
+++ b/docs/doc/Examples/Post/probeFlushPT.py
@@ -1,0 +1,12 @@
+# - Probe flush (pyTree) -
+import Post.Probe as Probe
+
+# create a probe using mode 4
+p4 = Probe.Probe('probe4.cgns', fields=['Density', 'Mach'], append=False, bufferSize=100)
+
+for i in range(110):
+    p4.extract(time=i*0.1, value=[i, i*10]) 
+    # p4 will automatically flushed itself when reaching the buffer size limit (100)
+
+# flush current buffered data to disk to save last extractions
+p4.flush()

--- a/docs/doc/Examples/Post/probeMode0PT.py
+++ b/docs/doc/Examples/Post/probeMode0PT.py
@@ -1,0 +1,25 @@
+# - Probe mode 0 (pyTree) -
+import Post.Probe as Probe
+import Converter.PyTree as C
+import Generator.PyTree as G
+
+# test case
+a = G.cartRx((0,0,0), (1,1,1), (30,30,30), (5,5,5))
+t = C.newPyTree(['Base', a])
+C._initVars(t, '{centers:Fx} = {centers:CoordinateX}')
+C._initVars(t, '{centers:Fy} = {centers:CoordinateY}')
+
+# create a probe using mode 0
+fields = ['centers:Fx', 'centers:Fy']
+p0 = Probe.Probe('probe0.cgns', t, X=(10.,10.,10.), fields=fields, append=False, bufferSize=100)
+p0.printInfo()
+
+# extract probe information over time
+for i in range(110):
+    time = 0.1*i
+    C._initVars(t, '{centers:Fx} = {centers:Fx} + cos(%f)'%time, isVectorized=True)
+    C._initVars(t, '{centers:Fy} = {centers:Fx} + sin(%f)'%time, isVectorized=True)
+    p0.extract(t, time=time)
+
+# force probe flush
+p0.flush()

--- a/docs/doc/Examples/Post/probeMode1PT.py
+++ b/docs/doc/Examples/Post/probeMode1PT.py
@@ -1,0 +1,25 @@
+# - Probe mode 1 (pyTree) -
+import Post.Probe as Probe
+import Converter.PyTree as C
+import Generator.PyTree as G
+
+# test case
+a = G.cartRx((0,0,0), (1,1,1), (30,30,30), (5,5,5))
+t = C.newPyTree(['Base', a])
+C._initVars(t, '{centers:Fx} = {centers:CoordinateX}')
+C._initVars(t, '{centers:Fy} = {centers:CoordinateY}')
+
+# create a probe using mode 1
+fields = ['centers:Fx', 'centers:Fy']
+p1 = Probe.Probe('probe1.cgns', t, ind=(10,10,10), blockName='cart1-1-1', fields=fields, append=False, bufferSize=100)
+p1.printInfo()
+
+# extract probe information over time
+for i in range(110):
+    time = 0.1*i
+    C._initVars(t, '{centers:Fx} = {centers:Fx} + cos(%f)'%time, isVectorized=True)
+    C._initVars(t, '{centers:Fy} = {centers:Fx} + sin(%f)'%time, isVectorized=True)
+    p1.extract(t, time=time)
+
+# force probe flush
+p1.flush()

--- a/docs/doc/Examples/Post/probeMode2PT.py
+++ b/docs/doc/Examples/Post/probeMode2PT.py
@@ -1,0 +1,27 @@
+# - Probe mode 2 (pyTree) -
+import Post.Probe as Probe
+import Converter.PyTree as C
+import Transform.PyTree as T
+import Geom.PyTree as D
+
+# test case
+b = D.cylinder((50,50,50), 10., 40., N=50, ntype='STRUCT')
+tR = C.newPyTree(['Base', b])
+C._initVars(tR, '{centers:Fx} = {centers:CoordinateX}')
+C._initVars(tR, '{centers:Fy} = {centers:CoordinateY}')
+
+# create a probe using mode 2
+fields = ['centers:Fx', 'centers:Fy']
+p2 = Probe.Probe('probe2.cgns', tR, fields=fields, append=False, bufferSize=100)
+p2.printInfo()
+
+# extract probe information over time
+for i in range(110):
+    time = 0.1*i
+    T._rotate(tR, (50.,50.,50.), (0.,0.,1.), 0.1)
+    C._initVars(tR, '{centers:Fx} = {centers:CoordinateX}')
+    C._initVars(tR, '{centers:Fy} = {centers:CoordinateY}')
+    p2.extract(tR, time=time)
+
+# force probe flush
+p2.flush()

--- a/docs/doc/Examples/Post/probeMode3PT.py
+++ b/docs/doc/Examples/Post/probeMode3PT.py
@@ -1,0 +1,36 @@
+# - Probe mode 3 (pyTree) -
+import Post.Probe as Probe
+import Converter.Internal as Internal
+import Converter.PyTree as C
+import Generator.PyTree as G
+import Geom.PyTree as D
+
+# test case
+a = G.cartRx((0,0,0), (1,1,1), (30,30,30), (5,5,5))
+t = C.newPyTree(['Base', a])
+C._initVars(t, '{centers:Fx} = {centers:CoordinateX}')
+C._initVars(t, '{centers:Fy} = {centers:CoordinateY}')
+
+b = D.cylinder((50,50,50), 10., 40., N=50, ntype='STRUCT')
+tR = C.newPyTree(['Base', b]) # receiver surface tree storing the interpolated flow variable data
+
+tD = Internal.copyRef(t) # donor tree storing the interpolation data (interpolation coefficients)
+
+# create a probe using mode 3
+fields = ['centers:Fx', 'centers:Fy']
+p3 = Probe.Probe('probe3.cgns', tPermeable=tR, fields=fields, append=False, bufferSize=100)
+
+# compute the interpolation data for probe extraction (mode 3 only)
+tD = p3.prepare(tD, loc='centers')
+
+# extract probe information over time
+for i in range(110):
+    time = 0.1*i
+    C._initVars(t, '{centers:Fx} = {centers:Fx} + cos(%f)'%time, isVectorized=True)
+    C._initVars(t, '{centers:Fy} = {centers:Fx} + sin(%f)'%time, isVectorized=True)
+    for varname in fields: C._cpVars(t, varname, tD, varname)
+    tD = C.center2Node(tD, fields) # donor solution is located at the nodes
+    p3.extract(tD, time=time)
+
+# force probe flush
+p3.flush()

--- a/docs/doc/Examples/Post/probeMode4PT.py
+++ b/docs/doc/Examples/Post/probeMode4PT.py
@@ -1,0 +1,39 @@
+# - Probe mode 4 (pyTree) -
+import Post.Probe as Probe
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+
+import numpy
+
+# test case
+a = G.cartRx((0,0,0), (1,1,1), (30,30,30), (5,5,5))
+t = C.newPyTree(['Base', a])
+C._initVars(t, '{centers:Fx} = {centers:CoordinateX}')
+C._initVars(t, '{centers:Fy} = {centers:CoordinateY}')
+
+# create a probe using mode 4
+p4 = Probe.Probe('probe4.cgns', fields=['minFx', 'maxFx', 'minFy', 'maxFy'], append=False, bufferSize=100)
+p4.printInfo()
+
+# extract probe information over time
+for i in range(110):
+    time = 0.1*i
+    maxFx, minFx = 0., 1.e6
+    maxFy, minFy = 0., 1.e6
+    C._initVars(t, '{centers:Fx} = {centers:Fx} + cos(%f)'%time, isVectorized=True)
+    C._initVars(t, '{centers:Fy} = {centers:Fx} + sin(%f)'%time, isVectorized=True)
+    for z in Internal.getZones(t):
+        Fx = Internal.getNodeFromName(z, 'Fx')[1]
+        Fy = Internal.getNodeFromName(z, 'Fy')[1]
+
+        minFx = min(minFx, numpy.min(Fx))
+        maxFx = max(maxFx, numpy.max(Fx))
+        
+        minFy = min(minFy, numpy.min(Fy))
+        maxFy = max(maxFy, numpy.max(Fy))
+        
+    p4.extract(t, time=time, value=[minFx, maxFx, minFy, maxFy])
+
+# force probe flush
+p4.flush()

--- a/docs/doc/Examples/Post/probePT_m1.py
+++ b/docs/doc/Examples/Post/probePT_m1.py
@@ -44,20 +44,19 @@ if Cmpi.rank == 0: test.testT(p2._probeZones, 2)
 Cmpi.barrier()
 
 # create a probe from zones
-p3 = Probe.Probe(LOCAL+'/probe3.cgns', fields=['centers:F'], append=False, bufferSize=15)
+a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
+a[0] = 'cart%d'%Cmpi.rank
+
+p3 = Probe.Probe(LOCAL+'/probe3.cgns', a, fields=['centers:F'], append=False, bufferSize=15)
 for i in range(20):
     time = 0.1*i
-    a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
-    a[0] = 'cart%d'%Cmpi.rank
     C._initVars(a, '{centers:F} = %20.16g'%time)
     p3.extract(a, time=time)
 p3.flush()
 
-p3 = Probe.Probe(LOCAL+'/probe3.cgns', fields=['centers:F'], append=True, bufferSize=15)
+p3 = Probe.Probe(LOCAL+'/probe3.cgns', a, fields=['centers:F'], append=True, bufferSize=15)
 for i in range(20):
     time = 2+0.1*i
-    a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
-    a[0] = 'cart%d'%Cmpi.rank
     C._initVars(a, '{centers:F} = %20.16g'%time)
     p3.extract(a, time=time)
 p3.flush()

--- a/docs/doc/Examples/Post/probePT_m4.py
+++ b/docs/doc/Examples/Post/probePT_m4.py
@@ -9,21 +9,21 @@ import KCore.test as test
 
 LOCAL = test.getLocal()
 
+# test case
+a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
+a[0] = 'cart%d'%Cmpi.rank
+
 # create a probe from zones
-p3 = Probe.Probe(LOCAL+'/probe3.cgns', fields=['F'], append=False, bufferSize=15)
+p3 = Probe.Probe(LOCAL+'/probe3.cgns', a, fields=['F'], append=False, bufferSize=15)
 for i in range(20):
     time = 0.1*i
-    a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
-    a[0] = 'cart%d'%Cmpi.rank
     C._initVars(a, '{F} = %20.16g'%time)
     p3.extract(a, time=time)
 p3.flush()
 
-p3 = Probe.Probe(LOCAL+'/probe3.cgns', fields=['F'], append=True, bufferSize=15)
+p3 = Probe.Probe(LOCAL+'/probe3.cgns', a, fields=['F'], append=True, bufferSize=15)
 for i in range(20):
     time = 2+0.1*i
-    a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
-    a[0] = 'cart%d'%Cmpi.rank
     C._initVars(a, '{F} = %20.16g'%time)
     p3.extract(a, time=time)
 p3.flush()

--- a/docs/doc/Examples/Post/probePT_m5.py
+++ b/docs/doc/Examples/Post/probePT_m5.py
@@ -9,21 +9,21 @@ import KCore.test as test
 
 LOCAL = test.getLocal()
 
+# test case
+a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
+a[0] = 'cart%d'%Cmpi.rank
+
 # create a probe from zones
-p3 = Probe.Probe(LOCAL+'/probe3.cgns', fields=['centers:F'], append=False, bufferSize=15)
+p3 = Probe.Probe(LOCAL+'/probe3.cgns', a, fields=['centers:F'], append=False, bufferSize=15)
 for i in range(20):
     time = 0.1*i
-    a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
-    a[0] = 'cart%d'%Cmpi.rank
     C._initVars(a, '{centers:F} = %20.16g'%time)
     p3.extract(a, time=time)
 p3.flush()
 
-p3 = Probe.Probe(LOCAL+'/probe3.cgns', fields=['centers:F'], append=True, bufferSize=15)
+p3 = Probe.Probe(LOCAL+'/probe3.cgns', a, fields=['centers:F'], append=True, bufferSize=15)
 for i in range(20):
     time = 2+0.1*i
-    a = G.cart((Cmpi.rank,0,0), (0.1,0.1,0.1), (11,11,1))
-    a[0] = 'cart%d'%Cmpi.rank
     C._initVars(a, '{centers:F} = %20.16g'%time)
     p3.extract(a, time=time)
 p3.flush()

--- a/docs/doc/Examples/Post/probePT_t1.py
+++ b/docs/doc/Examples/Post/probePT_t1.py
@@ -40,18 +40,18 @@ p1.flush()
 test.testT(p1._probeZones, 2)
 
 # create probe from zones
-p1 = Probe.Probe(LOCAL+'/probe3.cgns', fields=['centers:F'], append=False, bufferSize=15)
+a = G.cart((0,0,0), (1,1,1), (5,5,1))
+
+p1 = Probe.Probe(LOCAL+'/probe3.cgns', a, fields=['centers:F'], append=False, bufferSize=15)
 for i in range(20):
     time = 0.1*i
-    a = G.cart((0,0,0), (1,1,1), (5,5,1))
     C._initVars(a, '{centers:F} = %20.16g'%time)
     p1.extract(a, time=time)
 p1.flush()
 
-p1 = Probe.Probe(LOCAL+'/probe3.cgns', fields=['centers:F'], append=True, bufferSize=15)
+p1 = Probe.Probe(LOCAL+'/probe3.cgns', a, fields=['centers:F'], append=True, bufferSize=15)
 for i in range(20):
     time = 2+0.1*i
-    a = G.cart((0,0,0), (1,1,1), (5,5,1))
     C._initVars(a, '{centers:F} = %20.16g'%time)
     p1.extract(a, time=time)
 p1.flush()

--- a/docs/doc/Examples/Post/probePT_t3.py
+++ b/docs/doc/Examples/Post/probePT_t3.py
@@ -1,4 +1,4 @@
-# - probe (pyTree) -
+# - Probe (pyTree) -
 # Relecture probe mode 2 pour donner un numpy qui concatene toute la solution
 # a tous les instants
 import Converter.PyTree as C
@@ -15,7 +15,7 @@ s = D.sphere((2.5,2.5,2.5), 1.)
 s = T.splitNParts(s, 2)
 
 # Create probe to store surface
-probe = Probe.Probe(LOCAL+'/probe.cgns', t=None, fields=['centers:F'], bufferSize=15)
+probe = Probe.Probe(LOCAL+'/probe.cgns', s, fields=['centers:F'], bufferSize=15)
 
 # Extractions
 for i in range(40):
@@ -25,7 +25,7 @@ for i in range(40):
 probe.flush()
 
 # Relecture par containers
-p2 = Probe.Probe(LOCAL+'/probe.cgns', fields=['centers:F'])
+p2 = Probe.Probe(LOCAL+'/probe.cgns')
 
 out = p2.readCont2(0, 'centers:F', [])
 out = p2.readCont2(1, 'centers:F', out)

--- a/docs/doc/Examples/Post/probePrepareCenterPT.py
+++ b/docs/doc/Examples/Post/probePrepareCenterPT.py
@@ -1,0 +1,24 @@
+# - Probe prepare - centers (pyTree) -
+import Post.Probe as Probe
+import Converter.Internal as Internal
+import Converter.PyTree as C
+import Generator.PyTree as G
+import Geom.PyTree as D
+
+# test case
+a = G.cart((0,0,0), (0.1,0.1,0.1), (11,11,11))
+t = C.newPyTree(['Base', a])
+C._initVars(t, '{centers:F} = {centers:CoordinateX}')
+
+b = D.box((0.2,0.2,0.2), (0.7,0.7,0.7), 6, ntype='STRUCT')
+tR = C.newPyTree(['Base', b]) # receiver surface tree storing the interpolated flow variable data
+
+tD = Internal.copyRef(t) # donor tree storing the interpolation data (interpolation coefficients)
+
+# create a probe using mode 3
+p3 = Probe.Probe('probe3.cgns', tPermeable=tR, fields=['centers:F'], append=False, bufferSize=100)
+
+# compute the interpolation data for probe extraction (mode 3 only)
+C._initVars(tD, '{cellN} = 1') # donor solution is located at the nodes
+C._initVars(tR, '{centers:cellN} = 2')
+tD = p3.prepare(tD, loc='centers')

--- a/docs/doc/Examples/Post/probePrepareNodePT.py
+++ b/docs/doc/Examples/Post/probePrepareNodePT.py
@@ -1,0 +1,24 @@
+# - Probe prepare - nodes (pyTree) -
+import Post.Probe as Probe
+import Converter.Internal as Internal
+import Converter.PyTree as C
+import Generator.PyTree as G
+import Geom.PyTree as D
+
+# test case
+a = G.cart((0,0,0), (0.1,0.1,0.1), (11,11,11))
+t = C.newPyTree(['Base', a])
+C._initVars(t, '{F} = {CoordinateX}')
+
+b = D.box((0.2,0.2,0.2), (0.7,0.7,0.7), 6, ntype='QUAD')
+tR = C.newPyTree(['Base', b]) # receiver surface tree storing the interpolated flow variable data
+
+tD = Internal.copyRef(t) # donor tree storing the interpolation data (interpolation coefficients)
+
+# create a probe using mode 3
+p3 = Probe.Probe('probe3.cgns', tPermeable=tR, fields=['F'], append=False, bufferSize=100)
+
+# compute the interpolation data for probe extraction (mode 3 only)
+C._initVars(tD, '{cellN} = 1') # donor solution is located at the nodes
+C._initVars(tR, '{cellN} = 2')
+tD = p3.prepare(tD, loc='nodes')

--- a/docs/doc/Examples/Post/probePrintInfoPT.py
+++ b/docs/doc/Examples/Post/probePrintInfoPT.py
@@ -1,0 +1,8 @@
+# - Probe printInfo (pyTree) -
+import Post.Probe as Probe
+
+# create a probe using mode 4
+p4 = Probe.Probe('probe4.cgns', fields=['Density', 'Mach'], append=False, bufferSize=100)
+
+# print all relevant information about the p4 probe object
+p4.printInfo()

--- a/docs/doc/Examples/Post/probeReadPT.py
+++ b/docs/doc/Examples/Post/probeReadPT.py
@@ -1,0 +1,37 @@
+# - Probe read (pyTree) -
+import Post.Probe as Probe
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+
+# test case
+a = G.cartRx((0,0,0), (1,1,1), (30,30,30), (5,5,5))
+t = C.newPyTree(['Base', a])
+C._initVars(t, '{centers:Fx} = {centers:CoordinateX}')
+C._initVars(t, '{centers:Fy} = {centers:CoordinateY}')
+
+# create a probe using mode 1
+fields = ['centers:Fx', 'centers:Fy']
+p1 = Probe.Probe('probe1.cgns', t, ind=(10,10,10), blockName='cart1-1-1', fields=fields, append=False, bufferSize=100)
+p1.printInfo()
+
+# extract probe information over time
+for i in range(210):
+    time = 0.1*i
+    C._initVars(t, '{centers:Fx} = {centers:Fx} + cos(%f)'%time, isVectorized=True)
+    C._initVars(t, '{centers:Fy} = {centers:Fx} + sin(%f)'%time, isVectorized=True)
+    p1.extract(t, time=time)
+
+# flush current buffered data to disk to save last extractions
+p1.flush()
+
+# reread probe from file (not necessary here as the probe object p1 is already loaded)
+p1 = Probe.Probe('probe1.cgns')
+
+# extract all points
+out = p1.read(cont=0) # get all the information located in the first container
+Internal.printTree(out) # list of 100 zones named 'probe@it' where 'it' goes from 0 to 99 (bufferSize-1)
+
+# extract all times
+out = p1.read(ind=0, probeName=0) # get all the information over time of the first point of the first probe zone
+Internal.printTree(out) # mono zone with numpy arrays of size 210

--- a/docs/doc/Post.html
+++ b/docs/doc/Post.html
@@ -173,18 +173,6 @@ pre- and post-processor for CFD simulations.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#Post.usurp" title="Post.usurp"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Post.usurp</span></code></a></p></td>
 <td><p>Extract unique surfaces using ranked polygons.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#Post.Probe.Probe" title="Post.Probe.Probe"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Post.Probe.Probe</span></code></a></p></td>
-<td><p>Probe for extracting data from fields during computations.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#Post.Probe.Probe.extract" title="Post.Probe.Probe.extract"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Post.Probe.Probe.extract</span></code></a></p></td>
-<td><p>Extract XYZ or Ind fields from t.</p></td>
-</tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#Post.Probe.Probe.flush" title="Post.Probe.Probe.flush"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Post.Probe.Probe.flush</span></code></a></p></td>
-<td><p>Flush probe to file.</p></td>
-</tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#Post.Probe.Probe.read" title="Post.Probe.Probe.read"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Post.Probe.Probe.read</span></code></a></p></td>
-<td><p>Reread all data from probe file.</p></td>
-</tr>
 </tbody>
 </table>
 <p><strong>&#8211; Streams/Isos</strong></p>
@@ -206,7 +194,7 @@ pre- and post-processor for CFD simulations.</p>
 <td><p>Compute an isoSurf corresponding to value of field 'var' in volume arrays.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#Post.isoSurfMC" title="Post.isoSurfMC"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Post.isoSurfMC</span></code></a></p></td>
-<td><p>Compute an isoSurf correponding to value of field 'var' in volume arrays.</p></td>
+<td><p>Compute an isoSurf corresponding to value of field 'var' in volume arrays.</p></td>
 </tr>
 </tbody>
 </table>
@@ -2280,110 +2268,6 @@ oriented in the same direction.</p>
 <span class="n">C</span><span class="o">.</span><span class="n">convertPyTree2File</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;out.cgns&#39;</span><span class="p">)</span>
 </pre></div>
 </div>
-</dd></dl>
-
-<hr class="docutils" />
-<dl class="py function">
-<dt class="sig sig-object py" id="Post.Probe.Probe">
-<span class="sig-prename descclassname"><span class="pre">Post.Probe.</span></span><span class="sig-name descname"><span class="pre">Probe</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">fileName</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">t</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">X</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">(x,</span> <span class="pre">y,</span> <span class="pre">z)</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">ind</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">blockName</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">tPermeable</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">fields</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">append</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">True</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">bufferSize</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">100</span></span></em><span class="sig-paren">)</span></dt>
-<dd><p>Create a probe. 4 modes are possible :</p>
-<ul class="simple">
-<li><p>mode 0 : if t and (x,y,z) are provided, the probe will extract given fields from t at single position (x,y,z).</p></li>
-<li><p>mode 1 : if t and (ind, blockName) are provided, the probe will extract given fields from block of t at single index ind of blockName.</p></li>
-<li><p>mode 2 : if t, (x,y,z) and ind are not provided, the probe will store the zones given at extract.</p></li>
-<li><p>mode 3 : if tPermeable is provided, the probe will interpolate on tPermeable.</p></li>
-</ul>
-<p>Result is periodically flush to file when buffer size exceeds bufferSize.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters<span class="colon">:</span></dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>fileName</strong> (<em>string</em>) &#8211; name of file to dump to</p></li>
-<li><p><strong>t</strong> (<em>pyTree</em>) &#8211; pyTree containing solution</p></li>
-<li><p><strong>(</strong><strong>x</strong><strong>,</strong><strong>y</strong><strong>,</strong><strong>z</strong><strong>)</strong> (<em>tuple</em><em> of </em><em>3 floats</em>) &#8211; position of single probe (mode 0)</p></li>
-<li><p><strong>ind</strong> (<em>integer</em>) &#8211; index of single probe in blockName (mode 1)</p></li>
-<li><p><strong>blockName</strong> (<em>string</em>) &#8211; name of block containing probe (mode 1)</p></li>
-<li><p><strong>tPermeable</strong> (<em>pyTree</em><em>, </em><em>zone</em><em> or </em><em>list</em><em> of </em><em>zones</em>) &#8211; surface to interpolate to.</p></li>
-<li><p><strong>fields</strong> (<em>list</em><em> of </em><em>strings</em><em> or </em><em>None</em>) &#8211; list of fields to extract</p></li>
-<li><p><strong>append</strong> (<em>Boolean</em>) &#8211; if True, append result to existing file</p></li>
-<li><p><strong>bufferSize</strong> (<em>int</em>) &#8211; size of internal buffer</p></li>
-</ul>
-</dd>
-<dt class="field-even">Return type<span class="colon">:</span></dt>
-<dd class="field-even"><p>probe instance</p>
-</dd>
-</dl>
-<p><em>Example of use:</em></p>
-<ul class="simple">
-<li><p><a class="reference external" href="Examples/Post/probePT.py">Probe extraction (pyTree)</a>:</p></li>
-</ul>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="c1"># - Probe (pyTree) -</span>
-<span class="kn">import</span> <span class="nn">Post.Probe</span> <span class="k">as</span> <span class="nn">Probe</span>
-<span class="kn">import</span> <span class="nn">Converter.PyTree</span> <span class="k">as</span> <span class="nn">C</span>
-<span class="kn">import</span> <span class="nn">Generator.PyTree</span> <span class="k">as</span> <span class="nn">G</span>
-
-<span class="c1"># test case</span>
-<span class="n">a</span> <span class="o">=</span> <span class="n">G</span><span class="o">.</span><span class="n">cartRx</span><span class="p">((</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">),</span> <span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">1</span><span class="p">,</span><span class="mi">1</span><span class="p">),</span> <span class="p">(</span><span class="mi">30</span><span class="p">,</span><span class="mi">30</span><span class="p">,</span><span class="mi">30</span><span class="p">),</span> <span class="p">(</span><span class="mi">5</span><span class="p">,</span><span class="mi">5</span><span class="p">,</span><span class="mi">5</span><span class="p">),</span> <span class="n">depth</span><span class="o">=</span><span class="mi">0</span><span class="p">,</span> <span class="n">addCellN</span><span class="o">=</span><span class="kc">False</span><span class="p">)</span>
-<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">a</span><span class="p">,</span> <span class="s1">&#39;</span><span class="si">{centers:F}</span><span class="s1"> = {centers:CoordinateX}&#39;</span><span class="p">)</span>
-<span class="n">t</span> <span class="o">=</span> <span class="n">C</span><span class="o">.</span><span class="n">newPyTree</span><span class="p">([</span><span class="s1">&#39;Base&#39;</span><span class="p">,</span> <span class="n">a</span><span class="p">])</span>
-
-<span class="c1"># create a probe</span>
-<span class="n">p1</span> <span class="o">=</span> <span class="n">Probe</span><span class="o">.</span><span class="n">Probe</span><span class="p">(</span><span class="s1">&#39;probe1.cgns&#39;</span><span class="p">,</span> <span class="n">t</span><span class="p">,</span> <span class="n">X</span><span class="o">=</span><span class="p">(</span><span class="mf">10.</span><span class="p">,</span><span class="mf">10.</span><span class="p">,</span><span class="mf">10.</span><span class="p">),</span> <span class="n">fields</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;centers:F&#39;</span><span class="p">],</span> <span class="n">append</span><span class="o">=</span><span class="kc">False</span><span class="p">)</span>
-<span class="n">p1</span><span class="o">.</span><span class="n">printInfo</span><span class="p">()</span>
-<span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="mi">110</span><span class="p">):</span>
-    <span class="n">time</span> <span class="o">=</span> <span class="mf">0.1</span><span class="o">*</span><span class="n">i</span>
-    <span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;</span><span class="si">{centers:F}</span><span class="s1"> = {centers:CoordinateX}+10.*sin(</span><span class="si">%20.16g</span><span class="s1">)&#39;</span><span class="o">%</span><span class="n">time</span><span class="p">)</span>
-    <span class="n">p1</span><span class="o">.</span><span class="n">extract</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="n">time</span><span class="o">=</span><span class="n">time</span><span class="p">)</span>
-<span class="n">p1</span><span class="o">.</span><span class="n">flush</span><span class="p">()</span>
-
-<span class="c1"># reread probe from file</span>
-<span class="n">p1</span> <span class="o">=</span> <span class="n">Probe</span><span class="o">.</span><span class="n">Probe</span><span class="p">(</span><span class="s1">&#39;probe1.cgns&#39;</span><span class="p">)</span>
-<span class="n">out</span> <span class="o">=</span> <span class="n">p1</span><span class="o">.</span><span class="n">read</span><span class="p">()</span>
-<span class="n">C</span><span class="o">.</span><span class="n">convertPyTree2File</span><span class="p">(</span><span class="n">out</span><span class="p">,</span> <span class="s1">&#39;out.cgns&#39;</span><span class="p">)</span>
-</pre></div>
-</div>
-</dd></dl>
-
-<hr class="docutils" />
-<dl class="py function">
-<dt class="sig sig-object py" id="Post.Probe.Probe.extract">
-<span class="sig-prename descclassname"><span class="pre">Post.Probe.Probe.</span></span><span class="sig-name descname"><span class="pre">extract</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">t</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">time</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">0.</span></span></em><span class="sig-paren">)</span></dt>
-<dd><p>Extract probe at given time from t.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters<span class="colon">:</span></dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>t</strong> (<em>pyTree</em>) &#8211; pyTree containing solution</p></li>
-<li><p><strong>time</strong> (<em>float</em>) &#8211; extraction time</p></li>
-</ul>
-</dd>
-</dl>
-</dd></dl>
-
-<hr class="docutils" />
-<dl class="py function">
-<dt class="sig sig-object py" id="Post.Probe.Probe.flush">
-<span class="sig-prename descclassname"><span class="pre">Post.Probe.Probe.</span></span><span class="sig-name descname"><span class="pre">flush</span></span><span class="sig-paren">(</span><span class="sig-paren">)</span></dt>
-<dd><p>Force probe flush to disk.</p>
-</dd></dl>
-
-<hr class="docutils" />
-<dl class="py function">
-<dt class="sig sig-object py" id="Post.Probe.Probe.read">
-<span class="sig-prename descclassname"><span class="pre">Post.Probe.Probe.</span></span><span class="sig-name descname"><span class="pre">read</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">cont</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">ind</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">probeName</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em><span class="sig-paren">)</span></dt>
-<dd><p>Read all data stored in probe file and return a zone.
-Can be used in two ways:</p>
-<ul class="simple">
-<li><p>cont: extract the given time container (all probe points)</p></li>
-<li><p>ind, probeName: extract the given index, zone (all times)</p></li>
-</ul>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters<span class="colon">:</span></dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>cont</strong> (<em>integer</em>) &#8211; number of time container</p></li>
-<li><p><strong>ind</strong> (<em>integer</em>) &#8211; index to extract</p></li>
-<li><p><strong>probeName</strong> (<em>string</em>) &#8211; name of probe zone to extract</p></li>
-</ul>
-</dd>
-</dl>
 </dd></dl>
 
 </section>

--- a/docs/doc/Probe.html
+++ b/docs/doc/Probe.html
@@ -1,0 +1,763 @@
+
+<!DOCTYPE html>
+
+<html lang="en">
+  <head>
+    <meta charset="ASCII" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.19: https://docutils.sourceforge.io/" />
+
+    <title>Post.Probe: Probe extraction &#8212; Post 4.1 documentation</title>
+    <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
+    <link rel="stylesheet" type="text/css" href="_static/classic.css" />
+    
+    <script data-url_root="./" id="documentation_options" src="_static/documentation_options.js"></script>
+    <script src="_static/jquery.js"></script>
+    <script src="_static/underscore.js"></script>
+    <script src="_static/_sphinx_javascript_frameworks_compat.js"></script>
+    <script src="_static/doctools.js"></script>
+    <script src="_static/sphinx_highlight.js"></script>
+    
+    <link rel="index" title="Index" href="genindex.html" />
+    <link rel="search" title="Search" href="search.html" /> 
+  </head><body>
+    <div class="related" role="navigation" aria-label="related navigation">
+      <h3>Navigation</h3>
+      <ul>
+        <li class="right" style="margin-right: 10px">
+          <a href="genindex.html" title="General Index"
+             accesskey="I">index</a></li>
+        <li class="right" >
+          <a href="py-modindex.html" title="Python Module Index"
+             >modules</a> |</li>
+        <li class="nav-item nav-item-0"><a href="Post.html">Post 4.1 documentation</a> &#187;</li>
+        <li class="nav-item nav-item-this"><a href="">Post.Probe: Probe extraction</a></li> 
+      </ul>
+    </div>  
+
+    <div class="document">
+      <div class="documentwrapper">
+        <div class="bodywrapper">
+          <div class="body" role="main">
+            
+  <p>for i in range(ncont).. Probe documentation master file</p>
+<dl class="field-list simple">
+<dt class="field-odd">tocdepth<span class="colon">:</span></dt>
+<dd class="field-odd"><p>2</p>
+</dd>
+</dl>
+<section id="post-probe-probe-extraction">
+<h1>Post.Probe: Probe extraction</h1>
+<p>Specific probe extraction module.</p>
+<p>This page describes how the object-oriented Probe module operates. The various methods presented below should be used after instantiating a Probe object of the same-named class.</p>
+<p>All of these methods and functions can be executed in both sequential and parallel contexts.</p>
+<span class="target" id="module-Post.Probe"></span><section id="list-of-functions">
+<h2>List of functions</h2>
+<p><strong>&#8211; Probe creation</strong></p>
+<table class="autosummary longtable docutils align-default">
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="#Post.Probe.Probe" title="Post.Probe.Probe"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Post.Probe.Probe</span></code></a></p></td>
+<td><p>Create Probe object to extract and save data during simulations.</p></td>
+</tr>
+</tbody>
+</table>
+<p><strong>&#8211; Probe methods</strong></p>
+<table class="autosummary longtable docutils align-default">
+<tbody>
+<tr class="row-odd"><td><p><a class="reference internal" href="#Post.Probe.Probe.printInfo" title="Post.Probe.Probe.printInfo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Probe.printInfo</span></code></a></p></td>
+<td><p>Print information about a new probe.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="#Post.Probe.Probe.prepare" title="Post.Probe.Probe.prepare"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Probe.prepare</span></code></a></p></td>
+<td><p>Prepare the interpolation data for probe extraction in mode 3.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="#Post.Probe.Probe.extract" title="Post.Probe.Probe.extract"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Probe.extract</span></code></a></p></td>
+<td><p>Extract probe information.</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="#Post.Probe.Probe.flush" title="Post.Probe.Probe.flush"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Probe.flush</span></code></a></p></td>
+<td><p>Flush buffered data to probe file.</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="#Post.Probe.Probe.read" title="Post.Probe.Probe.read"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Probe.read</span></code></a></p></td>
+<td><p>Read data from existing probe file.</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="contents">
+<h2>Contents</h2>
+<section id="probe-creation">
+<h3>Probe creation</h3>
+<dl class="py function">
+<dt class="sig sig-object py" id="Post.Probe.Probe">
+<span class="sig-prename descclassname"><span class="pre">Post.Probe.</span></span><span class="sig-name descname"><span class="pre">Probe</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">fileName</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">t</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">X</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">ind</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">blockName</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">tPermeable</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">fields</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">append</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">False</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">bufferSize</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">100</span></span></em><span class="sig-paren">)</span></dt>
+<dd><p>Create a Python object from the Probe class. Five modes are possible:</p>
+<ul class="simple">
+<li><p><strong>mode 0</strong>: if t and X are provided, the probe will extract the fields from t at the absolute position X=(x,y,z).</p></li>
+<li><p><strong>mode 1</strong>: if t and (ind, blockName) are provided, the probe will extract the fields from t at the given index of the specified block.</p></li>
+<li><p><strong>mode 2</strong>: if t is provided without a specific location (index or position), the probe will store all zones of t with both coordinates and fields. t must be 1D or 2D.</p></li>
+<li><p><strong>mode 3</strong>: if t and tPermeable are provided, the probe will interpolate the fields on tPermeable using t as the donor tree. tPermeable must be 1D or 2D.</p></li>
+<li><p><strong>mode 4</strong>: if t is not provided, the probe will simply store specified values over time.</p></li>
+</ul>
+<p>Data are periodically flushed to probe file when the buffer size exceeds the user input bufferSize.</p>
+<p>For Probe objects in modes 0, 1, or 4, all data are stored in 1D numpy arrays of size bufferSize.</p>
+<p>For Probe objects in modes 2 or 3, the data are stored in 2D/3D numpy arrays of size (bufferSize,ni,nj) where (ni,nj) are the original dimensions of the receiver tree zones (t for mode 2 or tPermeable for mode 3).</p>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>Modes 2 and 3 only operates with structured meshes.</p>
+</div>
+<dl class="field-list simple">
+<dt class="field-odd">Parameters<span class="colon">:</span></dt>
+<dd class="field-odd"><ul class="simple">
+<li><p><strong>fileName</strong> (<em>string</em>) &#8211; name of the probe file</p></li>
+<li><p><strong>t</strong> (<em>pyTree</em>) &#8211; pyTree containing the flow solution</p></li>
+<li><p><strong>X</strong> (<em>tuple</em><em> of </em><em>3 floats</em><em> (</em><em>x</em><em>,</em><em>y</em><em>,</em><em>z</em><em>)</em>) &#8211; absolute position of a single probe (mode 0 only)</p></li>
+<li><p><strong>ind</strong> (<em>integer</em><em> or </em><em>tuple</em><em> of </em><em>3 integers</em><em> (</em><em>i</em><em>,</em><em>j</em><em>,</em><em>k</em><em>)</em>) &#8211; index of a single probe located in blockName (mode 1 only)</p></li>
+<li><p><strong>blockName</strong> (<em>string</em>) &#8211; name of the block containing the probe index (mode 1 only)</p></li>
+<li><p><strong>tPermeable</strong> (<em>pyTree</em><em>, </em><em>zone</em><em> or </em><em>list</em><em> of </em><em>zones</em>) &#8211; interpolated tree (mode 3 only)</p></li>
+<li><p><strong>fields</strong> (<em>list</em><em> of </em><em>strings</em>) &#8211; list of fields to extract (located at the mesh nodes OR the mesh centers)</p></li>
+<li><p><strong>append</strong> (<em>Boolean</em>) &#8211; if True, append result to existing file</p></li>
+<li><p><strong>bufferSize</strong> (<em>int</em>) &#8211; size of internal buffer</p></li>
+</ul>
+</dd>
+<dt class="field-even">Return type<span class="colon">:</span></dt>
+<dd class="field-even"><p>probe instance</p>
+</dd>
+</dl>
+<p><em>Example of use:</em></p>
+<ul class="simple">
+<li><p><a class="reference external" href="Examples/Post/probeMode0PT.py">Probe - mode 0 (pyTree)</a>:</p></li>
+</ul>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="c1"># - Probe mode 0 (pyTree) -</span>
+<span class="kn">import</span> <span class="nn">Post.Probe</span> <span class="k">as</span> <span class="nn">Probe</span>
+<span class="kn">import</span> <span class="nn">Converter.PyTree</span> <span class="k">as</span> <span class="nn">C</span>
+<span class="kn">import</span> <span class="nn">Generator.PyTree</span> <span class="k">as</span> <span class="nn">G</span>
+
+<span class="c1"># test case</span>
+<span class="n">a</span> <span class="o">=</span> <span class="n">G</span><span class="o">.</span><span class="n">cartRx</span><span class="p">((</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">),</span> <span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">1</span><span class="p">,</span><span class="mi">1</span><span class="p">),</span> <span class="p">(</span><span class="mi">30</span><span class="p">,</span><span class="mi">30</span><span class="p">,</span><span class="mi">30</span><span class="p">),</span> <span class="p">(</span><span class="mi">5</span><span class="p">,</span><span class="mi">5</span><span class="p">,</span><span class="mi">5</span><span class="p">))</span>
+<span class="n">t</span> <span class="o">=</span> <span class="n">C</span><span class="o">.</span><span class="n">newPyTree</span><span class="p">([</span><span class="s1">&#39;Base&#39;</span><span class="p">,</span> <span class="n">a</span><span class="p">])</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fx} = {centers:CoordinateX}&#39;</span><span class="p">)</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fy} = {centers:CoordinateY}&#39;</span><span class="p">)</span>
+
+<span class="c1"># create a probe using mode 0</span>
+<span class="n">fields</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;centers:Fx&#39;</span><span class="p">,</span> <span class="s1">&#39;centers:Fy&#39;</span><span class="p">]</span>
+<span class="n">p0</span> <span class="o">=</span> <span class="n">Probe</span><span class="o">.</span><span class="n">Probe</span><span class="p">(</span><span class="s1">&#39;probe0.cgns&#39;</span><span class="p">,</span> <span class="n">t</span><span class="p">,</span> <span class="n">X</span><span class="o">=</span><span class="p">(</span><span class="mf">10.</span><span class="p">,</span><span class="mf">10.</span><span class="p">,</span><span class="mf">10.</span><span class="p">),</span> <span class="n">fields</span><span class="o">=</span><span class="n">fields</span><span class="p">,</span> <span class="n">append</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span> <span class="n">bufferSize</span><span class="o">=</span><span class="mi">100</span><span class="p">)</span>
+<span class="n">p0</span><span class="o">.</span><span class="n">printInfo</span><span class="p">()</span>
+
+<span class="c1"># extract probe information over time</span>
+<span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="mi">110</span><span class="p">):</span>
+    <span class="n">time</span> <span class="o">=</span> <span class="mf">0.1</span><span class="o">*</span><span class="n">i</span>
+    <span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fx} = {centers:Fx} + cos(</span><span class="si">%f</span><span class="s1">)&#39;</span><span class="o">%</span><span class="n">time</span><span class="p">,</span> <span class="n">isVectorized</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+    <span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fy} = {centers:Fx} + sin(</span><span class="si">%f</span><span class="s1">)&#39;</span><span class="o">%</span><span class="n">time</span><span class="p">,</span> <span class="n">isVectorized</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+    <span class="n">p0</span><span class="o">.</span><span class="n">extract</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="n">time</span><span class="o">=</span><span class="n">time</span><span class="p">)</span>
+
+<span class="c1"># force probe flush</span>
+<span class="n">p0</span><span class="o">.</span><span class="n">flush</span><span class="p">()</span>
+</pre></div>
+</div>
+<ul class="simple">
+<li><p><a class="reference external" href="Examples/Post/probeMode1PT.py">Probe - mode 1 (pyTree)</a>:</p></li>
+</ul>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="c1"># - Probe mode 1 (pyTree) -</span>
+<span class="kn">import</span> <span class="nn">Post.Probe</span> <span class="k">as</span> <span class="nn">Probe</span>
+<span class="kn">import</span> <span class="nn">Converter.PyTree</span> <span class="k">as</span> <span class="nn">C</span>
+<span class="kn">import</span> <span class="nn">Generator.PyTree</span> <span class="k">as</span> <span class="nn">G</span>
+
+<span class="c1"># test case</span>
+<span class="n">a</span> <span class="o">=</span> <span class="n">G</span><span class="o">.</span><span class="n">cartRx</span><span class="p">((</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">),</span> <span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">1</span><span class="p">,</span><span class="mi">1</span><span class="p">),</span> <span class="p">(</span><span class="mi">30</span><span class="p">,</span><span class="mi">30</span><span class="p">,</span><span class="mi">30</span><span class="p">),</span> <span class="p">(</span><span class="mi">5</span><span class="p">,</span><span class="mi">5</span><span class="p">,</span><span class="mi">5</span><span class="p">))</span>
+<span class="n">t</span> <span class="o">=</span> <span class="n">C</span><span class="o">.</span><span class="n">newPyTree</span><span class="p">([</span><span class="s1">&#39;Base&#39;</span><span class="p">,</span> <span class="n">a</span><span class="p">])</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fx} = {centers:CoordinateX}&#39;</span><span class="p">)</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fy} = {centers:CoordinateY}&#39;</span><span class="p">)</span>
+
+<span class="c1"># create a probe using mode 1</span>
+<span class="n">fields</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;centers:Fx&#39;</span><span class="p">,</span> <span class="s1">&#39;centers:Fy&#39;</span><span class="p">]</span>
+<span class="n">p1</span> <span class="o">=</span> <span class="n">Probe</span><span class="o">.</span><span class="n">Probe</span><span class="p">(</span><span class="s1">&#39;probe1.cgns&#39;</span><span class="p">,</span> <span class="n">t</span><span class="p">,</span> <span class="n">ind</span><span class="o">=</span><span class="p">(</span><span class="mi">10</span><span class="p">,</span><span class="mi">10</span><span class="p">,</span><span class="mi">10</span><span class="p">),</span> <span class="n">blockName</span><span class="o">=</span><span class="s1">&#39;cart1-1-1&#39;</span><span class="p">,</span> <span class="n">fields</span><span class="o">=</span><span class="n">fields</span><span class="p">,</span> <span class="n">append</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span> <span class="n">bufferSize</span><span class="o">=</span><span class="mi">100</span><span class="p">)</span>
+<span class="n">p1</span><span class="o">.</span><span class="n">printInfo</span><span class="p">()</span>
+
+<span class="c1"># extract probe information over time</span>
+<span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="mi">110</span><span class="p">):</span>
+    <span class="n">time</span> <span class="o">=</span> <span class="mf">0.1</span><span class="o">*</span><span class="n">i</span>
+    <span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fx} = {centers:Fx} + cos(</span><span class="si">%f</span><span class="s1">)&#39;</span><span class="o">%</span><span class="n">time</span><span class="p">,</span> <span class="n">isVectorized</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+    <span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fy} = {centers:Fx} + sin(</span><span class="si">%f</span><span class="s1">)&#39;</span><span class="o">%</span><span class="n">time</span><span class="p">,</span> <span class="n">isVectorized</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+    <span class="n">p1</span><span class="o">.</span><span class="n">extract</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="n">time</span><span class="o">=</span><span class="n">time</span><span class="p">)</span>
+
+<span class="c1"># force probe flush</span>
+<span class="n">p1</span><span class="o">.</span><span class="n">flush</span><span class="p">()</span>
+</pre></div>
+</div>
+<ul class="simple">
+<li><p><a class="reference external" href="Examples/Post/probeMode2PT.py">Probe - mode 2 (pyTree)</a>:</p></li>
+</ul>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="c1"># - Probe mode 2 (pyTree) -</span>
+<span class="kn">import</span> <span class="nn">Post.Probe</span> <span class="k">as</span> <span class="nn">Probe</span>
+<span class="kn">import</span> <span class="nn">Converter.PyTree</span> <span class="k">as</span> <span class="nn">C</span>
+<span class="kn">import</span> <span class="nn">Transform.PyTree</span> <span class="k">as</span> <span class="nn">T</span>
+<span class="kn">import</span> <span class="nn">Geom.PyTree</span> <span class="k">as</span> <span class="nn">D</span>
+
+<span class="c1"># test case</span>
+<span class="n">b</span> <span class="o">=</span> <span class="n">D</span><span class="o">.</span><span class="n">cylinder</span><span class="p">((</span><span class="mi">50</span><span class="p">,</span><span class="mi">50</span><span class="p">,</span><span class="mi">50</span><span class="p">),</span> <span class="mf">10.</span><span class="p">,</span> <span class="mf">40.</span><span class="p">,</span> <span class="n">N</span><span class="o">=</span><span class="mi">50</span><span class="p">,</span> <span class="n">ntype</span><span class="o">=</span><span class="s1">&#39;STRUCT&#39;</span><span class="p">)</span>
+<span class="n">tR</span> <span class="o">=</span> <span class="n">C</span><span class="o">.</span><span class="n">newPyTree</span><span class="p">([</span><span class="s1">&#39;Base&#39;</span><span class="p">,</span> <span class="n">b</span><span class="p">])</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">tR</span><span class="p">,</span> <span class="s1">&#39;{centers:Fx} = {centers:CoordinateX}&#39;</span><span class="p">)</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">tR</span><span class="p">,</span> <span class="s1">&#39;{centers:Fy} = {centers:CoordinateY}&#39;</span><span class="p">)</span>
+
+<span class="c1"># create a probe using mode 2</span>
+<span class="n">fields</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;centers:Fx&#39;</span><span class="p">,</span> <span class="s1">&#39;centers:Fy&#39;</span><span class="p">]</span>
+<span class="n">p2</span> <span class="o">=</span> <span class="n">Probe</span><span class="o">.</span><span class="n">Probe</span><span class="p">(</span><span class="s1">&#39;probe2.cgns&#39;</span><span class="p">,</span> <span class="n">tR</span><span class="p">,</span> <span class="n">fields</span><span class="o">=</span><span class="n">fields</span><span class="p">,</span> <span class="n">append</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span> <span class="n">bufferSize</span><span class="o">=</span><span class="mi">100</span><span class="p">)</span>
+<span class="n">p2</span><span class="o">.</span><span class="n">printInfo</span><span class="p">()</span>
+
+<span class="c1"># extract probe information over time</span>
+<span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="mi">110</span><span class="p">):</span>
+    <span class="n">time</span> <span class="o">=</span> <span class="mf">0.1</span><span class="o">*</span><span class="n">i</span>
+    <span class="n">T</span><span class="o">.</span><span class="n">_rotate</span><span class="p">(</span><span class="n">tR</span><span class="p">,</span> <span class="p">(</span><span class="mf">50.</span><span class="p">,</span><span class="mf">50.</span><span class="p">,</span><span class="mf">50.</span><span class="p">),</span> <span class="p">(</span><span class="mf">0.</span><span class="p">,</span><span class="mf">0.</span><span class="p">,</span><span class="mf">1.</span><span class="p">),</span> <span class="mf">0.1</span><span class="p">)</span>
+    <span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">tR</span><span class="p">,</span> <span class="s1">&#39;{centers:Fx} = {centers:CoordinateX}&#39;</span><span class="p">)</span>
+    <span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">tR</span><span class="p">,</span> <span class="s1">&#39;{centers:Fy} = {centers:CoordinateY}&#39;</span><span class="p">)</span>
+    <span class="n">p2</span><span class="o">.</span><span class="n">extract</span><span class="p">(</span><span class="n">tR</span><span class="p">,</span> <span class="n">time</span><span class="o">=</span><span class="n">time</span><span class="p">)</span>
+
+<span class="c1"># force probe flush</span>
+<span class="n">p2</span><span class="o">.</span><span class="n">flush</span><span class="p">()</span>
+</pre></div>
+</div>
+<ul class="simple">
+<li><p><a class="reference external" href="Examples/Post/probeMode3PT.py">Probe - mode 3 (pyTree)</a>:</p></li>
+</ul>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="c1"># - Probe mode 3 (pyTree) -</span>
+<span class="kn">import</span> <span class="nn">Post.Probe</span> <span class="k">as</span> <span class="nn">Probe</span>
+<span class="kn">import</span> <span class="nn">Converter.Internal</span> <span class="k">as</span> <span class="nn">Internal</span>
+<span class="kn">import</span> <span class="nn">Converter.PyTree</span> <span class="k">as</span> <span class="nn">C</span>
+<span class="kn">import</span> <span class="nn">Generator.PyTree</span> <span class="k">as</span> <span class="nn">G</span>
+<span class="kn">import</span> <span class="nn">Geom.PyTree</span> <span class="k">as</span> <span class="nn">D</span>
+
+<span class="c1"># test case</span>
+<span class="n">a</span> <span class="o">=</span> <span class="n">G</span><span class="o">.</span><span class="n">cartRx</span><span class="p">((</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">),</span> <span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">1</span><span class="p">,</span><span class="mi">1</span><span class="p">),</span> <span class="p">(</span><span class="mi">30</span><span class="p">,</span><span class="mi">30</span><span class="p">,</span><span class="mi">30</span><span class="p">),</span> <span class="p">(</span><span class="mi">5</span><span class="p">,</span><span class="mi">5</span><span class="p">,</span><span class="mi">5</span><span class="p">))</span>
+<span class="n">t</span> <span class="o">=</span> <span class="n">C</span><span class="o">.</span><span class="n">newPyTree</span><span class="p">([</span><span class="s1">&#39;Base&#39;</span><span class="p">,</span> <span class="n">a</span><span class="p">])</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fx} = {centers:CoordinateX}&#39;</span><span class="p">)</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fy} = {centers:CoordinateY}&#39;</span><span class="p">)</span>
+
+<span class="n">b</span> <span class="o">=</span> <span class="n">D</span><span class="o">.</span><span class="n">cylinder</span><span class="p">((</span><span class="mi">50</span><span class="p">,</span><span class="mi">50</span><span class="p">,</span><span class="mi">50</span><span class="p">),</span> <span class="mf">10.</span><span class="p">,</span> <span class="mf">40.</span><span class="p">,</span> <span class="n">N</span><span class="o">=</span><span class="mi">50</span><span class="p">,</span> <span class="n">ntype</span><span class="o">=</span><span class="s1">&#39;STRUCT&#39;</span><span class="p">)</span>
+<span class="n">tR</span> <span class="o">=</span> <span class="n">C</span><span class="o">.</span><span class="n">newPyTree</span><span class="p">([</span><span class="s1">&#39;Base&#39;</span><span class="p">,</span> <span class="n">b</span><span class="p">])</span> <span class="c1"># receiver surface tree storing the interpolated flow variable data</span>
+
+<span class="n">tD</span> <span class="o">=</span> <span class="n">Internal</span><span class="o">.</span><span class="n">copyRef</span><span class="p">(</span><span class="n">t</span><span class="p">)</span> <span class="c1"># donor tree storing the interpolation data (interpolation coefficients)</span>
+
+<span class="c1"># create a probe using mode 3</span>
+<span class="n">fields</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;centers:Fx&#39;</span><span class="p">,</span> <span class="s1">&#39;centers:Fy&#39;</span><span class="p">]</span>
+<span class="n">p3</span> <span class="o">=</span> <span class="n">Probe</span><span class="o">.</span><span class="n">Probe</span><span class="p">(</span><span class="s1">&#39;probe3.cgns&#39;</span><span class="p">,</span> <span class="n">tPermeable</span><span class="o">=</span><span class="n">tR</span><span class="p">,</span> <span class="n">fields</span><span class="o">=</span><span class="n">fields</span><span class="p">,</span> <span class="n">append</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span> <span class="n">bufferSize</span><span class="o">=</span><span class="mi">100</span><span class="p">)</span>
+
+<span class="c1"># compute the interpolation data for probe extraction (mode 3 only)</span>
+<span class="n">tD</span> <span class="o">=</span> <span class="n">p3</span><span class="o">.</span><span class="n">prepare</span><span class="p">(</span><span class="n">tD</span><span class="p">,</span> <span class="n">loc</span><span class="o">=</span><span class="s1">&#39;centers&#39;</span><span class="p">)</span>
+
+<span class="c1"># extract probe information over time</span>
+<span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="mi">110</span><span class="p">):</span>
+    <span class="n">time</span> <span class="o">=</span> <span class="mf">0.1</span><span class="o">*</span><span class="n">i</span>
+    <span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fx} = {centers:Fx} + cos(</span><span class="si">%f</span><span class="s1">)&#39;</span><span class="o">%</span><span class="n">time</span><span class="p">,</span> <span class="n">isVectorized</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+    <span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fy} = {centers:Fx} + sin(</span><span class="si">%f</span><span class="s1">)&#39;</span><span class="o">%</span><span class="n">time</span><span class="p">,</span> <span class="n">isVectorized</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+    <span class="k">for</span> <span class="n">varname</span> <span class="ow">in</span> <span class="n">fields</span><span class="p">:</span> <span class="n">C</span><span class="o">.</span><span class="n">_cpVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="n">varname</span><span class="p">,</span> <span class="n">tD</span><span class="p">,</span> <span class="n">varname</span><span class="p">)</span>
+    <span class="n">tD</span> <span class="o">=</span> <span class="n">C</span><span class="o">.</span><span class="n">center2Node</span><span class="p">(</span><span class="n">tD</span><span class="p">,</span> <span class="n">fields</span><span class="p">)</span> <span class="c1"># donor solution is located at the nodes</span>
+    <span class="n">p3</span><span class="o">.</span><span class="n">extract</span><span class="p">(</span><span class="n">tD</span><span class="p">,</span> <span class="n">time</span><span class="o">=</span><span class="n">time</span><span class="p">)</span>
+
+<span class="c1"># force probe flush</span>
+<span class="n">p3</span><span class="o">.</span><span class="n">flush</span><span class="p">()</span>
+</pre></div>
+</div>
+<ul class="simple">
+<li><p><a class="reference external" href="Examples/Post/probeMode4PT.py">Probe - mode 4 (pyTree)</a>:</p></li>
+</ul>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="c1"># - Probe mode 4 (pyTree) -</span>
+<span class="kn">import</span> <span class="nn">Post.Probe</span> <span class="k">as</span> <span class="nn">Probe</span>
+<span class="kn">import</span> <span class="nn">Converter.PyTree</span> <span class="k">as</span> <span class="nn">C</span>
+<span class="kn">import</span> <span class="nn">Converter.Internal</span> <span class="k">as</span> <span class="nn">Internal</span>
+<span class="kn">import</span> <span class="nn">Generator.PyTree</span> <span class="k">as</span> <span class="nn">G</span>
+
+<span class="kn">import</span> <span class="nn">numpy</span>
+
+<span class="c1"># test case</span>
+<span class="n">a</span> <span class="o">=</span> <span class="n">G</span><span class="o">.</span><span class="n">cartRx</span><span class="p">((</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">),</span> <span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">1</span><span class="p">,</span><span class="mi">1</span><span class="p">),</span> <span class="p">(</span><span class="mi">30</span><span class="p">,</span><span class="mi">30</span><span class="p">,</span><span class="mi">30</span><span class="p">),</span> <span class="p">(</span><span class="mi">5</span><span class="p">,</span><span class="mi">5</span><span class="p">,</span><span class="mi">5</span><span class="p">))</span>
+<span class="n">t</span> <span class="o">=</span> <span class="n">C</span><span class="o">.</span><span class="n">newPyTree</span><span class="p">([</span><span class="s1">&#39;Base&#39;</span><span class="p">,</span> <span class="n">a</span><span class="p">])</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fx} = {centers:CoordinateX}&#39;</span><span class="p">)</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fy} = {centers:CoordinateY}&#39;</span><span class="p">)</span>
+
+<span class="c1"># create a probe using mode 4</span>
+<span class="n">p4</span> <span class="o">=</span> <span class="n">Probe</span><span class="o">.</span><span class="n">Probe</span><span class="p">(</span><span class="s1">&#39;probe4.cgns&#39;</span><span class="p">,</span> <span class="n">fields</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;minFx&#39;</span><span class="p">,</span> <span class="s1">&#39;maxFx&#39;</span><span class="p">,</span> <span class="s1">&#39;minFy&#39;</span><span class="p">,</span> <span class="s1">&#39;maxFy&#39;</span><span class="p">],</span> <span class="n">append</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span> <span class="n">bufferSize</span><span class="o">=</span><span class="mi">100</span><span class="p">)</span>
+<span class="n">p4</span><span class="o">.</span><span class="n">printInfo</span><span class="p">()</span>
+
+<span class="c1"># extract probe information over time</span>
+<span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="mi">110</span><span class="p">):</span>
+    <span class="n">time</span> <span class="o">=</span> <span class="mf">0.1</span><span class="o">*</span><span class="n">i</span>
+    <span class="n">maxFx</span><span class="p">,</span> <span class="n">minFx</span> <span class="o">=</span> <span class="mf">0.</span><span class="p">,</span> <span class="mf">1.e6</span>
+    <span class="n">maxFy</span><span class="p">,</span> <span class="n">minFy</span> <span class="o">=</span> <span class="mf">0.</span><span class="p">,</span> <span class="mf">1.e6</span>
+    <span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fx} = {centers:Fx} + cos(</span><span class="si">%f</span><span class="s1">)&#39;</span><span class="o">%</span><span class="n">time</span><span class="p">,</span> <span class="n">isVectorized</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+    <span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fy} = {centers:Fx} + sin(</span><span class="si">%f</span><span class="s1">)&#39;</span><span class="o">%</span><span class="n">time</span><span class="p">,</span> <span class="n">isVectorized</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+    <span class="k">for</span> <span class="n">z</span> <span class="ow">in</span> <span class="n">Internal</span><span class="o">.</span><span class="n">getZones</span><span class="p">(</span><span class="n">t</span><span class="p">):</span>
+        <span class="n">Fx</span> <span class="o">=</span> <span class="n">Internal</span><span class="o">.</span><span class="n">getNodeFromName</span><span class="p">(</span><span class="n">z</span><span class="p">,</span> <span class="s1">&#39;Fx&#39;</span><span class="p">)[</span><span class="mi">1</span><span class="p">]</span>
+        <span class="n">Fy</span> <span class="o">=</span> <span class="n">Internal</span><span class="o">.</span><span class="n">getNodeFromName</span><span class="p">(</span><span class="n">z</span><span class="p">,</span> <span class="s1">&#39;Fy&#39;</span><span class="p">)[</span><span class="mi">1</span><span class="p">]</span>
+
+        <span class="n">minFx</span> <span class="o">=</span> <span class="nb">min</span><span class="p">(</span><span class="n">minFx</span><span class="p">,</span> <span class="n">numpy</span><span class="o">.</span><span class="n">min</span><span class="p">(</span><span class="n">Fx</span><span class="p">))</span>
+        <span class="n">maxFx</span> <span class="o">=</span> <span class="nb">max</span><span class="p">(</span><span class="n">maxFx</span><span class="p">,</span> <span class="n">numpy</span><span class="o">.</span><span class="n">max</span><span class="p">(</span><span class="n">Fx</span><span class="p">))</span>
+        
+        <span class="n">minFy</span> <span class="o">=</span> <span class="nb">min</span><span class="p">(</span><span class="n">minFy</span><span class="p">,</span> <span class="n">numpy</span><span class="o">.</span><span class="n">min</span><span class="p">(</span><span class="n">Fy</span><span class="p">))</span>
+        <span class="n">maxFy</span> <span class="o">=</span> <span class="nb">max</span><span class="p">(</span><span class="n">maxFy</span><span class="p">,</span> <span class="n">numpy</span><span class="o">.</span><span class="n">max</span><span class="p">(</span><span class="n">Fy</span><span class="p">))</span>
+        
+    <span class="n">p4</span><span class="o">.</span><span class="n">extract</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="n">time</span><span class="o">=</span><span class="n">time</span><span class="p">,</span> <span class="n">value</span><span class="o">=</span><span class="p">[</span><span class="n">minFx</span><span class="p">,</span> <span class="n">maxFx</span><span class="p">,</span> <span class="n">minFy</span><span class="p">,</span> <span class="n">maxFy</span><span class="p">])</span>
+
+<span class="c1"># force probe flush</span>
+<span class="n">p4</span><span class="o">.</span><span class="n">flush</span><span class="p">()</span>
+</pre></div>
+</div>
+</dd></dl>
+
+</section>
+<hr class="docutils" />
+<section id="probe-methods">
+<h3>Probe methods</h3>
+<dl class="py function">
+<dt class="sig sig-object py" id="Post.Probe.Probe.printInfo">
+<span class="sig-prename descclassname"><span class="pre">Probe.</span></span><span class="sig-name descname"><span class="pre">printInfo</span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="reference internal" href="_modules/Post/Probe.html#Probe.printInfo"><span class="viewcode-link"><span class="pre">[source]</span></span></a></dt>
+<dd><p><strong>printInfo</strong> is a method of the Probe class.</p>
+<p>Print all the information about a probe object.</p>
+<p><em>Example of use:</em></p>
+<ul class="simple">
+<li><p><a class="reference external" href="Examples/Post/probePrintInfoPT.py">Print information about a given probe (pyTree)</a>:</p></li>
+</ul>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="c1"># - Probe printInfo (pyTree) -</span>
+<span class="kn">import</span> <span class="nn">Post.Probe</span> <span class="k">as</span> <span class="nn">Probe</span>
+
+<span class="c1"># create a probe using mode 4</span>
+<span class="n">p4</span> <span class="o">=</span> <span class="n">Probe</span><span class="o">.</span><span class="n">Probe</span><span class="p">(</span><span class="s1">&#39;probe4.cgns&#39;</span><span class="p">,</span> <span class="n">fields</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;Density&#39;</span><span class="p">,</span> <span class="s1">&#39;Mach&#39;</span><span class="p">],</span> <span class="n">append</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span> <span class="n">bufferSize</span><span class="o">=</span><span class="mi">100</span><span class="p">)</span>
+
+<span class="c1"># print all relevant information about the p4 probe object</span>
+<span class="n">p4</span><span class="o">.</span><span class="n">printInfo</span><span class="p">()</span>
+</pre></div>
+</div>
+</dd></dl>
+
+<hr class="docutils" />
+<dl class="py function">
+<dt class="sig sig-object py" id="Post.Probe.Probe.prepare">
+<span class="sig-prename descclassname"><span class="pre">Probe.</span></span><span class="sig-name descname"><span class="pre">prepare</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">t</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">loc</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">'nodes'</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">extrap</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">1</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">nature</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">1</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">penalty</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">1</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">verbose</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">2</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="_modules/Post/Probe.html#Probe.prepare"><span class="viewcode-link"><span class="pre">[source]</span></span></a></dt>
+<dd><p><strong>prepare</strong> is a method of the Probe class.</p>
+<p>Only for mode 3. Prepare the interpolation data for probe extraction from a donor computational tree to a 1D or 2D receiver mesh.</p>
+<p>The arguments are mostly the same as those for Connector.setInterpData2(). Donor tree flow fields must be located at the nodes. Receiver tree flow fields can be located at the nodes (loc=&#8217;nodes&#8217;) or at the centers (loc=&#8217;centers&#8217;).</p>
+<p>If the cellN field (cell nature field) is not found in the donor tree, the function assumes that all cells are computed cells (cellN = 1). Similarly, if the cellN field is not found in the receiver tree, the function assumes that all cells are interpolated cells (cellN = 2).</p>
+<p>extrap options:</p>
+<ul class="simple">
+<li><p><strong>0</strong>: extrapolation is disabled. Extrapolated cells are flagged as orphans.</p></li>
+<li><p><strong>1</strong>: extrapolation is enabled.</p></li>
+</ul>
+<p>nature options:</p>
+<ul class="simple">
+<li><p><strong>0</strong>: candidate donors can be everything but blanked cells (cellN = 0).</p></li>
+<li><p><strong>1</strong>: candidate donors can only be computed cells (cellN = 1).</p></li>
+</ul>
+<p>penalty options:</p>
+<ul class="simple">
+<li><p><strong>0</strong>: all candidates have the same weight.</p></li>
+<li><p><strong>1</strong>: donor cell candidates located at a zone border are penalized against interior cells.</p></li>
+</ul>
+<p>verbose options:</p>
+<ul class="simple">
+<li><p><strong>0</strong>: no information is printed.</p></li>
+<li><p><strong>1</strong>: print only the summary of the interpolation data search.</p></li>
+<li><p><strong>2</strong>: print the summary and indices of the orphan points (if any).</p></li>
+</ul>
+<dl class="field-list simple">
+<dt class="field-odd">Parameters<span class="colon">:</span></dt>
+<dd class="field-odd"><ul class="simple">
+<li><p><strong>t</strong> (<em>pyTree</em>) &#8211; pyTree containing the flow solution</p></li>
+<li><p><strong>loc</strong> (<em>string</em><em> (</em><em>'centers'</em><em> or </em><em>'nodes'</em><em>)</em>) &#8211; extraction location</p></li>
+<li><p><strong>extrap</strong> (<em>integer</em><em> (</em><em>0</em><em> or </em><em>1</em><em>)</em>) &#8211; extrapolation parameter</p></li>
+<li><p><strong>nature</strong> (<em>integer</em><em> (</em><em>0</em><em> or </em><em>1</em><em>)</em>) &#8211; donor cell nature parameter</p></li>
+<li><p><strong>penalty</strong> (<em>integer</em><em> (</em><em>0</em><em> or </em><em>1</em><em>)</em>) &#8211; penalization parameter</p></li>
+<li><p><strong>verbose</strong> (<em>integer</em><em> (</em><em>0</em><em>, </em><em>1</em><em>, or </em><em>2</em><em>)</em>) &#8211; print parameter</p></li>
+</ul>
+</dd>
+</dl>
+<p><em>Example of use:</em></p>
+<ul class="simple">
+<li><p><a class="reference external" href="Examples/Post/probePrepareCenterPT.py">Probe (mode 3) prepare operation for receiver flow fields located at centers (pyTree)</a>:</p></li>
+</ul>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="c1"># - Probe prepare - centers (pyTree) -</span>
+<span class="kn">import</span> <span class="nn">Post.Probe</span> <span class="k">as</span> <span class="nn">Probe</span>
+<span class="kn">import</span> <span class="nn">Converter.Internal</span> <span class="k">as</span> <span class="nn">Internal</span>
+<span class="kn">import</span> <span class="nn">Converter.PyTree</span> <span class="k">as</span> <span class="nn">C</span>
+<span class="kn">import</span> <span class="nn">Generator.PyTree</span> <span class="k">as</span> <span class="nn">G</span>
+<span class="kn">import</span> <span class="nn">Geom.PyTree</span> <span class="k">as</span> <span class="nn">D</span>
+
+<span class="c1"># test case</span>
+<span class="n">a</span> <span class="o">=</span> <span class="n">G</span><span class="o">.</span><span class="n">cart</span><span class="p">((</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">),</span> <span class="p">(</span><span class="mf">0.1</span><span class="p">,</span><span class="mf">0.1</span><span class="p">,</span><span class="mf">0.1</span><span class="p">),</span> <span class="p">(</span><span class="mi">11</span><span class="p">,</span><span class="mi">11</span><span class="p">,</span><span class="mi">11</span><span class="p">))</span>
+<span class="n">t</span> <span class="o">=</span> <span class="n">C</span><span class="o">.</span><span class="n">newPyTree</span><span class="p">([</span><span class="s1">&#39;Base&#39;</span><span class="p">,</span> <span class="n">a</span><span class="p">])</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;</span><span class="si">{centers:F}</span><span class="s1"> = {centers:CoordinateX}&#39;</span><span class="p">)</span>
+
+<span class="n">b</span> <span class="o">=</span> <span class="n">D</span><span class="o">.</span><span class="n">box</span><span class="p">((</span><span class="mf">0.2</span><span class="p">,</span><span class="mf">0.2</span><span class="p">,</span><span class="mf">0.2</span><span class="p">),</span> <span class="p">(</span><span class="mf">0.7</span><span class="p">,</span><span class="mf">0.7</span><span class="p">,</span><span class="mf">0.7</span><span class="p">),</span> <span class="mi">6</span><span class="p">,</span> <span class="n">ntype</span><span class="o">=</span><span class="s1">&#39;STRUCT&#39;</span><span class="p">)</span>
+<span class="n">tR</span> <span class="o">=</span> <span class="n">C</span><span class="o">.</span><span class="n">newPyTree</span><span class="p">([</span><span class="s1">&#39;Base&#39;</span><span class="p">,</span> <span class="n">b</span><span class="p">])</span> <span class="c1"># receiver surface tree storing the interpolated flow variable data</span>
+
+<span class="n">tD</span> <span class="o">=</span> <span class="n">Internal</span><span class="o">.</span><span class="n">copyRef</span><span class="p">(</span><span class="n">t</span><span class="p">)</span> <span class="c1"># donor tree storing the interpolation data (interpolation coefficients)</span>
+
+<span class="c1"># create a probe using mode 3</span>
+<span class="n">p3</span> <span class="o">=</span> <span class="n">Probe</span><span class="o">.</span><span class="n">Probe</span><span class="p">(</span><span class="s1">&#39;probe3.cgns&#39;</span><span class="p">,</span> <span class="n">tPermeable</span><span class="o">=</span><span class="n">tR</span><span class="p">,</span> <span class="n">fields</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;centers:F&#39;</span><span class="p">],</span> <span class="n">append</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span> <span class="n">bufferSize</span><span class="o">=</span><span class="mi">100</span><span class="p">)</span>
+
+<span class="c1"># compute the interpolation data for probe extraction (mode 3 only)</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">tD</span><span class="p">,</span> <span class="s1">&#39;</span><span class="si">{cellN}</span><span class="s1"> = 1&#39;</span><span class="p">)</span> <span class="c1"># donor solution is located at the nodes</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">tR</span><span class="p">,</span> <span class="s1">&#39;{centers:cellN} = 2&#39;</span><span class="p">)</span>
+<span class="n">tD</span> <span class="o">=</span> <span class="n">p3</span><span class="o">.</span><span class="n">prepare</span><span class="p">(</span><span class="n">tD</span><span class="p">,</span> <span class="n">loc</span><span class="o">=</span><span class="s1">&#39;centers&#39;</span><span class="p">)</span>
+</pre></div>
+</div>
+<ul class="simple">
+<li><p><a class="reference external" href="Examples/Post/probePrepareNodePT.py">Probe (mode 3) prepare operation for receiver flow fields located at nodes (pyTree)</a>:</p></li>
+</ul>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="c1"># - Probe prepare - nodes (pyTree) -</span>
+<span class="kn">import</span> <span class="nn">Post.Probe</span> <span class="k">as</span> <span class="nn">Probe</span>
+<span class="kn">import</span> <span class="nn">Converter.Internal</span> <span class="k">as</span> <span class="nn">Internal</span>
+<span class="kn">import</span> <span class="nn">Converter.PyTree</span> <span class="k">as</span> <span class="nn">C</span>
+<span class="kn">import</span> <span class="nn">Generator.PyTree</span> <span class="k">as</span> <span class="nn">G</span>
+<span class="kn">import</span> <span class="nn">Geom.PyTree</span> <span class="k">as</span> <span class="nn">D</span>
+
+<span class="c1"># test case</span>
+<span class="n">a</span> <span class="o">=</span> <span class="n">G</span><span class="o">.</span><span class="n">cart</span><span class="p">((</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">),</span> <span class="p">(</span><span class="mf">0.1</span><span class="p">,</span><span class="mf">0.1</span><span class="p">,</span><span class="mf">0.1</span><span class="p">),</span> <span class="p">(</span><span class="mi">11</span><span class="p">,</span><span class="mi">11</span><span class="p">,</span><span class="mi">11</span><span class="p">))</span>
+<span class="n">t</span> <span class="o">=</span> <span class="n">C</span><span class="o">.</span><span class="n">newPyTree</span><span class="p">([</span><span class="s1">&#39;Base&#39;</span><span class="p">,</span> <span class="n">a</span><span class="p">])</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;</span><span class="si">{F}</span><span class="s1"> = </span><span class="si">{CoordinateX}</span><span class="s1">&#39;</span><span class="p">)</span>
+
+<span class="n">b</span> <span class="o">=</span> <span class="n">D</span><span class="o">.</span><span class="n">box</span><span class="p">((</span><span class="mf">0.2</span><span class="p">,</span><span class="mf">0.2</span><span class="p">,</span><span class="mf">0.2</span><span class="p">),</span> <span class="p">(</span><span class="mf">0.7</span><span class="p">,</span><span class="mf">0.7</span><span class="p">,</span><span class="mf">0.7</span><span class="p">),</span> <span class="mi">6</span><span class="p">,</span> <span class="n">ntype</span><span class="o">=</span><span class="s1">&#39;QUAD&#39;</span><span class="p">)</span>
+<span class="n">tR</span> <span class="o">=</span> <span class="n">C</span><span class="o">.</span><span class="n">newPyTree</span><span class="p">([</span><span class="s1">&#39;Base&#39;</span><span class="p">,</span> <span class="n">b</span><span class="p">])</span> <span class="c1"># receiver surface tree storing the interpolated flow variable data</span>
+
+<span class="n">tD</span> <span class="o">=</span> <span class="n">Internal</span><span class="o">.</span><span class="n">copyRef</span><span class="p">(</span><span class="n">t</span><span class="p">)</span> <span class="c1"># donor tree storing the interpolation data (interpolation coefficients)</span>
+
+<span class="c1"># create a probe using mode 3</span>
+<span class="n">p3</span> <span class="o">=</span> <span class="n">Probe</span><span class="o">.</span><span class="n">Probe</span><span class="p">(</span><span class="s1">&#39;probe3.cgns&#39;</span><span class="p">,</span> <span class="n">tPermeable</span><span class="o">=</span><span class="n">tR</span><span class="p">,</span> <span class="n">fields</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;F&#39;</span><span class="p">],</span> <span class="n">append</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span> <span class="n">bufferSize</span><span class="o">=</span><span class="mi">100</span><span class="p">)</span>
+
+<span class="c1"># compute the interpolation data for probe extraction (mode 3 only)</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">tD</span><span class="p">,</span> <span class="s1">&#39;</span><span class="si">{cellN}</span><span class="s1"> = 1&#39;</span><span class="p">)</span> <span class="c1"># donor solution is located at the nodes</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">tR</span><span class="p">,</span> <span class="s1">&#39;</span><span class="si">{cellN}</span><span class="s1"> = 2&#39;</span><span class="p">)</span>
+<span class="n">tD</span> <span class="o">=</span> <span class="n">p3</span><span class="o">.</span><span class="n">prepare</span><span class="p">(</span><span class="n">tD</span><span class="p">,</span> <span class="n">loc</span><span class="o">=</span><span class="s1">&#39;nodes&#39;</span><span class="p">)</span>
+</pre></div>
+</div>
+</dd></dl>
+
+<hr class="docutils" />
+<dl class="py function">
+<dt class="sig sig-object py" id="Post.Probe.Probe.extract">
+<span class="sig-prename descclassname"><span class="pre">Probe.</span></span><span class="sig-name descname"><span class="pre">extract</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">t</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">time</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">-1.</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">value</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">[]</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">onlyTransfer</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">False</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="_modules/Post/Probe.html#Probe.extract"><span class="viewcode-link"><span class="pre">[source]</span></span></a></dt>
+<dd><p><strong>extract</strong> is a method of the Probe class.</p>
+<p>Extract the probe information (coordinates and field) at a given time from t.</p>
+<p>Flow solution and grid coordinate extractions from the donor tree t are based on the information located in the Internal.__FlowSolutionNodes__, Internal.__FlowSolutionCenters, and Internal.__FlowSolutionCenters__ containers. Users can modify these container names by editing the constant names in the Internal module. New containers are created each time the local buffer size exceeds the bufferSize limits specified by the user.</p>
+<p>Probe information data is then stored in the following fixed container names: GridCoordinates#i, FlowSolution#i, and FlowSolution#Centers#i, where i is an iterator that is automatically set and handled by the Probe class.</p>
+<p>To extract the receiver tree interpolated data at a given time without stacking the information (coordinates and field) in the probe, set onlyTransfer to True for mode 3. This option is useful when users only want to monitor integral quantities instead of monitoring all solution fields over time.</p>
+<dl class="field-list simple">
+<dt class="field-odd">Parameters<span class="colon">:</span></dt>
+<dd class="field-odd"><ul class="simple">
+<li><p><strong>t</strong> (<em>pyTree</em>) &#8211; pyTree containing the flow solution</p></li>
+<li><p><strong>time</strong> (<em>float</em>) &#8211; extraction time</p></li>
+<li><p><strong>value</strong> (<em>list</em><em> of </em><em>floats</em>) &#8211; list of values to be stored in probe (only for mode 4)</p></li>
+<li><p><strong>onlyTransfer</strong> (<em>boolean</em>) &#8211; deactivate information stacking in the probe object (only for mode 3)</p></li>
+</ul>
+</dd>
+</dl>
+<p><em>Example of use:</em></p>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>for simpler examples of each mode, see the Post.Probe.Probe function definition.</p>
+</div>
+<ul class="simple">
+<li><p><a class="reference external" href="Examples/Post/probeExtractPT.py">Probe extraction using both mode 3 and mode 4 to monitor integral quantities (pyTree)</a>:</p></li>
+</ul>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="c1"># - Probe extract (pyTree) -</span>
+<span class="kn">import</span> <span class="nn">Post.Probe</span> <span class="k">as</span> <span class="nn">Probe</span>
+<span class="kn">import</span> <span class="nn">Converter.Internal</span> <span class="k">as</span> <span class="nn">Internal</span>
+<span class="kn">import</span> <span class="nn">Converter.PyTree</span> <span class="k">as</span> <span class="nn">C</span>
+<span class="kn">import</span> <span class="nn">Generator.PyTree</span> <span class="k">as</span> <span class="nn">G</span>
+<span class="kn">import</span> <span class="nn">Post.PyTree</span> <span class="k">as</span> <span class="nn">P</span>
+
+<span class="c1"># test case</span>
+<span class="n">a</span> <span class="o">=</span> <span class="n">G</span><span class="o">.</span><span class="n">cart</span><span class="p">((</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">),</span> <span class="p">(</span><span class="mf">0.1</span><span class="p">,</span><span class="mf">0.1</span><span class="p">,</span><span class="mf">0.1</span><span class="p">),</span> <span class="p">(</span><span class="mi">51</span><span class="p">,</span><span class="mi">11</span><span class="p">,</span><span class="mi">11</span><span class="p">))</span>
+<span class="n">t</span> <span class="o">=</span> <span class="n">C</span><span class="o">.</span><span class="n">newPyTree</span><span class="p">([</span><span class="s1">&#39;Base&#39;</span><span class="p">,</span> <span class="n">a</span><span class="p">])</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;</span><span class="si">{Density}</span><span class="s1"> = 1.&#39;</span><span class="p">)</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;</span><span class="si">{VelocityX}</span><span class="s1"> = </span><span class="si">{CoordinateX}</span><span class="s1">-1&#39;</span><span class="p">)</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;</span><span class="si">{VelocityY}</span><span class="s1"> = </span><span class="si">{CoordinateY}</span><span class="s1">-1&#39;</span><span class="p">)</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;</span><span class="si">{VelocityZ}</span><span class="s1"> = </span><span class="si">{CoordinateZ}</span><span class="s1">-1&#39;</span><span class="p">)</span>
+
+<span class="n">b1</span> <span class="o">=</span> <span class="n">G</span><span class="o">.</span><span class="n">cart</span><span class="p">((</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">),</span> <span class="p">(</span><span class="mf">0.</span><span class="p">,</span><span class="mf">0.1</span><span class="p">,</span><span class="mf">0.1</span><span class="p">),</span> <span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">11</span><span class="p">,</span><span class="mi">11</span><span class="p">));</span> <span class="n">b1</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span> <span class="o">=</span> <span class="s1">&#39;upstream&#39;</span>
+<span class="n">b2</span> <span class="o">=</span> <span class="n">G</span><span class="o">.</span><span class="n">cart</span><span class="p">((</span><span class="mi">5</span><span class="p">,</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">),</span> <span class="p">(</span><span class="mf">0.</span><span class="p">,</span><span class="mf">0.1</span><span class="p">,</span><span class="mf">0.1</span><span class="p">),</span> <span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">11</span><span class="p">,</span><span class="mi">11</span><span class="p">));</span> <span class="n">b2</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span> <span class="o">=</span> <span class="s1">&#39;downstream&#39;</span>
+<span class="n">tR</span> <span class="o">=</span> <span class="n">C</span><span class="o">.</span><span class="n">newPyTree</span><span class="p">([</span><span class="s1">&#39;Base&#39;</span><span class="p">,</span> <span class="p">[</span><span class="n">b1</span><span class="p">,</span><span class="n">b2</span><span class="p">]])</span>
+<span class="n">G</span><span class="o">.</span><span class="n">_getSmoothNormalMap</span><span class="p">(</span><span class="n">tR</span><span class="p">)</span>
+
+<span class="n">tD</span> <span class="o">=</span> <span class="n">Internal</span><span class="o">.</span><span class="n">copyRef</span><span class="p">(</span><span class="n">t</span><span class="p">)</span>
+
+<span class="c1"># create a first probe using mode 3</span>
+<span class="n">fields</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;Density&#39;</span><span class="p">,</span> <span class="s1">&#39;VelocityX&#39;</span><span class="p">,</span> <span class="s1">&#39;VelocityY&#39;</span><span class="p">,</span> <span class="s1">&#39;VelocityZ&#39;</span><span class="p">]</span>
+<span class="n">p3</span> <span class="o">=</span> <span class="n">Probe</span><span class="o">.</span><span class="n">Probe</span><span class="p">(</span><span class="s1">&#39;probe3.cgns&#39;</span><span class="p">,</span> <span class="n">tPermeable</span><span class="o">=</span><span class="n">tR</span><span class="p">,</span> <span class="n">fields</span><span class="o">=</span><span class="n">fields</span><span class="p">,</span> <span class="n">append</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span> <span class="n">bufferSize</span><span class="o">=</span><span class="mi">100</span><span class="p">)</span>
+<span class="n">tD</span> <span class="o">=</span> <span class="n">p3</span><span class="o">.</span><span class="n">prepare</span><span class="p">(</span><span class="n">tD</span><span class="p">,</span> <span class="n">loc</span><span class="o">=</span><span class="s1">&#39;nodes&#39;</span><span class="p">)</span>
+
+<span class="c1"># create a second probe using mode 4</span>
+<span class="n">p4</span> <span class="o">=</span> <span class="n">Probe</span><span class="o">.</span><span class="n">Probe</span><span class="p">(</span><span class="s1">&#39;probe4.cgns&#39;</span><span class="p">,</span> <span class="n">fields</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;massflow_upstream&#39;</span><span class="p">,</span> <span class="s1">&#39;massflow_downstream&#39;</span><span class="p">],</span> <span class="n">bufferSize</span><span class="o">=</span><span class="mi">100</span><span class="p">,</span> <span class="n">append</span><span class="o">=</span><span class="kc">False</span><span class="p">)</span>
+
+<span class="c1"># extract flow information on the receiver surface tree</span>
+<span class="k">for</span> <span class="n">varname</span> <span class="ow">in</span> <span class="n">fields</span><span class="p">:</span> <span class="n">C</span><span class="o">.</span><span class="n">_cpVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="n">varname</span> <span class="p">,</span> <span class="n">tD</span><span class="p">,</span> <span class="n">varname</span><span class="p">)</span>
+<span class="n">p3</span><span class="o">.</span><span class="n">extract</span><span class="p">(</span><span class="n">tD</span><span class="p">,</span> <span class="n">onlyTransfer</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+
+<span class="c1"># tR interpolated data are now updated: integral quantities can be computed on each surface</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">tR</span><span class="p">,</span> <span class="s1">&#39;</span><span class="si">{massflow}</span><span class="s1">=</span><span class="si">{Density}</span><span class="s1">*(</span><span class="si">{sx}</span><span class="s1">*</span><span class="si">{VelocityX}</span><span class="s1">+</span><span class="si">{sy}</span><span class="s1">*</span><span class="si">{VelocityY}</span><span class="s1">+</span><span class="si">{sz}</span><span class="s1">*</span><span class="si">{VelocityZ}</span><span class="s1">)&#39;</span><span class="p">)</span>
+
+<span class="n">z_upstream</span> <span class="o">=</span> <span class="n">Internal</span><span class="o">.</span><span class="n">getNodeFromName</span><span class="p">(</span><span class="n">tR</span><span class="p">,</span> <span class="s1">&#39;upstream&#39;</span><span class="p">)</span>
+<span class="n">massflow_upstream</span> <span class="o">=</span> <span class="n">P</span><span class="o">.</span><span class="n">integ</span><span class="p">(</span><span class="n">z_upstream</span><span class="p">,</span> <span class="s1">&#39;massflow&#39;</span><span class="p">)[</span><span class="mi">0</span><span class="p">]</span>
+
+<span class="n">z_downstream</span> <span class="o">=</span> <span class="n">Internal</span><span class="o">.</span><span class="n">getNodeFromName</span><span class="p">(</span><span class="n">tR</span><span class="p">,</span> <span class="s1">&#39;downstream&#39;</span><span class="p">)</span>
+<span class="n">massflow_downstream</span> <span class="o">=</span> <span class="n">P</span><span class="o">.</span><span class="n">integ</span><span class="p">(</span><span class="n">z_downstream</span><span class="p">,</span> <span class="s1">&#39;massflow&#39;</span><span class="p">)[</span><span class="mi">0</span><span class="p">]</span>
+
+<span class="c1"># store data information in the p4 probe using single integrated values</span>
+<span class="n">p4</span><span class="o">.</span><span class="n">extract</span><span class="p">(</span><span class="n">time</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="n">value</span><span class="o">=</span><span class="p">[</span><span class="n">massflow_upstream</span><span class="p">,</span> <span class="n">massflow_downstream</span><span class="p">])</span>
+
+<span class="n">p4</span><span class="o">.</span><span class="n">flush</span><span class="p">()</span>
+</pre></div>
+</div>
+</dd></dl>
+
+<hr class="docutils" />
+<dl class="py function">
+<dt class="sig sig-object py" id="Post.Probe.Probe.flush">
+<span class="sig-prename descclassname"><span class="pre">Probe.</span></span><span class="sig-name descname"><span class="pre">flush</span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="reference internal" href="_modules/Post/Probe.html#Probe.flush"><span class="viewcode-link"><span class="pre">[source]</span></span></a></dt>
+<dd><p><strong>flush</strong> is a method of the Probe class.</p>
+<p>Force buffered data to be written in the associated probe file before reaching the user input bufferSize limit.</p>
+<p><em>Example of use:</em></p>
+<ul class="simple">
+<li><p><a class="reference external" href="Examples/Post/probeFlushPT.py">Flush unsaved probe data to disk. (pyTree)</a>:</p></li>
+</ul>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="c1"># - Probe flush (pyTree) -</span>
+<span class="kn">import</span> <span class="nn">Post.Probe</span> <span class="k">as</span> <span class="nn">Probe</span>
+
+<span class="c1"># create a probe using mode 4</span>
+<span class="n">p4</span> <span class="o">=</span> <span class="n">Probe</span><span class="o">.</span><span class="n">Probe</span><span class="p">(</span><span class="s1">&#39;probe4.cgns&#39;</span><span class="p">,</span> <span class="n">fields</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;Density&#39;</span><span class="p">,</span> <span class="s1">&#39;Mach&#39;</span><span class="p">],</span> <span class="n">append</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span> <span class="n">bufferSize</span><span class="o">=</span><span class="mi">100</span><span class="p">)</span>
+
+<span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="mi">110</span><span class="p">):</span>
+    <span class="n">p4</span><span class="o">.</span><span class="n">extract</span><span class="p">(</span><span class="n">time</span><span class="o">=</span><span class="n">i</span><span class="o">*</span><span class="mf">0.1</span><span class="p">,</span> <span class="n">value</span><span class="o">=</span><span class="p">[</span><span class="n">i</span><span class="p">,</span> <span class="n">i</span><span class="o">*</span><span class="mi">10</span><span class="p">])</span> 
+    <span class="c1"># p4 will automatically flushed itself when reaching the buffer size limit (100)</span>
+
+<span class="c1"># flush current buffered data to disk to save last extractions</span>
+<span class="n">p4</span><span class="o">.</span><span class="n">flush</span><span class="p">()</span>
+</pre></div>
+</div>
+</dd></dl>
+
+<hr class="docutils" />
+<dl class="py function">
+<dt class="sig sig-object py" id="Post.Probe.Probe.read">
+<span class="sig-prename descclassname"><span class="pre">Probe.</span></span><span class="sig-name descname"><span class="pre">read</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">cont</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">ind</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">probeName</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="_modules/Post/Probe.html#Probe.read"><span class="viewcode-link"><span class="pre">[source]</span></span></a></dt>
+<dd><p>Read the data stored in the probe file and return either a zone or a list of zones.</p>
+<p>The Probe object must already be instantiated with the desired probe file name. Otherwise, use Post.Probe.Probe(fileName) to create a new probe object from an existing probe file for reading purposes only.</p>
+<p>Can be used in two ways:</p>
+<ul class="simple">
+<li><p><strong>extract all points</strong>: if cont is provided, this function extracts all data from the given time container.</p></li>
+<li><p><strong>extract all times</strong>: if ind and probeName are provided, this function now extracts the given index value(s) of the given zone at all times.</p></li>
+</ul>
+<p>If ind is provided but probeName is not, the function will automatically selects the first zone in the probe.</p>
+<p>When extracting all points, the output is a list of zones. Each zone corresponds to a probe zone at a single time included in the loaded container.</p>
+<p>When extracting all times, the output is a single zone. This zone contains numpy arrays of size (ntime,npoints) depending on the number of point indices provided.</p>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>For modes 0, 1, and 4, probes consist of only one zone named &#8216;probe&#8217;. For modes 2 and 3, probes contain the same number of zones as the original tree (t for mode 2 or tPermeable for mode 3).</p>
+</div>
+<dl class="field-list simple">
+<dt class="field-odd">Parameters<span class="colon">:</span></dt>
+<dd class="field-odd"><ul class="simple">
+<li><p><strong>cont</strong> (<em>integer</em>) &#8211; time container number</p></li>
+<li><p><strong>ind</strong> (<em>integer</em><em>, </em><em>tuple</em><em> of </em><em>3 integers</em><em> (</em><em>i</em><em>,</em><em>j</em><em>,</em><em>k</em><em>)</em><em>, </em><em>list</em><em> of </em><em>integers</em><em>, or </em><em>list</em><em> of </em><em>tuples</em><em> of </em><em>3 integers</em><em> [</em><em>(</em><em>i1</em><em>,</em><em>j1</em><em>,</em><em>k1</em><em>)</em><em>, </em><em>(</em><em>i2</em><em>,</em><em>j2</em><em>,</em><em>k2</em><em>)</em><em>, </em><em>...</em><em>]</em>) &#8211; index (or indices) of probe point(s) located in probeName</p></li>
+<li><p><strong>probeName</strong> (<em>string</em><em> or </em><em>int</em>) &#8211; only used when ind is provided. Name or number of the probe zone to extract</p></li>
+</ul>
+</dd>
+<dt class="field-even">Return type<span class="colon">:</span></dt>
+<dd class="field-even"><p>zone or list of zones</p>
+</dd>
+</dl>
+<p><em>Example of use:</em></p>
+<ul class="simple">
+<li><p><a class="reference external" href="Examples/Post/probeReadPT.py">Read data from probe file. (pyTree)</a>:</p></li>
+</ul>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="c1"># - Probe read (pyTree) -</span>
+<span class="kn">import</span> <span class="nn">Post.Probe</span> <span class="k">as</span> <span class="nn">Probe</span>
+<span class="kn">import</span> <span class="nn">Converter.PyTree</span> <span class="k">as</span> <span class="nn">C</span>
+<span class="kn">import</span> <span class="nn">Converter.Internal</span> <span class="k">as</span> <span class="nn">Internal</span>
+<span class="kn">import</span> <span class="nn">Generator.PyTree</span> <span class="k">as</span> <span class="nn">G</span>
+
+<span class="c1"># test case</span>
+<span class="n">a</span> <span class="o">=</span> <span class="n">G</span><span class="o">.</span><span class="n">cartRx</span><span class="p">((</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">,</span><span class="mi">0</span><span class="p">),</span> <span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">1</span><span class="p">,</span><span class="mi">1</span><span class="p">),</span> <span class="p">(</span><span class="mi">30</span><span class="p">,</span><span class="mi">30</span><span class="p">,</span><span class="mi">30</span><span class="p">),</span> <span class="p">(</span><span class="mi">5</span><span class="p">,</span><span class="mi">5</span><span class="p">,</span><span class="mi">5</span><span class="p">))</span>
+<span class="n">t</span> <span class="o">=</span> <span class="n">C</span><span class="o">.</span><span class="n">newPyTree</span><span class="p">([</span><span class="s1">&#39;Base&#39;</span><span class="p">,</span> <span class="n">a</span><span class="p">])</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fx} = {centers:CoordinateX}&#39;</span><span class="p">)</span>
+<span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fy} = {centers:CoordinateY}&#39;</span><span class="p">)</span>
+
+<span class="c1"># create a probe using mode 1</span>
+<span class="n">fields</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;centers:Fx&#39;</span><span class="p">,</span> <span class="s1">&#39;centers:Fy&#39;</span><span class="p">]</span>
+<span class="n">p1</span> <span class="o">=</span> <span class="n">Probe</span><span class="o">.</span><span class="n">Probe</span><span class="p">(</span><span class="s1">&#39;probe1.cgns&#39;</span><span class="p">,</span> <span class="n">t</span><span class="p">,</span> <span class="n">ind</span><span class="o">=</span><span class="p">(</span><span class="mi">10</span><span class="p">,</span><span class="mi">10</span><span class="p">,</span><span class="mi">10</span><span class="p">),</span> <span class="n">blockName</span><span class="o">=</span><span class="s1">&#39;cart1-1-1&#39;</span><span class="p">,</span> <span class="n">fields</span><span class="o">=</span><span class="n">fields</span><span class="p">,</span> <span class="n">append</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span> <span class="n">bufferSize</span><span class="o">=</span><span class="mi">100</span><span class="p">)</span>
+<span class="n">p1</span><span class="o">.</span><span class="n">printInfo</span><span class="p">()</span>
+
+<span class="c1"># extract probe information over time</span>
+<span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="mi">210</span><span class="p">):</span>
+    <span class="n">time</span> <span class="o">=</span> <span class="mf">0.1</span><span class="o">*</span><span class="n">i</span>
+    <span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fx} = {centers:Fx} + cos(</span><span class="si">%f</span><span class="s1">)&#39;</span><span class="o">%</span><span class="n">time</span><span class="p">,</span> <span class="n">isVectorized</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+    <span class="n">C</span><span class="o">.</span><span class="n">_initVars</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="s1">&#39;{centers:Fy} = {centers:Fx} + sin(</span><span class="si">%f</span><span class="s1">)&#39;</span><span class="o">%</span><span class="n">time</span><span class="p">,</span> <span class="n">isVectorized</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+    <span class="n">p1</span><span class="o">.</span><span class="n">extract</span><span class="p">(</span><span class="n">t</span><span class="p">,</span> <span class="n">time</span><span class="o">=</span><span class="n">time</span><span class="p">)</span>
+
+<span class="c1"># flush current buffered data to disk to save last extractions</span>
+<span class="n">p1</span><span class="o">.</span><span class="n">flush</span><span class="p">()</span>
+
+<span class="c1"># reread probe from file (not necessary here as the probe object p1 is already loaded)</span>
+<span class="n">p1</span> <span class="o">=</span> <span class="n">Probe</span><span class="o">.</span><span class="n">Probe</span><span class="p">(</span><span class="s1">&#39;probe1.cgns&#39;</span><span class="p">)</span>
+
+<span class="c1"># extract all points</span>
+<span class="n">out</span> <span class="o">=</span> <span class="n">p1</span><span class="o">.</span><span class="n">read</span><span class="p">(</span><span class="n">cont</span><span class="o">=</span><span class="mi">0</span><span class="p">)</span> <span class="c1"># get all the information located in the first container</span>
+<span class="n">Internal</span><span class="o">.</span><span class="n">printTree</span><span class="p">(</span><span class="n">out</span><span class="p">)</span> <span class="c1"># list of 100 zones named &#39;probe@it&#39; where &#39;it&#39; goes from 0 to 99 (bufferSize-1)</span>
+
+<span class="c1"># extract all times</span>
+<span class="n">out</span> <span class="o">=</span> <span class="n">p1</span><span class="o">.</span><span class="n">read</span><span class="p">(</span><span class="n">ind</span><span class="o">=</span><span class="mi">0</span><span class="p">,</span> <span class="n">probeName</span><span class="o">=</span><span class="mi">0</span><span class="p">)</span> <span class="c1"># get all the information over time of the first point of the first probe zone</span>
+<span class="n">Internal</span><span class="o">.</span><span class="n">printTree</span><span class="p">(</span><span class="n">out</span><span class="p">)</span> <span class="c1"># mono zone with numpy arrays of size 210</span>
+</pre></div>
+</div>
+</dd></dl>
+
+<hr class="docutils" />
+</section>
+</section>
+</section>
+
+
+            <div class="clearer"></div>
+          </div>
+        </div>
+      </div>
+      <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
+        <div class="sphinxsidebarwrapper">
+  <div>
+    <h3><a href="Post.html">Table of Contents</a></h3>
+    <ul>
+<li><a class="reference internal" href="#">Post.Probe: Probe extraction</a><ul>
+<li><a class="reference internal" href="#list-of-functions">List of functions</a></li>
+<li><a class="reference internal" href="#contents">Contents</a><ul>
+<li><a class="reference internal" href="#probe-creation">Probe creation</a><ul>
+<li><a class="reference internal" href="#Post.Probe.Probe"><code class="docutils literal notranslate"><span class="pre">Post.Probe.Probe()</span></code></a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#probe-methods">Probe methods</a><ul>
+<li><a class="reference internal" href="#Post.Probe.Probe.printInfo"><code class="docutils literal notranslate"><span class="pre">Probe.printInfo()</span></code></a></li>
+<li><a class="reference internal" href="#Post.Probe.Probe.prepare"><code class="docutils literal notranslate"><span class="pre">Probe.prepare()</span></code></a></li>
+<li><a class="reference internal" href="#Post.Probe.Probe.extract"><code class="docutils literal notranslate"><span class="pre">Probe.extract()</span></code></a></li>
+<li><a class="reference internal" href="#Post.Probe.Probe.flush"><code class="docutils literal notranslate"><span class="pre">Probe.flush()</span></code></a></li>
+<li><a class="reference internal" href="#Post.Probe.Probe.read"><code class="docutils literal notranslate"><span class="pre">Probe.read()</span></code></a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+
+  </div>
+<div id="searchbox" style="display: none" role="search">
+  <h3 id="searchlabel">Quick search</h3>
+    <div class="searchformwrapper">
+    <form class="search" action="search.html" method="get">
+      <input type="text" name="q" aria-labelledby="searchlabel" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"/>
+      <input type="submit" value="Go" />
+    </form>
+    </div>
+</div>
+<script>document.getElementById('searchbox').style.display = "block"</script><a  href="Probe.pdf" target="_self">Download pdf version</a>
+<p></p>
+<head>
+<style>
+#myBtn {
+  display: none;
+  position: fixed;
+  bottom: 20px;
+  right: 30px;
+  z-index: 99;
+  border: none;
+  outline: none;
+  background-color: #282a35;
+  cursor: pointer;
+  padding: 15px;
+  border-radius: 10px;
+}
+
+#myBtn:hover {
+  background-color: rgb(26,85,85);
+}
+
+#myImg:hover {
+  opacity: 50%;
+}
+
+</style>
+</head>
+
+<button onclick="topFunction()" id="myBtn" title="Go to top"><img src="./_static/icon.png" width="20" height="20"></button>
+
+<script>
+const targetDiv = document.getElementsByClassName('sphinxsidebarwrapper')[0];
+
+const link = document.createElement('a');
+link.href = "../index.html";
+
+const newImage = document.createElement('img');
+newImage.src = '../Images/CassiopeeLogo.png';
+newImage.id = 'myImg';
+newImage.style.width = '80%';
+newImage.style.height = 'auto';
+newImage.style.border = 'none';
+newImage.style.borderRadius = '0px';
+newImage.style.marginLeft = '18px';
+newImage.style.marginBottom = '50px';
+
+// Append the image to the div
+link.appendChild(newImage);
+targetDiv.prepend(link);
+
+// When the user scrolls down 20px from the top of the document, show the button
+window.onscroll = scrollFunction;
+function scrollFunction() {
+    if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
+        document.getElementById("myBtn").style.display = "block";
+    } else {
+        document.getElementById("myBtn").style.display = "none";
+    }
+}
+
+// When the user clicks on the button, scroll to the top of the document
+function topFunction() {
+    document.body.scrollTop = 0;
+    document.documentElement.scrollTop = 0;
+}
+
+// When the window is too small, hide the sidebar
+window.onresize = resizeFunction;
+window.onload = resizeFunction;
+function resizeFunction() {
+  var bodyWidth = document.bodyWidth;
+  if (window.outerWidth < 1000) {
+        document.getElementsByClassName("sphinxsidebar")[0].style.visibility = "hidden";
+        document.getElementById("myBtn").style.visibility = "visible";
+        document.getElementsByClassName("body")[0].style.marginLeft = "-170px";
+        document.getElementsByClassName("body")[0].style.maxWidth = "135%";
+        document.getElementsByClassName("body")[0].style.paddingLeft = "30px";
+    } else {
+        document.getElementsByClassName("sphinxsidebar")[0].style.visibility = "visible";
+        document.getElementsByClassName("body")[0].style.marginLeft = "130px";
+        document.getElementsByClassName("body")[0].style.maxWidth = "80%";
+        document.getElementsByClassName("body")[0].style.paddingLeft = "0px";
+    }
+}
+
+</script>
+        </div>
+      </div>
+      <div class="clearer"></div>
+    </div>
+    <div class="related" role="navigation" aria-label="related navigation">
+      <h3>Navigation</h3>
+      <ul>
+        <li class="right" style="margin-right: 10px">
+          <a href="genindex.html" title="General Index"
+             >index</a></li>
+        <li class="right" >
+          <a href="py-modindex.html" title="Python Module Index"
+             >modules</a> |</li>
+        <li class="nav-item nav-item-0"><a href="Post.html">Post 4.1 documentation</a> &#187;</li>
+        <li class="nav-item nav-item-this"><a href="">Post.Probe: Probe extraction</a></li> 
+      </ul>
+    </div>
+    <div class="footer" role="contentinfo">
+    </div>
+  </body>
+</html>

--- a/docs/doc/Probe.html
+++ b/docs/doc/Probe.html
@@ -39,13 +39,7 @@
         <div class="bodywrapper">
           <div class="body" role="main">
             
-  <p>for i in range(ncont).. Probe documentation master file</p>
-<dl class="field-list simple">
-<dt class="field-odd">tocdepth<span class="colon">:</span></dt>
-<dd class="field-odd"><p>2</p>
-</dd>
-</dl>
-<section id="post-probe-probe-extraction">
+  <section id="post-probe-probe-extraction">
 <h1>Post.Probe: Probe extraction</h1>
 <p>Specific probe extraction module.</p>
 <p>This page describes how the object-oriented Probe module operates. The various methods presented below should be used after instantiating a Probe object of the same-named class.</p>
@@ -624,21 +618,7 @@
     <ul>
 <li><a class="reference internal" href="#">Post.Probe: Probe extraction</a><ul>
 <li><a class="reference internal" href="#list-of-functions">List of functions</a></li>
-<li><a class="reference internal" href="#contents">Contents</a><ul>
-<li><a class="reference internal" href="#probe-creation">Probe creation</a><ul>
-<li><a class="reference internal" href="#Post.Probe.Probe"><code class="docutils literal notranslate"><span class="pre">Post.Probe.Probe()</span></code></a></li>
-</ul>
-</li>
-<li><a class="reference internal" href="#probe-methods">Probe methods</a><ul>
-<li><a class="reference internal" href="#Post.Probe.Probe.printInfo"><code class="docutils literal notranslate"><span class="pre">Probe.printInfo()</span></code></a></li>
-<li><a class="reference internal" href="#Post.Probe.Probe.prepare"><code class="docutils literal notranslate"><span class="pre">Probe.prepare()</span></code></a></li>
-<li><a class="reference internal" href="#Post.Probe.Probe.extract"><code class="docutils literal notranslate"><span class="pre">Probe.extract()</span></code></a></li>
-<li><a class="reference internal" href="#Post.Probe.Probe.flush"><code class="docutils literal notranslate"><span class="pre">Probe.flush()</span></code></a></li>
-<li><a class="reference internal" href="#Post.Probe.Probe.read"><code class="docutils literal notranslate"><span class="pre">Probe.read()</span></code></a></li>
-</ul>
-</li>
-</ul>
-</li>
+<li><a class="reference internal" href="#contents">Contents</a></li>
 </ul>
 </li>
 </ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -115,6 +115,7 @@
           <ul>
             <li><a href="doc/ExtraVariables2.html"><strong>Post.ExtraVariables2:</strong> compute derived fields from primitive variables</a></li>
             <li><a href="doc/Rotor.html"><strong>Post.Rotor:</strong> Specific rotor and propeller post-processing</a></li>
+            <li><a href="doc/Probe.html"><strong>Post.Probe:</strong> Probe extraction</a></li>
             <li><a href="doc/Post_IBM.html"><strong>Post.IBM:</strong> Specific post-processing for IBM simulations</a></li>
           </ul>
 


### PR DESCRIPTION
No regressions.

Minor modifications in probe module for consistency and clarity. Add new functionalities regarding mode 4 and flow solutions located at centers.

New Probe module doc outside of Post to enhance clarity and copy other submodules (e.g., Rotor, IBM, etc.). The doc is now extended with new test case examples.

------

Two small patches have been added to the readInd() function to replicate the previous behavior and avoid regressions. Previous implementation prevented from reading flow solution containers stored at the centers while erroneously increasing the numpy array size in the output zone when both FlowSolution @ centers and @ nodes were in the probe.

A future commit will remove these patches and update probePT_t1.py and probePT_m5.py test cases. 