### PR TITLE
KCore/Generator: cleanConnectivity/close: fix bug when cleaning orphans

### DIFF
--- a/Cassiopee/Converter/Converter/convertStruct2NGon.cpp
+++ b/Cassiopee/Converter/Converter/convertStruct2NGon.cpp
@@ -392,6 +392,6 @@ PyObject* K_CONVERTER::convertStruct2NGon(PyObject* self, PyObject* args)
   );
   
   RELEASESHAREDU(tpl, f2, cn2);
-  if (tplClean == NULL) return tpl;
-  else { Py_DECREF(tpl); return tplClean; }
+  Py_DECREF(tpl);
+  return tplClean;
 }

--- a/Cassiopee/Converter/Converter/convertUnstruct2NGon.cpp
+++ b/Cassiopee/Converter/Converter/convertUnstruct2NGon.cpp
@@ -396,6 +396,6 @@ PyObject* K_CONVERTER::convertUnstruct2NGon(PyObject* self, PyObject* args)
   );
   
   RELEASESHAREDU(tpl, f2, cn2);
-  if (tplClean == NULL) return tpl;
-  else { Py_DECREF(tpl); return tplClean; }
+  Py_DECREF(tpl);
+  return tplClean;
 }

--- a/Cassiopee/Generator/Generator/PyTree.py
+++ b/Cassiopee/Generator/Generator/PyTree.py
@@ -981,6 +981,17 @@ def _close(t, tol=1.e-12, rmOverlappingPts=True, rmOrphanPts=True,
     C.setFields(fields, t, 'nodes')
     return None
 
+def rmOrphans(a):
+    """Remove orphan vertices."""
+    return close(a, rmOverlappingPts=False, rmOrphanPts=True,
+                 rmDuplicatedFaces=False, rmDuplicatedElts=False,
+                 rmDegeneratedFaces=False, rmDegeneratedElts=False)
+
+def _rmOrphans(a):
+    return _close(a, rmOverlappingPts=False, rmOrphanPts=True,
+                  rmDuplicatedFaces=False, rmDuplicatedElts=False,
+                  rmDegeneratedFaces=False, rmDegeneratedElts=False)
+
 def zip(a, tol=1.e-12):
     """Zip zones if they are distant of tol."""
     t = Internal.copyRef(a)

--- a/Cassiopee/Generator/Generator/close.cpp
+++ b/Cassiopee/Generator/Generator/close.cpp
@@ -91,8 +91,7 @@ PyObject* K_GENERATOR::closeMesh(PyObject* self, PyObject* args)
         rmDegeneratedFaces, rmDegeneratedElts, exportIndirPts);
 
     RELEASESHAREDU(array, f, cn);
-    if (tpl == NULL) return array;
-    else return tpl;
+    return tpl;
   }
   else
   {

--- a/Cassiopee/Generator/Generator/stack.cpp
+++ b/Cassiopee/Generator/Generator/stack.cpp
@@ -45,7 +45,7 @@ PyObject* K_GENERATOR::stackMesh(PyObject* self, PyObject* args)
 
   E_Int ns = structF.size();
   E_Int nu = unstructF.size();
-  PyObject* tpl=NULL;
+  PyObject* tpl = NULL;
 
   if (ns >= 2) // concatenate all structs, il doivent etre tous ni*nj et memes champs
   {

--- a/Cassiopee/Generator/doc/source/Generator.rst
+++ b/Cassiopee/Generator/doc/source/Generator.rst
@@ -97,6 +97,7 @@ List of functions
    :nosignatures:
 
    Generator.close
+   Generator.rmOrphans
    Generator.zip
    Generator.selectInsideElts
    Generator.map
@@ -1310,7 +1311,7 @@ Operations on meshes
     :type rmDegeneratedElts: boolean
     :param indices: vertex indirection table following mesh cleaning
     :type indices: [array, list of arrays]
-    :return: modified reference copy of t
+    :return: modified reference copy of a
     :rtype: array or pyTree
 
     *Example of use:*
@@ -1322,7 +1323,26 @@ Operations on meshes
     * `Mesh closing (pyTree) <Examples/Generator/closePT.py>`_:
 
     .. literalinclude:: ../build/Examples/Generator/closePT.py
-        
+
+---------------------------------------
+
+.. py:function:: Generator.rmOrphans(a)
+
+    Remove orphan vertices from an unstructured mesh defined by array a.
+    
+    Exists also as in place version (_rmOrphans) that modifies a and returns None. 
+
+    :param a:  input mesh
+    :type  a:  array or pyTree
+    :return: modified reference copy of a
+    :rtype: array or pyTree
+
+    *Example of use:*
+
+    * `Mesh closing (pyTree) <Examples/Generator/rmOrphansPT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Generator/rmOrphansPT.py
+
 ---------------------------------------
 
 .. py:function:: Generator.zip(a, tol=1.e-12)

--- a/Cassiopee/Generator/test/rmOrphansPT.py
+++ b/Cassiopee/Generator/test/rmOrphansPT.py
@@ -1,0 +1,65 @@
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+
+insertPos = [3, 10, 22, 57, 91]
+norphans = len(insertPos)
+
+def _addOrphans(t, api):
+    import numpy as np
+    np.random.seed(42)
+
+    gc = Internal.getNodeFromType2(t, 'GridCoordinates_t')
+    n_x = Internal.getNodeFromName1(gc, 'CoordinateX')
+    n_y = Internal.getNodeFromName1(gc, 'CoordinateY')
+    n_z = Internal.getNodeFromName1(gc, 'CoordinateZ')
+    x = n_x[1]; y = n_y[1]; z = n_z[1]
+    ngon = Internal.getNGonNode(t)
+    ec = Internal.getNodeFromName1(ngon, 'ElementConnectivity')[1]
+
+    npts = x.shape[0]
+    npts2 = npts + norphans
+    indir = np.full(npts2, -1, dtype=Internal.E_NpyInt)
+    mask = np.ones(npts2, dtype=bool)
+    mask[insertPos] = False
+    indir[mask] = np.arange(npts)
+    origPts = indir >= 0
+
+    # New coords: copy existing coords and add new ones
+    x2 = np.empty(npts2, dtype=x.dtype)
+    y2 = np.empty(npts2, dtype=y.dtype)
+    z2 = np.empty(npts2, dtype=z.dtype)
+
+    x2[mask] = x[indir[mask]]
+    y2[mask] = y[indir[mask]]
+    z2[mask] = z[indir[mask]]
+
+    x2[~mask] = np.random.uniform(10., 11., norphans)
+    y2[~mask] = np.random.uniform(10., 11., norphans)
+    z2[~mask] = np.random.uniform(10., 11., norphans)
+
+    Internal.setValue(n_x, x2)
+    Internal.setValue(n_y, y2)
+    Internal.setValue(n_z, z2)
+
+    if api != 3:
+        mask = np.zeros(ec.size, dtype=bool)
+        i = 0
+        while i < ec.size:
+            nvert = ec[i]
+            mask[i+1:i+1+nvert] = True
+            i += nvert + 1
+    else:
+        mask = np.ones(ec.size, dtype=bool)
+
+    invIndir = np.empty(npts, dtype=Internal.E_NpyInt)
+    invIndir[indir[origPts]] = np.flatnonzero(origPts)
+    ec[mask] = invIndir[ec[mask] - 1] + 1
+
+    t[1][0][0] += norphans
+
+api = 3
+a = G.cartNGon((0,0,0), (1,1,1), (10,10,10), api=api)
+_addOrphans(a, api=api)
+G._rmOrphans(a)
+C.convertPyTree2File(a, 'out.cgns')

--- a/Cassiopee/Generator/test/rmOrphansPT_t1.py
+++ b/Cassiopee/Generator/test/rmOrphansPT_t1.py
@@ -1,0 +1,79 @@
+# - rmOrphans (pyTree) -
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+import KCore.test as test
+
+insertPos = [3, 10, 22, 57, 91]
+norphans = len(insertPos)
+
+def _addOrphans(t, api):
+    import numpy as np
+    np.random.seed(42)
+
+    gc = Internal.getNodeFromType2(t, 'GridCoordinates_t')
+    n_x = Internal.getNodeFromName1(gc, 'CoordinateX')
+    n_y = Internal.getNodeFromName1(gc, 'CoordinateY')
+    n_z = Internal.getNodeFromName1(gc, 'CoordinateZ')
+    x = n_x[1]; y = n_y[1]; z = n_z[1]
+    ngon = Internal.getNGonNode(t)
+    ec = Internal.getNodeFromName1(ngon, 'ElementConnectivity')[1]
+
+    npts = x.shape[0]
+    npts2 = npts + norphans
+    indir = np.full(npts2, -1, dtype=Internal.E_NpyInt)
+    mask = np.ones(npts2, dtype=bool)
+    mask[insertPos] = False
+    indir[mask] = np.arange(npts)
+    origPts = indir >= 0
+
+    # New coords: copy existing coords and add new ones
+    x2 = np.empty(npts2, dtype=x.dtype)
+    y2 = np.empty(npts2, dtype=y.dtype)
+    z2 = np.empty(npts2, dtype=z.dtype)
+
+    x2[mask] = x[indir[mask]]
+    y2[mask] = y[indir[mask]]
+    z2[mask] = z[indir[mask]]
+
+    x2[~mask] = np.random.uniform(10., 11., norphans)
+    y2[~mask] = np.random.uniform(10., 11., norphans)
+    z2[~mask] = np.random.uniform(10., 11., norphans)
+
+    Internal.setValue(n_x, x2)
+    Internal.setValue(n_y, y2)
+    Internal.setValue(n_z, z2)
+
+    if api != 3:
+        mask = np.zeros(ec.size, dtype=bool)
+        i = 0
+        while i < ec.size:
+            nvert = ec[i]
+            mask[i+1:i+1+nvert] = True
+            i += nvert + 1
+    else:
+        mask = np.ones(ec.size, dtype=bool)
+
+    invIndir = np.empty(npts, dtype=Internal.E_NpyInt)
+    invIndir[indir[origPts]] = np.flatnonzero(origPts)
+    ec[mask] = invIndir[ec[mask] - 1] + 1
+
+    t[1][0][0] += norphans
+
+# add and delete orphans - api 1
+api = 1
+a = G.cartNGon((0,0,0), (1,1,1), (10,10,10), api=api)
+test.testT(a, 1)
+
+_addOrphans(a, api=api)
+G._rmOrphans(a)
+test.testT(a, 2)  # same as ref1 but non-compact
+
+# add and delete orphans - api 3
+api = 3
+a = G.cartNGon((0,0,0), (1,1,1), (10,10,10), api=api)
+test.testT(a, 3)  # create orphan-free ref
+
+_addOrphans(a, api=api)
+G._rmOrphans(a)
+test.testT(a, 3)

--- a/Cassiopee/Post/Post/selectCellCenters.cpp
+++ b/Cassiopee/Post/Post/selectCellCenters.cpp
@@ -251,7 +251,7 @@ PyObject* K_POST::selectCellCenters(PyObject* self, PyObject* args)
 
   // Selection
   PyObject* l = PyList_New(0);
-  PyObject* tpl=NULL;
+  PyObject* tpl = NULL;
 
   if (strcmp(eltType, "NGON") != 0) // tous les elements sauf NGON
   {

--- a/Cassiopee/Transform/Transform/dual.cpp
+++ b/Cassiopee/Transform/Transform/dual.cpp
@@ -96,6 +96,7 @@ PyObject* K_TRANSFORM::dualNGon(PyObject* self, PyObject* args)
   {
     tpl = K_CONNECT::V_cleanConnectivityNGon(posx, posy, posz, varString,
                                              fd, cNGD, 1.e-10);
+    return tpl;
   }
   else
   {

--- a/Cassiopee/Transform/Transform/subzone.cpp
+++ b/Cassiopee/Transform/Transform/subzone.cpp
@@ -78,7 +78,7 @@ PyObject* K_TRANSFORM::subzoneStruct(PyObject* self, PyObject* args)
     }
 
     // Construit l'array resultat
-    PyObject* tpl= K_ARRAY::buildArray3(nfld, varString, in, jn, kn, api);
+    PyObject* tpl = K_ARRAY::buildArray3(nfld, varString, in, jn, kn, api);
     E_Float* fnp = K_ARRAY::getFieldPtr(tpl);
     FldArrayF subzone0(injn*kn, nfld, fnp, true);
 


### PR DESCRIPTION
No regressions

- Fix bug in K_CONNECT::v_cleanConnectivityNGon when cleaning orphans only
- Create G.rmOrphans to remove orphans only from an unstructured array (+ test NGon + doc)
- Return a copy of the input array when there is nothing to do in v_cleanConnectivityNGon

Future work: optimise v_cleanConnectivity