### PR TITLE
Converter: identifyElements ME

### DIFF
--- a/Cassiopee/Converter/Converter/PyTree.py
+++ b/Cassiopee/Converter/Converter/PyTree.py
@@ -4419,7 +4419,7 @@ def _recoverBCs2(t, BCInfo, tol=1.e-11):
     try: import Generator.PyTree as G
     except: raise ImportError("_recoverBCs: requires Generator module.")
     zones = Internal.getZones(t)
-    (BCs, BCNames, BCTypes) = BCInfo
+    BCs, BCNames, BCTypes = BCInfo
     for z in zones:
         dim = Internal.getZoneDim(z)
         if dim[0] == 'Structured': raise ValueError("recoverBC: not for structured grids.")
@@ -4460,53 +4460,37 @@ def _recoverBCs2(t, BCInfo, tol=1.e-11):
                 for b in bc:
                     if Internal.getZoneType(b) == 1: b = convertArray2Hexa(b)
                     if G.bboxIntersection(zf, b):
-                        # Break BC connectivity si necessaire
-                        elts = Internal.getElementNodes(b)
-                        size = 0
-                        for e in elts:
-                            erange = Internal.getNodeFromName1(e, 'ElementRange')[1]
-                            size += erange[1]-erange[0]+1
-                        n = len(elts)
-                        if n == 1:
-                            ids = identifyElements(hook, b, tol)
-                        else:
-                            bb = breakConnectivity(b)
-                            ids = numpy.array([], dtype=Internal.E_NpyInt)
-                            for bc in bb:
-                                ids = numpy.concatenate([ids, identifyElements(hook, bc, tol)])
-
+                        ids = identifyElements(hook, b, tol)
                         # Cree les BCs
-                        ids0 = ids # keep ids for bcdata
-                        ids = ids[ids > -1]
+                        validIds = ids > -1
+                        ids = ids[validIds]
                         sizebc = ids.size
-                        if sizebc > 0:
-                            #if dim[3] == 'NGON':
-                            id2 = numpy.empty(sizebc, dtype=Internal.E_NpyInt)
-                            id2[:] = indicesE[ids[:]-1]
-                            _addBC2Zone(z, BCNames[c], BCTypes[c], faceList=id2)
-                            #else:
-                            #    _addBC2Zone(z, BCNames[c], BCTypes[c], subzone=b)
+                        if sizebc == 0: continue
+                        #if dim[3] == 'NGON':
+                        id2 = numpy.empty(sizebc, dtype=Internal.E_NpyInt)
+                        id2[:] = indicesE[ids[:]-1]
+                        _addBC2Zone(z, BCNames[c], BCTypes[c], faceList=id2)
+                        #else:
+                        #    _addBC2Zone(z, BCNames[c], BCTypes[c], subzone=b)
 
-                            # Recupere BCDataSets
-                            fsc = Internal.getNodeFromName(b, Internal.__FlowSolutionCenters__)
+                        # Recupere BCDataSets
+                        fsc = Internal.getNodeFromName(b, Internal.__FlowSolutionCenters__)
+                        if fsc is not None:
+                            newBCName = getLastBCName(BCNames[c])
+                            bcz = Internal.getNodeFromNameAndType(z, newBCName, 'BC_t')
+                            ds = Internal.newBCDataSet(name='BCDataSet', value='UserDefined',
+                                                       gridLocation='FaceCenter', parent=bcz)
+                            d = Internal.newBCData('NeumannData', parent=ds)
 
-                            if fsc is not None:
-                                newNameOfBC = getLastBCName(BCNames[c])
-                                bcz = Internal.getNodeFromNameAndType(z, newNameOfBC, 'BC_t')
-
-                                ds = Internal.newBCDataSet(name='BCDataSet', value='UserDefined',
-                                                           gridLocation='FaceCenter', parent=bcz)
-                                d = Internal.newBCData('NeumannData', parent=ds)
-
-                                for node in Internal.getChildren(fsc):
-                                    if Internal.isType(node, 'DataArray_t'):
-                                        val0 = Internal.getValue(node)
-                                        if isinstance(val0,numpy.ndarray):
-                                            val0 = numpy.reshape(val0, val0.size, order='F')
-                                        else:
-                                            val0 = numpy.array([val0])
-                                        val1 = val0[ids0>-1]
-                                        Internal._createUniqueChild(d, node[0], 'DataArray_t', value=val1)
+                            for node in Internal.getChildren(fsc):
+                                if Internal.isType(node, 'DataArray_t'):
+                                    val0 = Internal.getValue(node)
+                                    if isinstance(val0,numpy.ndarray):
+                                        val0 = numpy.reshape(val0, val0.size, order='F')
+                                    else:
+                                        val0 = numpy.array([val0])
+                                    val1 = val0[validIds]
+                                    Internal._createUniqueChild(d, node[0], 'DataArray_t', value=val1)
             freeHook(hook)
     return None
 
@@ -4517,7 +4501,7 @@ def _recoverBCs1(a, BCInfo, tol=1.e-11):
     except: raise ImportError("_recoverBCs: requires Post module.")
     _deleteZoneBC__(a)
     zones = Internal.getZones(a)
-    (BCs, BCNames, BCTypes) = BCInfo
+    BCs, BCNames, BCTypes = BCInfo
     for z in zones:
         dim = Internal.getZoneDim(z)
         if dim[0] == 'Structured': raise ValueError("recoverBC: not for structured grids.")
@@ -4530,52 +4514,37 @@ def _recoverBCs1(a, BCInfo, tol=1.e-11):
             if bc == []: raise ValueError("_recoverBCs: boundary is probably ill-defined.")
             for b in bc:
                 if Internal.getZoneType(b) == 1: b = convertArray2Hexa(b)
-                # Break BC connectivity si necessaire
-                elts = Internal.getElementNodes(b)
-                size = 0
-                for e in elts:
-                    erange = Internal.getNodeFromName1(e, 'ElementRange')[1]
-                    size += erange[1]-erange[0]+1
-                n = len(elts)
-                if n == 1: # BE or NGon
-                    ids = identifyElements(hook, b, tol)
-                else: # ME
-                    bb = breakConnectivity(b)
-                    ids = numpy.array([], dtype=Internal.E_NpyInt)
-                    for bc in bb:
-                        ids = numpy.concatenate([ids, identifyElements(hook, bc, tol)])
+                ids = identifyElements(hook, b, tol)
                 # Cree les BCs
-                ids0 = ids # keep ids for bcdata
-                ids = ids[ids > -1]
+                validIds = ids > -1
+                ids = ids[validIds]
                 sizebc = ids.size
-                if sizebc > 0:
-                    #if dim[3] == 'NGON':
-                    id2 = numpy.empty(sizebc, dtype=Internal.E_NpyInt)
-                    id2[:] = indicesF[ids[:]-1]
-                    _addBC2Zone(z, BCNames[c], BCTypes[c], faceList=id2)
-                    #else:
-                    #    _addBC2Zone(z, BCNames[c], BCTypes[c], subzone=b)
+                if sizebc == 0: continue
+                #if dim[3] == 'NGON':
+                id2 = numpy.empty(sizebc, dtype=Internal.E_NpyInt)
+                id2[:] = indicesF[ids[:]-1]
+                _addBC2Zone(z, BCNames[c], BCTypes[c], faceList=id2)
+                #else:
+                #    _addBC2Zone(z, BCNames[c], BCTypes[c], subzone=b)
 
-                    # Recupere BCDataSets
-                    fsc = Internal.getNodeFromName(b, Internal.__FlowSolutionCenters__)
+                # Recupere BCDataSets
+                fsc = Internal.getNodeFromName(b, Internal.__FlowSolutionCenters__)
+                if fsc is not None:
+                    newBCName = getLastBCName(BCNames[c])
+                    bcz = Internal.getNodeFromNameAndType(z, newBCName, 'BC_t')
+                    ds = Internal.newBCDataSet(name='BCDataSet', value='UserDefined',
+                                               gridLocation='FaceCenter', parent=bcz)
+                    d = Internal.newBCData('NeumannData', parent=ds)
 
-                    if fsc is not None:
-                        newNameOfBC = getLastBCName(BCNames[c])
-                        bcz = Internal.getNodeFromNameAndType(z, newNameOfBC, 'BC_t')
-
-                        ds = Internal.newBCDataSet(name='BCDataSet', value='UserDefined',
-                                                   gridLocation='FaceCenter', parent=bcz)
-                        d = Internal.newBCData('NeumannData', parent=ds)
-
-                        for node in Internal.getChildren(fsc):
-                            if Internal.isType(node, 'DataArray_t'):
-                                val0 = Internal.getValue(node)
-                                if isinstance(val0,numpy.ndarray):
-                                    val0 = numpy.reshape(val0, val0.size, order='F')
-                                else:
-                                    val0 = numpy.array([val0])
-                                val1 = val0[ids0>-1]
-                                Internal._createUniqueChild(d, node[0], 'DataArray_t', value=val1)
+                    for node in Internal.getChildren(fsc):
+                        if Internal.isType(node, 'DataArray_t'):
+                            val0 = Internal.getValue(node)
+                            if isinstance(val0,numpy.ndarray):
+                                val0 = numpy.reshape(val0, val0.size, order='F')
+                            else:
+                                val0 = numpy.array([val0])
+                            val1 = val0[validIds]
+                            Internal._createUniqueChild(d, node[0], 'DataArray_t', value=val1)
         freeHook(hook)
     return None
 

--- a/Cassiopee/Converter/Converter/identify.cpp
+++ b/Cassiopee/Converter/Converter/identify.cpp
@@ -417,7 +417,6 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
       {
         // Acces universel element i
         E_Int* elem = cnl->getElt(i, nf, nface, indPH);
-        std::cout << "nf = " << nf << std::endl;
         xf = 0.; yf = 0.; zf = 0.; c = 0;
 
 #ifdef QUADDOUBLE

--- a/Cassiopee/Converter/Converter/identify.cpp
+++ b/Cassiopee/Converter/Converter/identify.cpp
@@ -348,8 +348,8 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
       E_Float pt[3];
       E_Int ic = 0;
 
+#pragma omp for collapse(3)
       for (E_Int k = 0; k < nke; k++)
-#pragma omp for
       for (E_Int j = 0; j < nje; j++)
       for (E_Int i = 0; i < nie; i++)
       {
@@ -417,6 +417,7 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
       {
         // Acces universel element i
         E_Int* elem = cnl->getElt(i, nf, nface, indPH);
+        std::cout << "nf = " << nf << std::endl;
         xf = 0.; yf = 0.; zf = 0.; c = 0;
 
 #ifdef QUADDOUBLE
@@ -444,6 +445,7 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
           for (E_Int n = 0; n < nf; n++)
           { 
             // Acces universel face elem[n]-1
+            std::cout << "elem[n]-1 = " << elem[n]-1 << std::endl;
             E_Int* face = cnl->getFace(elem[n]-1, nv, ngon, indPG);
             for (E_Int p = 0; p < nv; p++)
             {
@@ -463,12 +465,16 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
   }
   else
   {
+    E_Float* xt = centers->begin(1);
+    E_Float* yt = centers->begin(2);
+    E_Float* zt = centers->begin(3);
+
     // Acces universel sur BE/ME
     E_Int nc = cnl->getNConnect();
     // Acces universel aux eltTypes
     std::vector<char*> eltTypes;
     K_ARRAY::extractVars(eltType, eltTypes);
-    E_Int nvert, nelts, ntotelts = 0;
+    std::vector<E_Int> nepc(nc+1, 0);
 
     // Boucle sur toutes les connectivites une premiere fois pour savoir si
     // elles sont valides et calculer le nombre total d'elements - permet
@@ -479,39 +485,37 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
       char* eltTypConn = eltTypes[ic];
       // Check that this connectivity is valid
       if (not(strcmp(eltTypConn,"BAR")==0 || strcmp(eltTypConn,"TRI")==0 || 
-          strcmp(eltTypConn,"QUAD")==0 || strcmp(eltTypConn,"TETRA")==0 || 
-          strcmp(eltTypConn,"HEXA")==0 || strcmp(eltTypConn,"PENTA")==0 ||
-          strcmp(eltTypConn,"PYRA")==0))
+              strcmp(eltTypConn,"QUAD")==0 || strcmp(eltTypConn,"TETRA")==0 || 
+              strcmp(eltTypConn,"HEXA")==0 || strcmp(eltTypConn,"PENTA")==0 ||
+              strcmp(eltTypConn,"PYRA")==0))
       {
         RELEASESHAREDB(res, array, f, cnl);
-        PyErr_SetString(PyExc_TypeError, 
+        PyErr_SetString(PyExc_TypeError,
                         "identifyElements: invalid type of array.");
         return NULL;
       }
-      ntotelts += cm.getSize();
+      nepc[ic+1] += nepc[ic] + cm.getSize();
     }
 
     for (size_t ic = 0; ic < eltTypes.size(); ic++) delete [] eltTypes[ic];
 
-    ac = K_NUMPY::buildNumpyArray(ntotelts, 1, 1);
+    ac = K_NUMPY::buildNumpyArray(nepc[nc], 1, 1);
     E_Int* nptr = K_NUMPY::getNumpyPtrI(ac);
 
     // Boucle sur toutes les connectivites pour remplir ac
-    for (E_Int ic = 0; ic < nc; ic++)
-    {
-      FldArrayI& cm = *(cnl->getConnect(ic));
-      nelts = cm.getSize(); // Number of elements of this connectivity
-      nvert = cm.getNfld(); // Nombre de points par elements de cette connectivite
-      E_Float inv = 1./E_Float(nvert);
-#ifdef QUADDOUBLE
-      quad_double qinv = quad_double(nvert);
-#endif
-      E_Float* xt = centers->begin(1);
-      E_Float* yt = centers->begin(2);
-      E_Float* zt = centers->begin(3);
-
 #pragma omp parallel default(shared)
+    {
+      for (E_Int ic = 0; ic < nc; ic++)
       {
+        FldArrayI& cm = *(cnl->getConnect(ic));
+        E_Int nelts = cm.getSize();
+        E_Int offset = nepc[ic];
+        E_Int nvpe = cm.getNfld();
+        E_Float inv = 1./E_Float(nvpe);
+#ifdef QUADDOUBLE
+        quad_double qinv = quad_double(nvpe);
+#endif
+
         E_Float pt[3];
         E_Float xf,yf,zf,dx,dy,dz;
         E_Int ind;
@@ -524,7 +528,7 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
         {
 #ifdef QUADDOUBLE
           qxf = 0.; qyf =0.; qzf = 0.;
-          for (E_Int n = 1; n <= nvert; n++)
+          for (E_Int n = 1; n <= nvpe; n++)
           {
             ind = cm(i,n)-1;
             qxf = qxf+quad_double(xp[ind]);
@@ -541,7 +545,7 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
             #ifdef __INTEL_COMPILER
             #pragma float_control(precise, on)
             #endif
-            for (E_Int n = 1; n <= nvert; n++)
+            for (E_Int n = 1; n <= nvpe; n++)
             {
               ind = cm(i,n)-1; 
               xf += xp[ind]; yf += yp[ind]; zf += zp[ind];        
@@ -554,14 +558,15 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
           ind = globalKdt->getClosest(pt); // closest pt
           dx = xt[ind]-xf; dy = yt[ind]-yf; dz = zt[ind]-zf;
           //d = dx*dx + dy*dy + dz*dz;
-          //if (d < tol) nptr[i] = ind+1;
-          //else nptr[i] = -1;
-          if (K_FUNC::E_abs(dx) < tol && K_FUNC::E_abs(dy) < tol && K_FUNC::E_abs(dz) < tol) nptr[i] = ind+1;
-          else nptr[i] = -1;
+          //if (d < tol) nptr[offset+i] = ind+1;
+          //else nptr[offset+i] = -1;
+          if (K_FUNC::E_abs(dx) < tol && K_FUNC::E_abs(dy) < tol && K_FUNC::E_abs(dz) < tol) nptr[offset+i] = ind+1;
+          else nptr[offset+i] = -1;
         }
       }
     }
   }
+
   RELEASESHAREDB(res, array, f, cnl);
   return ac;
 }

--- a/Cassiopee/Converter/test/identifyElementsPT_t1.py
+++ b/Cassiopee/Converter/test/identifyElementsPT_t1.py
@@ -1,0 +1,99 @@
+# - identifyElements (pyTree) -
+import Converter.PyTree as C
+import Generator.PyTree as G
+import Post.PyTree as P
+import KCore.test as test
+
+# structured
+a = G.cart((0,0,0), (1,0,0), (10,1,1))
+f = P.exteriorElts(a)
+hook = C.createHook(a, function='elementCenters')
+elts = C.identifyElements(hook, f)
+C.freeHook(hook)
+test.testO(elts, 1)
+
+a = G.cart((0,0,0), (1,1,0), (10,10,1))
+f = P.exteriorElts(a)
+hook = C.createHook(a, function='elementCenters')
+elts = C.identifyElements(hook, f)
+C.freeHook(hook)
+test.testO(elts, 2)
+
+a = G.cart((0,0,0), (1,1,1), (10,10,10))
+f = P.exteriorElts(a)
+hook = C.createHook(a, function='elementCenters')
+elts = C.identifyElements(hook, f)
+C.freeHook(hook)
+test.testO(elts, 3)
+
+# 2D BE: tri
+a = G.cartTetra((0,0,0), (1,1,0), (10,10,1))
+f = P.exteriorElts(a)
+hook = C.createHook(a, function='elementCenters')
+elts = C.identifyElements(hook, f)
+C.freeHook(hook)
+test.testO(elts, 4)
+
+# 3D BE: hexa
+a = G.cartHexa((0,0,0), (1,1,1), (10,10,10))
+f = P.exteriorElts(a)
+hook = C.createHook(a, function='elementCenters')
+elts = C.identifyElements(hook, f)
+C.freeHook(hook)
+test.testO(elts, 5)
+
+# 3D ME: tri-quad
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,0.2), (5,10,1))
+b = G.cartHexa((0.4,0.,0.), (0.1,0.1,0.2), (5,10,1))
+a = C.mergeConnectivity([a, b], None)
+f = P.exteriorElts(a)
+hook = C.createHook(a, function='elementCenters')
+elts = C.identifyElements(hook, f)
+C.freeHook(hook)
+test.testO(elts, 6)
+
+# 3D ME: pyra - penta - hexa
+a = G.cartPyra((0.,0.,0.), (0.1,0.1,0.1), (5,5,5))
+b = G.cartPenta((0.4,0.,0.), (0.1,0.1,0.1), (5,5,5))
+c = G.cartHexa((0.8,0.,0.), (0.1,0.1,0.1), (5,5,5))
+a = C.mergeConnectivity([a, b, c], None)
+f = P.exteriorElts(a)
+hook = C.createHook(a, function='elementCenters')
+elts = C.identifyElements(hook, f)
+C.freeHook(hook)
+test.testO(elts, 7)
+
+# 2D NGon v3
+a = G.cartNGon((0,0,0), (1,1,0), (10,10,1), api=1)
+f = P.exteriorElts(a)
+hook = C.createHook(a, function='elementCenters')
+#elts = C.identifyElements(hook, f)
+#print(elts)
+C.freeHook(hook)
+#test.testO(elts, 8)
+
+# 3D NGon v3
+a = G.cartNGon((0,0,0), (1,1,1), (10,10,10), api=1)
+f = P.exteriorElts(a)
+hook = C.createHook(a, function='elementCenters')
+#elts = C.identifyElements(hook, f)
+#print(elts)
+C.freeHook(hook)
+#test.testO(elts, 9)
+
+# 2D NGon v4
+a = G.cartNGon((0,0,0), (1,1,0), (10,10,1), api=3)
+f = P.exteriorElts(a)
+hook = C.createHook(a, function='elementCenters')
+elts = C.identifyElements(hook, f)
+C.freeHook(hook)
+test.testO(elts, 10)
+
+# 3D NGon v4
+a = G.cartNGon((0,0,0), (1,1,1), (10,10,10), api=3)
+f = P.exteriorElts(a)
+hook = C.createHook(a, function='elementCenters')
+elts = C.identifyElements(hook, f)
+C.freeHook(hook)
+test.testO(elts, 11)
+

--- a/Cassiopee/Converter/test/identifyElementsPT_t1.py
+++ b/Cassiopee/Converter/test/identifyElementsPT_t1.py
@@ -96,4 +96,3 @@ hook = C.createHook(a, function='elementCenters')
 elts = C.identifyElements(hook, f)
 C.freeHook(hook)
 test.testO(elts, 11)
-

--- a/Cassiopee/KCore/KCore/Connect/getNFPE.cpp
+++ b/Cassiopee/KCore/KCore/Connect/getNFPE.cpp
@@ -81,7 +81,9 @@ E_Int K_CONNECT::getNFPE(
     }
     else
     {
-      printf("Error in getNFPE: element type unknown or not covered.");
+      PyErr_Format(PyExc_TypeError,
+                   "Error in getNFPE: element type unknown or not covered: %s",
+                   eltTypeConn);
       for (size_t ic = 0; ic < eltTypes.size(); ic++) delete [] eltTypes[ic];
       return 1;
     };

--- a/Cassiopee/Post/Post/selectExteriorElts.cpp
+++ b/Cassiopee/Post/Post/selectExteriorElts.cpp
@@ -374,7 +374,7 @@ PyObject* K_POST::selectExteriorEltsNGon(FldArrayF& f, FldArrayI& cn,
   E_Bool hasCnOffsets = (ngonType == 2 || ngonType == 3);
   
   E_Int nf, nv, extElt, indface;
-  E_Int pos, e1, e2;
+  E_Int e1, e2;
 
   FldArrayI indirFaces(nfaces); indirFaces.setAllValuesAt(-1);
   FldArrayI nface2Temp(sizeEF), indPH2Temp(0);
@@ -415,7 +415,6 @@ PyObject* K_POST::selectExteriorEltsNGon(FldArrayF& f, FldArrayI& cn,
         if (indirFaces[indface] == -1) 
         {
           cn.getFace(indface, nv, ngon, indPG);
-          sizeFN2 += nv + shift;
           indFaceExt = nExtFaces; nExtFaces++;
           indirFaces[indface] = indFaceExt;
           origIndicesOfExtFaces.push_back(indface);
@@ -439,12 +438,12 @@ PyObject* K_POST::selectExteriorEltsNGon(FldArrayF& f, FldArrayI& cn,
   FldArrayI ngon2Temp(sizeFN), indPG2Temp(0);
   if (hasCnOffsets) { indPG2Temp.resize(nExtFaces+1); indPG2Temp[0] = 0; }
 
-  pos = 0;
+  sizeFN2 = 0;
   for (E_Int f = 0; f < nExtFaces; f++)
   {
     indface2 = origIndicesOfExtFaces[f];  // starts at 0
     E_Int* face = cn.getFace(indface2, nv, ngon, indPG);
-    ngon2Temp[pos] = nv;
+    ngon2Temp[sizeFN2] = nv;
     if (hasCnOffsets) indPG2Temp[f+1] = indPG2Temp[f] + nv;
     for (E_Int p = 0; p < nv; p++)
     {
@@ -452,13 +451,14 @@ PyObject* K_POST::selectExteriorEltsNGon(FldArrayF& f, FldArrayI& cn,
       if (indirNodes[indnode] == -1)  // creation
       {
         indirNodes[indnode] = npts2 + 1;
-        ngon2Temp[pos+p+shift] = npts2 + 1;
+        ngon2Temp[sizeFN2+p+shift] = npts2 + 1;
         npts2++;
       }
-      else ngon2Temp[pos+p+shift] = indirNodes[indnode];
+      else ngon2Temp[sizeFN2+p+shift] = indirNodes[indnode];
     }
-    pos += nv + shift;
+    sizeFN2 += nv + shift;
   }
+  ngon2Temp.resize(sizeFN2);
   origIndicesOfExtFaces.clear();
 
   // Reconstruction de la connectivite finale


### PR DESCRIPTION
Please **SQUASH**
No regressions

### Converter: identifyElements ME
- fix missing offset for ME in identifyElements
- add test cases
- simplify C._recoverBCs (remove breakElements)

Future work:
- identifyElements does not work for NGon v3, although the shift index seems to be correctly implemented