### PR TITLE
Converter: add BE and NGon tests for C.getEmptyBC

### DIFF
--- a/Cassiopee/Converter/Converter/Converter1.cpp
+++ b/Cassiopee/Converter/Converter/Converter1.cpp
@@ -859,7 +859,7 @@ PyObject* K_CONVERTER::convertArrays2File(PyObject* self, PyObject* args)
   else if (K_STRING::cmp(fileFmt, "fmt_foam") == 0) // fmt open foam
   {
     if (fieldc.size() != 0)
-      printf("Warning: convertArrays2File: structured arrays not convertedin foam.\n"); 
+      printf("Warning: convertArrays2File: structured arrays not converted in foam.\n"); 
     
     isok = K_IO::GenIO::getInstance()->foamwrite(fileName, dataFmt, varString,
                                                  ni, nj, nk,

--- a/Cassiopee/Converter/Converter/IO/GenIO_gmsh1.h
+++ b/Cassiopee/Converter/Converter/IO/GenIO_gmsh1.h
@@ -164,7 +164,7 @@
         for (E_Int j = 0; j < 15; j++) READI;
         break;
 
-      case 24: // ??-node TRI (fifth order) -> pas en CGNS
+      case 24: // 15-node incomplete TRI (fifth order) -> pas en CGNS
         nTRI++;
         for (E_Int j = 0; j < 15; j++) READI;
         break;

--- a/Cassiopee/Converter/test/getEmptyBC_t1.py
+++ b/Cassiopee/Converter/test/getEmptyBC_t1.py
@@ -1,6 +1,7 @@
 # - getEmptyBC (pyTree) -
-import Generator.PyTree as G
+# 2D structured
 import Converter.PyTree as C
+import Generator.PyTree as G
 import KCore.test as test
 
 # Sur une zone
@@ -8,7 +9,7 @@ a = G.cart((0.,0.,0.), (0.1, 0.1, 0.1), (11, 21, 2))
 a = C.initVars(a,'F',1.); a = C.initVars(a,'centers:G',2.)
 a = C.addBC2Zone(a, 'wall1', 'BCWall', 'imin')
 a = C.addBC2Zone(a, 'wall2', 'BCWall', 'imax')
-wins = C.getEmptyBC(a,2)
+wins = C.getEmptyBC(a, dim=3)
 test.testO(wins, 1)
 
 # Sur un arbre
@@ -17,11 +18,11 @@ b = C.addBC2Zone(b, 'wall1', 'BCWall', 'imax')
 t = C.newPyTree(['Base']); t[2][1][2] += [a,b]
 t = C.initVars(t,'F',1.); t = C.initVars(t,'centers:G',2.)
 t[2][1] = C.addState(t[2][1], 'Mach', 0.6)
-wins = C.getEmptyBC(t, 2)
+wins = C.getEmptyBC(t, dim=2)
 test.testO(wins, 2)
 
 # Sur une liste de zones
-wins = C.getEmptyBC([a,b], 2)
+wins = C.getEmptyBC([a,b], dim=2)
 test.testO(wins, 3)
 
 # Sur un arbre
@@ -31,5 +32,5 @@ t = C.newPyTree(['Base']); t[2][1][2] += [a,b]
 t = C.initVars(t,'F',1.); t = C.initVars(t,'centers:G',2.)
 t[2][1] = C.addState(t[2][1], 'Mach', 0.6)
 t = C.fillEmptyBCWith(t, 'ov', 'BCOverlap', dim=2)
-wins = C.getEmptyBC(t,2)
-test.testO(wins,4)
+wins = C.getEmptyBC(t, dim=2)
+test.testO(wins, 4)

--- a/Cassiopee/Converter/test/getEmptyBC_t2.py
+++ b/Cassiopee/Converter/test/getEmptyBC_t2.py
@@ -1,5 +1,5 @@
 # - getEmptyBC (pyTree) -
-# 3d
+# 3D structured
 import Converter.PyTree as C
 import Generator.PyTree as G
 import KCore.test as test
@@ -11,6 +11,7 @@ a = C.addBC2Zone(a, 'wall1', 'BCWall', 'imin')
 a = C.addBC2Zone(a, 'wall2', 'BCWall', 'imax')
 wins = C.getEmptyBC(a)
 test.testO(wins, 1)
+
 # Sur un arbre
 b = G.cart((1., 0.2, 0.), (0.1, 0.1, 0.1), (11, 21, 21))
 b = C.addBC2Zone(b, 'wall1', 'BCWall', 'imax')
@@ -32,4 +33,4 @@ t = C.initVars(t,'F',1.); t = C.initVars(t,'centers:G',21.)
 t[2][1] = C.addState(t[2][1], 'Mach', 0.6)
 t = C.fillEmptyBCWith(t, 'ov', 'BCOverlap')
 wins = C.getEmptyBC(t)
-test.testO(wins,4)
+test.testO(wins, 4)

--- a/Cassiopee/Converter/test/getEmptyBC_t3.py
+++ b/Cassiopee/Converter/test/getEmptyBC_t3.py
@@ -49,4 +49,3 @@ t[2][1] = C.addState(t[2][1], 'Mach', 0.6)
 t = C.fillEmptyBCWith(t, 'wall', 'BCWall', dim=2)
 wins = C.getEmptyBC(t, dim=2)
 test.testO(wins, 5)
-

--- a/Cassiopee/Converter/test/getEmptyBC_t3.py
+++ b/Cassiopee/Converter/test/getEmptyBC_t3.py
@@ -1,0 +1,52 @@
+# - getEmptyBC (pyTree) -
+# 2D NGon
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+import KCore.test as test
+
+# Sur une zone
+a = G.cartNGon((0.,0.,0.), (0.1, 0.1, 0.1), (11, 21, 1))
+a = C.initVars(a,'F',1.); a = C.initVars(a,'centers:G',2.)
+wins = C.getEmptyBC(a, dim=2)
+test.testO(wins, 1)
+a = C.addBC2Zone(a, 'wall1', 'BCWall', faceList=wins)
+wins = C.getEmptyBC(a, dim=2)
+test.testO(wins, 2)
+
+# Sur une liste de zones
+b = G.cartNGon((1., 0.2, 0.), (0.1, 0.1, 0.1), (11, 21, 1))
+wins = C.getEmptyBC([a, b], dim=2)
+test.testO(wins, 3)
+
+# Sur un arbre avec _addBC2Zone
+t = C.newPyTree(['Base']); t[2][1][2] += [a, b]
+t = C.initVars(t,'F',1.); t = C.initVars(t,'centers:G',2.)
+t[2][1] = C.addState(t[2][1], 'Mach', 0.6)
+wins = C.getEmptyBC(t, dim=2)[0]
+test.testO(wins, 4)
+zones = Internal.getZones(t)
+for i, z in enumerate(zones):
+    if wins[i]:
+        C._addBC2Zone(z, f'inlet{i+1:d}', 'BCFarfield', faceList=wins[i])
+test.testT(t, 41)
+
+# Sur un arbre avec _addBCFaces
+t = C.newPyTree(['Base']); t[2][1][2] += [a, b]
+t = C.initVars(t,'F',1.); t = C.initVars(t,'centers:G',2.)
+t[2][1] = C.addState(t[2][1], 'Mach', 0.6)
+wins = C.getEmptyBC(t, dim=2)[0]
+BCNames = [f'inlet{i+1:d}' for i in range(len(wins))]
+BCFaces = [[n, f] for n, f in zip(BCNames, wins)]
+C._addBCFaces(t, BCFaces)
+test.testT(t, 42)
+
+# Sur un arbre apres appel a fillEmptyBCWith
+b = G.cartNGon((1., 0.2, 0.), (0.1, 0.1, 0.1), (11, 21, 1))
+t = C.newPyTree(['Base']); t[2][1][2] += [a, b]
+t = C.initVars(t,'F',1.); t = C.initVars(t,'centers:G',2.)
+t[2][1] = C.addState(t[2][1], 'Mach', 0.6)
+t = C.fillEmptyBCWith(t, 'wall', 'BCWall', dim=2)
+wins = C.getEmptyBC(t, dim=2)
+test.testO(wins, 5)
+

--- a/Cassiopee/Converter/test/getEmptyBC_t4.py
+++ b/Cassiopee/Converter/test/getEmptyBC_t4.py
@@ -1,0 +1,41 @@
+# - getEmptyBC (pyTree) -
+# 3D NGon
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+import KCore.test as test
+
+# Sur une zone
+a = G.cartNGon((0.,0.,0.), (0.1, 0.1, 0.1), (11, 21, 21))
+a = C.initVars(a,'F',1.); a = C.initVars(a,'centers:G',2.)
+wins = C.getEmptyBC(a)
+test.testO(wins, 1)
+a = C.addBC2Zone(a, 'wall1', 'BCWall', faceList=wins)
+test.testT(a, 11)
+
+# Sur une liste de zones
+b = G.cartNGon((1., 0.2, 0.), (0.1, 0.1, 0.1), (11, 21, 21))
+wins = C.getEmptyBC([a, b])
+test.testO(wins, 2)
+
+# Sur un arbre
+t = C.newPyTree(['Base']); t[2][1][2] += [a, b]
+t = C.initVars(t,'F',1.); t = C.initVars(t,'centers:G',2.)
+t[2][1] = C.addState(t[2][1], 'Mach', 0.6)
+wins = C.getEmptyBC(t)[0]
+test.testO(wins, 3)
+zones = Internal.getZones(t)
+for i, z in enumerate(zones):
+    if wins[i]:
+        C._addBC2Zone(z, f'inlet{i+1:d}', 'BCFarfield', faceList=wins[i])
+test.testT(t, 31)
+
+# Sur un arbre apres appel a fillEmptyBCWith
+b = G.cartNGon((1., 0.2, 0.), (0.1, 0.1, 0.1), (11, 21, 21))
+t = C.newPyTree(['Base']); t[2][1][2] += [a, b]
+t = C.initVars(t,'F',1.); t = C.initVars(t,'centers:G',21.)
+t[2][1] = C.addState(t[2][1], 'Mach', 0.6)
+t = C.fillEmptyBCWith(t, 'wall', 'BCWall')
+wins = C.getEmptyBC(t)
+test.testO(wins, 4)
+

--- a/Cassiopee/Converter/test/getEmptyBC_t4.py
+++ b/Cassiopee/Converter/test/getEmptyBC_t4.py
@@ -38,4 +38,3 @@ t[2][1] = C.addState(t[2][1], 'Mach', 0.6)
 t = C.fillEmptyBCWith(t, 'wall', 'BCWall')
 wins = C.getEmptyBC(t)
 test.testO(wins, 4)
-

--- a/Cassiopee/Converter/test/getEmptyBC_t5.py
+++ b/Cassiopee/Converter/test/getEmptyBC_t5.py
@@ -1,0 +1,42 @@
+# - getEmptyBC (pyTree) -
+# 2D BE
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+import KCore.test as test
+
+# Sur une zone
+a = G.cartHexa((0.,0.,0.), (0.1, 0.1, 0.1), (11, 21, 1))
+a = C.initVars(a,'F',1.); a = C.initVars(a,'centers:G',2.)
+wins = C.getEmptyBC(a, dim=2)
+test.testO(wins, 1)
+a = C.addBC2Zone(a, 'wall1', 'BCWall', faceList=wins)
+wins = C.getEmptyBC(a, dim=2)
+test.testO(wins, 2)
+
+# Sur une liste de zones
+b = G.cartTetra((1., 0.2, 0.), (0.1, 0.1, 0.1), (11, 21, 1))
+wins = C.getEmptyBC([a, b], dim=2)
+test.testO(wins, 3)
+
+# Sur un arbre
+t = C.newPyTree(['Base']); t[2][1][2] += [a, b]
+t = C.initVars(t,'F',1.); t = C.initVars(t,'centers:G',2.)
+t[2][1] = C.addState(t[2][1], 'Mach', 0.6)
+wins = C.getEmptyBC(t, dim=2)[0]
+test.testO(wins, 4)
+zones = Internal.getZones(t)
+for i, z in enumerate(zones):
+    if wins[i]:
+        C._addBC2Zone(z, f'inlet{i+1:d}', 'BCFarfield', faceList=wins[i])
+test.testT(t, 41)
+
+# Sur un arbre apres appel a fillEmptyBCWith
+b = G.cartTetra((1., 0.2, 0.), (0.1, 0.1, 0.1), (11, 21, 1))
+t = C.newPyTree(['Base']); t[2][1][2] += [a, b]
+t = C.initVars(t,'F',1.); t = C.initVars(t,'centers:G',2.)
+t[2][1] = C.addState(t[2][1], 'Mach', 0.6)
+t = C.fillEmptyBCWith(t, 'wall', 'BCWall', dim=2)
+wins = C.getEmptyBC(t, dim=2)
+test.testO(wins, 5)
+

--- a/Cassiopee/Converter/test/getEmptyBC_t5.py
+++ b/Cassiopee/Converter/test/getEmptyBC_t5.py
@@ -39,4 +39,3 @@ t[2][1] = C.addState(t[2][1], 'Mach', 0.6)
 t = C.fillEmptyBCWith(t, 'wall', 'BCWall', dim=2)
 wins = C.getEmptyBC(t, dim=2)
 test.testO(wins, 5)
-

--- a/Cassiopee/Converter/test/getEmptyBC_t6.py
+++ b/Cassiopee/Converter/test/getEmptyBC_t6.py
@@ -1,0 +1,41 @@
+# - getEmptyBC (pyTree) -
+# 3D BE
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+import KCore.test as test
+
+# Sur une zone
+a = G.cartHexa((0.,0.,0.), (0.1, 0.1, 0.1), (11, 21, 21))
+a = C.initVars(a,'F',1.); a = C.initVars(a,'centers:G',2.)
+wins = C.getEmptyBC(a)
+test.testO(wins, 1)
+a = C.addBC2Zone(a, 'wall1', 'BCWall', faceList=wins)
+test.testT(a, 11)
+
+# Sur une liste de zones
+b = G.cartTetra((1., 0.2, 0.), (0.1, 0.1, 0.1), (11, 21, 21))
+wins = C.getEmptyBC([a, b])
+test.testO(wins, 2)
+
+# Sur un arbre
+t = C.newPyTree(['Base']); t[2][1][2] += [a, b]
+t = C.initVars(t,'F',1.); t = C.initVars(t,'centers:G',2.)
+t[2][1] = C.addState(t[2][1], 'Mach', 0.6)
+wins = C.getEmptyBC(t)[0]
+test.testO(wins, 3)
+zones = Internal.getZones(t)
+for i, z in enumerate(zones):
+    if wins[i]:
+        C._addBC2Zone(z, f'inlet{i+1:d}', 'BCFarfield', faceList=wins[i])
+test.testT(t, 31)
+
+# Sur un arbre apres appel a fillEmptyBCWith
+b = G.cartTetra((1., 0.2, 0.), (0.1, 0.1, 0.1), (11, 21, 21))
+t = C.newPyTree(['Base']); t[2][1][2] += [a, b]
+t = C.initVars(t,'F',1.); t = C.initVars(t,'centers:G',21.)
+t[2][1] = C.addState(t[2][1], 'Mach', 0.6)
+t = C.fillEmptyBCWith(t, 'wall', 'BCWall')
+wins = C.getEmptyBC(t)
+test.testO(wins, 4)
+

--- a/Cassiopee/Converter/test/getEmptyBC_t6.py
+++ b/Cassiopee/Converter/test/getEmptyBC_t6.py
@@ -38,4 +38,3 @@ t[2][1] = C.addState(t[2][1], 'Mach', 0.6)
 t = C.fillEmptyBCWith(t, 'wall', 'BCWall')
 wins = C.getEmptyBC(t)
 test.testO(wins, 4)
-


### PR DESCRIPTION
No regressions

- add tests for C.getEmptyBC: NGon 2D, 3D and BE 2D and 3D

Future work:
C.getEmptyBC, C.fillEmptyBCWith for ME: requires
- P.selectCells2 ME and PyTree api3
- T.splitConnexity ME and PyTree api3
- P.exteriorFaces PyTree api3

@benoit128 : these tests are PyTree tests but are missing the PT suffix