### PR TITLE
Geom.IBM: bug fix symmetrizePb. Update doc and test case.

### DIFF
--- a/Cassiopee/Geom/Geom/IBM.py
+++ b/Cassiopee/Geom/Geom/IBM.py
@@ -141,6 +141,7 @@ def getMinimumCartesianSpacing(t):
 # Creation of a case with a symmetry plane
 #==============================================================================
 def _symmetrizePb(t, bodySymName, snear_sym, dir_sym=2):
+    """Symmetrize the geometry tree and add a symmetry plane."""
     if dir_sym not in [1,2,3]:
         raise ValueError('The symmetry direction %d is not supported. Must be '
                          '1(x), 2(y), or 3(z). Exiting...'%dir_sym)
@@ -165,7 +166,8 @@ def _symmetrizeBody(base, dir_sym=2, symPlane=(0.,0.,0.)):
     elif dir_sym == 3:
         v1 = (1,0,0); v2 =(0,1,0)
 
-    zones_dup = T.symmetrize(zones, symPlane, v1, v2)
+    zones_dup = [Internal.copyTree(z) for z in zones]
+    T._symmetrize(zones_dup, symPlane, v1, v2)
     for z in zones_dup: z[0] += '_sym'
     dim = Internal.getZoneDim(zones_dup[0])
     if dim[0] == 'Structured': order = (-1, 2, 3)
@@ -210,6 +212,7 @@ def _addSymPlane(tb, snear_sym, dir_sym=2, midPlane=0):
     _setIBCType(base, "slip")
     return None
 
+_symetrizePb = _symmetrizePb
 #==============================================================================
 # Set snear in zones
 #==============================================================================

--- a/Cassiopee/Geom/doc/source/Geom_IBM.rst
+++ b/Cassiopee/Geom/doc/source/Geom_IBM.rst
@@ -72,7 +72,7 @@ List of functions
     Geom.IBM.initOutflow
     Geom.IBM.initInj
     Geom.IBM.setFluidInside
-
+    Geom.IBM._symmetrizePb
 
 Contents
 ########
@@ -121,31 +121,29 @@ Setting Snear & Dfar
 
 ---------------------------------------
 
-
-
     .. .. py:function:: Geom.IBM.getDfarOpt(tb, vmin, snear, factor=10, nlevel=-1)
 
-       Computes the optimal dfar to get the exact snear.
+    ..    Computes the optimal dfar to get the exact snear.
 
-       :param tb: geometry tree
-       :type  tb: [zone, list of zones, tree]
-       :param vmin: number of points per elementary structured octree zone
-       :type vmin: integer
-       :param snear: targeted snear (smallest value)
-       :type snear: float
-       :param factor: factor*L is the extent of the octree, where L is the maximum length of the bounding box of tb.
-       :type factor: float
-       :param nlevel: number of levels prescribed for the octree (-1 means that the number of refinement levels are computed according to the parameter factor).
-       :type nlevel: integer
-       :return: float
+    ..    :param tb: geometry tree
+    ..    :type  tb: [zone, list of zones, tree]
+    ..    :param vmin: number of points per elementary structured octree zone
+    ..    :type vmin: integer
+    ..    :param snear: targeted snear (smallest value)
+    ..    :type snear: float
+    ..    :param factor: factor*L is the extent of the octree, where L is the maximum length of the bounding box of tb.
+    ..    :type factor: float
+    ..    :param nlevel: number of levels prescribed for the octree (-1 means that the number of refinement levels are computed according to the parameter factor).
+    ..    :type nlevel: integer
+    ..    :return: float
 
-       *Example of use:*
+    ..    *Example of use:*
 
-       * `Get the value of the dfar to respect exactly snear (pyTree) <Examples/Geom/getDfarOptPT.py>`_:
+    ..    * `Get the value of the dfar to respect exactly snear (pyTree) <Examples/Geom/getDfarOptPT.py>`_:
 
-       .. literalinclude:: ../build/Examples/Geom/getDfarOptPT.py
+    ..    .. literalinclude:: ../build/Examples/Geom/getDfarOptPT.py
 
----------------------------------------
+.. ---------------------------------------
 
 
 .. py:function:: Geom.IBM.snearFactor(tb, sfactor)
@@ -223,13 +221,17 @@ Setting IBC Type
 
 ---------------------------------------
 
-.. py:function:: Geom.IBM.symmetrizePb(tb)
+.. py:function:: Geom.IBM._symmetrizePb(tb, bodySymName, snear_sym, dir_sym=2)
 
-    Add a symmetry plane and symmetrize the body base; input surface must be y>=0 if the symmetry plane is at y=0.
-    Creates the geometry for the symmetry plane, the snear and slip IBC type.
+    Add a symmetry plane and symmetrize the body base. The geometry must be aligned with the input direction (dir_sym).
+
+    The symmetry plane is located at the local minimum found in the case coordinates (xmin, ymin, or zmin), based on the input direction, and is placed in a separate base labeled 'BOX'.
+
+    The symmetrized body zones are labeled zname_sym, where zname is the name of a given zone. These zones are located in the same base as the original zones (bodySymName).
+
     :param tb: geometry tree 
     :type  tb: [zone, list of zones, tree]
-    :param bodyNameSym: name of the base where
+    :param bodyNameSym: name of the base in which the body is defined
     :type bodyNameSym: string
     :param snear_sym: mesh resolution at the symmetry plane
     :type snear_sym: float

--- a/Cassiopee/Geom/test/symetrizePbPT.py
+++ b/Cassiopee/Geom/test/symetrizePbPT.py
@@ -2,10 +2,11 @@
 import Converter.PyTree as C
 import Geom.IBM as D_IBM
 import Geom.PyTree as D
+
 # Geometry
 a = D.cone((0,0,0), 1. , 0., 1.)
 D_IBM._setDfar(a, 10.)
-D_IBM._setSnear(a,0.01)
-tb = C.newPyTree(["BODY",a])
+D_IBM._setSnear(a, 0.01)
+tb = C.newPyTree(["BODY", a])
 D_IBM._symmetrizePb(tb,"BODY", 0.1, dir_sym=3)
 C.convertPyTree2File(tb, 'out.cgns')

--- a/Cassiopee/Geom/test/symetrizePbPT_t1.py
+++ b/Cassiopee/Geom/test/symetrizePbPT_t1.py
@@ -3,10 +3,20 @@ import Converter.PyTree as C
 import Geom.IBM as D_IBM
 import Geom.PyTree as D
 import KCore.test as test
-# Geometry
+
+# STRUCT
 a = D.cone((0,0,0), 1. , 0., 1.)
 D_IBM._setDfar(a, 10.)
-D_IBM._setSnear(a,0.01)
-tb = C.newPyTree(["BODY",a,2])
-D_IBM._symmetrizePb(tb,"BODY", 0.1, dir_sym=3)
-test.testT(tb)
+D_IBM._setSnear(a, 0.01)
+tb = C.newPyTree(["BODY", a, 2])
+D_IBM._symmetrizePb(tb, "BODY", 0.1, dir_sym=3)
+test.testT(tb, 1)
+
+# BE (TRI)
+a = D.cone((0,0,0), 1. , 0., 1.)
+a = C.convertArray2Tetra(a)
+D_IBM._setDfar(a, 10.)
+D_IBM._setSnear(a, 0.01)
+tb = C.newPyTree(["BODY", a, 2])
+D_IBM._symmetrizePb(tb, "BODY", 0.1, dir_sym=3)
+test.testT(tb, 2)


### PR DESCRIPTION
No regression.

Bug fix for the symmetrizePb function, where an unstructured case would end up entirely blanked due to an internal copyRef of the cellN flow variable. Doc and test-case update.
