### PR TITLE
Deployment: PyPI, Docker, conda/mamba (no isolation)

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8.20, 3.9.19, 3.10.14, 3.11.9, 3.12.4]
+        python-version: [3.8.20, 3.9.19, 3.10.14, 3.11.9, 3.12.4, 3.14.3]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -84,6 +84,7 @@ jobs:
               sed -i 's/Modeler//g' MODULES
               sed -i 's/OCC//g' MODULES
               FREE_MODULES=\$(cat MODULES | head -1 | cut -d '=' -f 2 | tr -d \')
+              export OMP_NUM_THREADS=2
               ./install || { echo \"Cassiopee install failed\"; exit 1; }
               cd \$CASSIOPEE/Dist/bin/\$ELSAPROD
               find . -type f -name '*.whl' -exec mv {} \$CASSIOPEE \;

--- a/Cassiopee/Apps/install
+++ b/Cassiopee/Apps/install
@@ -43,7 +43,7 @@ elif [ $PRODMODE -eq 1 ]; then # pip
     [ $? != 0 ] && exit 1;
 elif [ $PRODMODE -eq 2 ]; then # pip+wheel
     # wheels in $INSTALLPATH
-    TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+    TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
     [ $? != 0 ] && exit 1;
 elif [ $PRODMODE -eq 3 ]; then # pip no isolation
     python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/Apps/pyproject.toml
+++ b/Cassiopee/Apps/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/Apps/setup.py
+++ b/Cassiopee/Apps/setup.py
@@ -1,16 +1,24 @@
-#from distutils.core import setup
-from setuptools import setup
-import os
-import KCore.Dist as Dist
-
 #=============================================================================
 # Apps requires:
 # ELSAPROD variable defined in environment
 # CASSIOPEE
 #=============================================================================
+import os
+from setuptools import setup
+from importlib.util import spec_from_file_location, module_from_spec
 
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+
+prod = os.getenv("ELSAPROD") or "xx"
 
 # setup ======================================================================
 setup(
@@ -18,9 +26,17 @@ setup(
     version="4.1",
     description="Application modules",
     author="ONERA",
+    url="https://onera.github.io/Cassiopee/",
     packages=['Apps', 'Apps.Chimera', 'Apps.Fast', 'Apps.Mesh', 'Apps.Coda'],
     package_dir={"":"."}
 )
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/CPlot/install
+++ b/Cassiopee/CPlot/install
@@ -64,7 +64,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/CPlot/pyproject.toml
+++ b/Cassiopee/CPlot/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/CPlot/setup.py
+++ b/Cassiopee/CPlot/setup.py
@@ -1,7 +1,3 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-import os
-
 #=============================================================================
 # CPlot requires:
 # C++ compiler
@@ -10,32 +6,48 @@ import os
 # GL
 # optional: MPEG, OSMesa
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
 
-# Write setup.cfg
-import KCore.Dist as Dist
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
-from KCore.config import *
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 libraryDirs = ["build/"+prod]
 includeDirs = [numpyIncDir, kcoreIncDir, kcoreLibDir+'/../include']
 
 libraries = []
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
 
 # Test if MPEG exists =========================================================
-from srcs import MPEG
-if MPEG:
+srcs = loadModuleFromPath('srcs')
+if srcs.MPEG:
     (mpeg, mpegIncDir, mpegLib) = Dist.checkMpeg(additionalLibPaths,
                                                  additionalIncludePaths)
     if mpeg:
@@ -113,11 +125,18 @@ setup(
     version="4.1",
     description="A plotter for *Cassiopee* Modules.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     packages=['CPlot'],
     package_dir={"":"."},
     ext_modules=extensions
 )
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/CPlot/setup.scons
+++ b/Cassiopee/CPlot/setup.scons
@@ -8,11 +8,13 @@ import KCore.Dist as Dist
 # GL
 # optional: OSMesa
 #==============================================================================
-from KCore.config import *
 
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -24,14 +26,14 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 libraries = ["kcore"]
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ['..', '.', pythonLibDir, kcoreLibDir, '/usr/X11R6/lib64']
 includeDirs = [pythonIncDir, numpyIncDir, kcoreIncDir, kcoreLibDir+'/../include']
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Test if MPEG exists =========================================================

--- a/Cassiopee/CPlot/setupLegacy.py
+++ b/Cassiopee/CPlot/setupLegacy.py
@@ -16,25 +16,31 @@ import os
 # set UseOSMesa to True (requires mesa)
 UseOSMesa = KCore.config.CPlotOffScreen
 
-# Write setup.cfg
 import KCore.Dist as Dist
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 libraries = ["GLU", "kcore", "Xi", "Xmu", "rt"]
-from KCore.config import *
 if not UseOSMesa: libraries += ["GL"]
 
 #libraryDirs = [kcoreLibDir]
 libraryDirs = [kcoreLibDir, '/usr/X11R6/lib64']
 includeDirs = [numpyIncDir, kcoreIncDir]
 
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Test if PNG exists =========================================================
@@ -91,6 +97,7 @@ setup(
     version="4.1",
     description="A plotter for *Cassiopee* Modules.",
     author="ONERA",
+    url="https://onera.github.io/Cassiopee/",
     package_dir={"":"."},
     packages=['CPlot'],
     ext_modules=extensions

--- a/Cassiopee/Compressor/install
+++ b/Cassiopee/Compressor/install
@@ -64,7 +64,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/Compressor/pyproject.toml
+++ b/Cassiopee/Compressor/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/Compressor/setup.py
+++ b/Cassiopee/Compressor/setup.py
@@ -1,34 +1,46 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-import os
-
 #=============================================================================
 # Compressor requires:
 # C++ compiler
 # Numpy
 # KCore
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
 
-# Write setup.cfg
-import KCore.Dist as Dist
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 libraryDirs = ['build/'+prod, kcoreLibDir]
 libraries = ["compressor", "kcore"]
-from KCore.config import *
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
-import srcs
+srcs = loadModuleFromPath('srcs')
 
 # Extensions =================================================================
 extensions = [

--- a/Cassiopee/Compressor/setup.scons
+++ b/Cassiopee/Compressor/setup.scons
@@ -10,6 +10,9 @@ import KCore.Dist as Dist
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -21,13 +24,12 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = [pythonLibDir, kcoreLibDir]
 libraries = ["kcore"]
-from KCore.config import *
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 ADDITIONALCFLAGS = ["-DZFP_INT64='long long'","-DZFP_INT64_SUFFIX='ll'","-DZFP_UINT64='unsigned long long'","-DZFP_UINT64_SUFFIX='ull'"]

--- a/Cassiopee/Compressor/setupLegacy.py
+++ b/Cassiopee/Compressor/setupLegacy.py
@@ -8,21 +8,27 @@ from setuptools import setup, Extension
 # KCore
 #=============================================================================
 
-# Write setup.cfg
 import KCore.Dist as Dist
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+includeDirs = Dist.getFromConfigDict("includeDirs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = [kcoreLibDir]
 libraries = ["kcore"]
-from KCore.config import *
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 includeDirs = [numpyIncDir, kcoreIncDir]
@@ -59,6 +65,7 @@ setup(
     version="4.1",
     description="Compress CFD solutions.",
     author="ONERA",
+    url="https://onera.github.io/Cassiopee/",
     package_dir={"":"."},
     #packages=['Compressor', 'Compressor.zfp', 'Compressor.sz'],
     packages=['Compressor'],

--- a/Cassiopee/Connector/install
+++ b/Cassiopee/Connector/install
@@ -65,7 +65,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/Connector/pyproject.toml
+++ b/Cassiopee/Connector/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/Connector/setup.py
+++ b/Cassiopee/Connector/setup.py
@@ -1,7 +1,3 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-import os
-
 #=============================================================================
 # Connector requires:
 # C++ compiler
@@ -9,29 +5,44 @@ import os
 # Numpy
 # KCore
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
+
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Write setup.cfg file
-import KCore.Dist as Dist
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
-
-from KCore.config import *
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Compilation des fortrans ===================================================
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ["build/"+prod, kcoreLibDir]
 libraries = ["connector", "kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 includeDirs = [numpyIncDir, kcoreIncDir]
 ADDITIONALCPPFLAGS=[]
@@ -54,10 +65,17 @@ setup(
     version="4.1",
     description="Connector for *Cassiopee* modules.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     packages=['Connector'],
     package_dir={"":"."},
     ext_modules=listExtensions)
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/Connector/setup.scons
+++ b/Cassiopee/Connector/setup.scons
@@ -1,6 +1,5 @@
 import os
 import KCore.Dist as Dist
-from KCore.config import *
 #==============================================================================
 # Connector requires :
 # C++ compiler
@@ -12,6 +11,10 @@ from KCore.config import *
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -23,15 +26,15 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ['..', '.', pythonLibDir, kcoreLibDir]
 includeDirs = ["Connector", "Connector/CMP/include"]+additionalIncludePaths+[pythonIncDir, numpyIncDir, kcoreIncDir]
 libraries = ["kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 ADDITIONALCPPFLAGS = []

--- a/Cassiopee/Connector/setupLegacy.py
+++ b/Cassiopee/Connector/setupLegacy.py
@@ -10,19 +10,25 @@ import os, sys
 # KCore
 #=============================================================================
 
-# Write setup.cfg file
 import KCore.Dist as Dist
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Compilation des fortrans ===================================================
-from KCore.config import *
-if f77compiler == "None":
+if f77compiler is None:
     print("Error: a fortran 77 compiler is required for compiling Connector.")
     sys.exit()
 args = Dist.getForArgs(); opt = ''
@@ -34,9 +40,9 @@ if prod is None: prod = 'xx'
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ["build/"+prod, kcoreLibDir]
 libraries = ["ConnectorF", "kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # setup =======================================================================
@@ -58,6 +64,7 @@ setup(
     version="4.1",
     description="Connector for *Cassiopee* modules.",
     author="ONERA",
+    url="https://onera.github.io/Cassiopee/",
     package_dir={"":"."},
     packages=['Connector'],
     ext_modules=listExtensions)

--- a/Cassiopee/Converter/install
+++ b/Cassiopee/Converter/install
@@ -65,7 +65,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/Converter/pyproject.toml
+++ b/Cassiopee/Converter/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/Converter/setup.py
+++ b/Cassiopee/Converter/setup.py
@@ -1,7 +1,3 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-import os
-
 #=============================================================================
 # Converter requires:
 # ELSAPROD variable defined in environment
@@ -10,18 +6,34 @@ import os
 # Numpy
 # KCore library
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
+
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Write setup.cfg file
-import KCore.Dist as Dist
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
-
-from KCore.config import *
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Test if libhdf5 exists ======================================================
 (hdf, hdfIncDir, hdfLibDir, hdflibs) = Dist.checkHdf(additionalLibPaths,
@@ -69,9 +81,9 @@ if netcdf:
 
 if mpi: libraries += mpiLibs
 
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Extensions ==================================================================
@@ -85,7 +97,7 @@ listExtensions.append(
               extra_compile_args=Dist.getCppArgs()+ADDITIONALCPPFLAGS,
               extra_link_args=Dist.getLinkArgs()
               ) )
-import srcs
+srcs = loadModuleFromPath('srcs')
 if srcs.EXPRESSION:
     listExtensions.append(
         Extension('Converter.expression',
@@ -102,11 +114,18 @@ setup(
     version="4.1",
     description="Converter for *Cassiopee* modules.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     packages=['Converter'],
     package_dir={"":"."},
     ext_modules=listExtensions
 )
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/Converter/setup.scons
+++ b/Cassiopee/Converter/setup.scons
@@ -1,6 +1,5 @@
 import os
 import KCore.Dist as Dist
-from KCore.config import *
 #==============================================================================
 # Converter requires:
 # C++ compiler
@@ -12,6 +11,11 @@ from KCore.config import *
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+Cppcompiler = Dist.getFromConfigDict("Cppcompiler", None)
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -23,7 +27,7 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Test if libhdf5 exists ======================================================
 (hdf, hdfIncDir, hdfLibDir, hdflibs) = Dist.checkHdf(additionalLibPaths,
@@ -67,9 +71,9 @@ if netcdf:
     ADDITIONALCPPFLAGS += ['-D_NETCDF']
 if mpi: libraries += mpiLibs
 
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Env =========================================================================

--- a/Cassiopee/Converter/setupLegacy.py
+++ b/Cassiopee/Converter/setupLegacy.py
@@ -11,17 +11,22 @@ import os
 # KCore library
 #=============================================================================
 
-# Write setup.cfg file
 import KCore.Dist as Dist
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
-
-from KCore.config import *
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Test if libhdf5 exists ======================================================
 (hdf, hdfIncDir, hdfLibDir, hdflibs) = Dist.checkHdf(additionalLibPaths,
@@ -38,7 +43,7 @@ from KCore.config import *
                                                         additionalIncludePaths)
 
 # Compilation des fortrans ====================================================
-if f77compiler == "None":
+if f77compiler is None:
     print("Error: a fortran 77 compiler is required for compiling Converter.")
 args = Dist.getForArgs(); opt = ''
 for c, v in enumerate(args): opt += 'FOPT'+str(c)+'='+v+' '
@@ -66,9 +71,9 @@ if mpi4py:
 if hdf: libraries += hdflibs
 if png: libraries.append('png')
 if mpi: libraries += mpiLibs
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 ADDITIONALCPPFLAGS = ['-DUSE_C_REGEX'] # for old gcc < 5.0
@@ -99,6 +104,7 @@ setup(
     version="4.1",
     description="Converter for *Cassiopee* modules.",
     author="ONERA",
+    url="https://onera.github.io/Cassiopee/",
     package_dir={"":"."},
     packages=['Converter'],
     ext_modules=listExtensions

--- a/Cassiopee/Dist2Walls/install
+++ b/Cassiopee/Dist2Walls/install
@@ -62,7 +62,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/Dist2Walls/pyproject.toml
+++ b/Cassiopee/Dist2Walls/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/Dist2Walls/setup.py
+++ b/Cassiopee/Dist2Walls/setup.py
@@ -1,34 +1,46 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-import os
-
 #=============================================================================
 # Dist2Walls requires:
 # C++ compiler
 # Numpy
 # KCore
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
 
-# Write setup.cfg
-import KCore.Dist as Dist
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
-from KCore.config import *
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 libraryDirs = [kcoreLibDir, 'build/'+prod]
 libraries = ["dist2walls", "kcore"]
-from KCore.config import *
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
 
 # Extensions =================================================================
@@ -49,11 +61,18 @@ setup(
     version="4.1",
     description="Computation of distance to walls.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     packages=['Dist2Walls'],
     package_dir={"":"."},
     ext_modules=extensions
 )
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/Dist2Walls/setup.scons
+++ b/Cassiopee/Dist2Walls/setup.scons
@@ -1,6 +1,5 @@
 import os
 import KCore.Dist as Dist
-from KCore.config import *
 #==============================================================================
 # Dist2Walls requires:
 # C++ compiler
@@ -11,6 +10,9 @@ from KCore.config import *
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -22,12 +24,12 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ['..', '.', pythonLibDir, kcoreLibDir]
 libraries = ["kcore"]
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Env =========================================================================

--- a/Cassiopee/Dist2Walls/setupLegacy.py
+++ b/Cassiopee/Dist2Walls/setupLegacy.py
@@ -8,21 +8,26 @@ from setuptools import setup, Extension
 # KCore
 #=============================================================================
 
-# Write setup.cfg
 import KCore.Dist as Dist
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = [kcoreLibDir]
 libraries = ["kcore"]
-from KCore.config import *
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Extensions =================================================================
@@ -44,6 +49,7 @@ setup(
     version="4.1",
     description="Computation of distance to walls.",
     author="ONERA",
+    url="https://onera.github.io/Cassiopee/",
     package_dir={"":"."},
     packages=['Dist2Walls'],
     ext_modules=extensions

--- a/Cassiopee/Distributor2/install
+++ b/Cassiopee/Distributor2/install
@@ -65,7 +65,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/Distributor2/pyproject.toml
+++ b/Cassiopee/Distributor2/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/Distributor2/setup.py
+++ b/Cassiopee/Distributor2/setup.py
@@ -1,34 +1,46 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-import os
-
 #=============================================================================
 # Distributor2 requires:
 # C++ compiler
 # Numpy
 # KCore
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
 
-# Write setup.cfg
-import KCore.Dist as Dist
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
-from KCore.config import *
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 
 libraryDirs = ['build/'+prod, kcoreLibDir]
 libraries = ["distributor2", "kcore"]
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
 
 # setup ======================================================================
@@ -37,7 +49,7 @@ setup(
     version="4.1",
     description="Distributor for arrays and pyTrees.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     packages=['Distributor2'],
     package_dir={"":"."},
     ext_modules=[Extension('Distributor2.distributor2',
@@ -52,4 +64,11 @@ setup(
 )
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/Distributor2/setup.scons
+++ b/Cassiopee/Distributor2/setup.scons
@@ -10,6 +10,9 @@ import KCore.Dist as Dist
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -21,13 +24,12 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = [pythonLibDir, kcoreLibDir]
 libraries = ["kcore"]
-from KCore.config import *
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Env =========================================================================

--- a/Cassiopee/Distributor2/setupLegacy.py
+++ b/Cassiopee/Distributor2/setupLegacy.py
@@ -8,21 +8,26 @@ from setuptools import setup, Extension
 # KCore
 #=============================================================================
 
-# Write setup.cfg
 import KCore.Dist as Dist
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = [kcoreLibDir]
 libraries = ["kcore"]
-from KCore.config import *
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # setup ======================================================================
@@ -32,6 +37,7 @@ setup(
     version="4.1",
     description="Distributor for arrays and pyTrees.",
     author="ONERA",
+    url="https://onera.github.io/Cassiopee/",
     package_dir={"":"."},
     packages=['Distributor2'],
     ext_modules=[Extension('Distributor2.distributor2',

--- a/Cassiopee/Envs/sh_Cassiopee_local
+++ b/Cassiopee/Envs/sh_Cassiopee_local
@@ -678,25 +678,24 @@ if ! [ -z $PATHL ]; then
 fi
 
 if [ "$PYTHONEXE" = "python3" ]; then
-    pyversion="python"`python3 -c "import sys; print('.'.join(str(n) for n in sys.version_info[:2]))"`
+    pylib=$($PYTHONEXE -c 'import os; import site; a = site.getsitepackages()[0].split("/")[-4:-2]; print(os.path.join(*a) if a[0] == "local" else a[1])' 2>/dev/null)
+    pysite=$($PYTHONEXE -c 'import os; import site; a = site.getsitepackages()[0].split("/")[-4:]; print(os.path.join(*a) if a[0] == "local" else os.path.join(*a[1:]))' 2>/dev/null)
     alias python=python3
 else
+    pyenv=$($PYTHONEXE -c 'import sys; print("pyenv" in sys.executable)' 2>/dev/null)
     pyversion="python"`python -c "import sys; print('.'.join(str(n) for n in sys.version_info[:2]))"`
-fi
-# Detect if pyenv is used
-pyenv=$($PYTHONEXE -c 'import sys; print("pyenv" in sys.executable)' 2>/dev/null)
-
-pylib="lib"
-if [ "$MAC" = "ubuntu" ] && [ "$pyenv" == "False" ]; then
-    pylib="local/"$pylib
-    pysite="dist-packages"
-else
-    pysite="site-packages"
+    if [ "$MAC" = "ubuntu" ] && [ "$pyenv" == "False" ]; then
+        pylib="local/lib"
+        pysite=$pylib/$pyversion/"dist-packages"
+    else
+        pylib="lib"
+        pysite=$pylib/$pyversion/"site-packages"
+    fi
 fi
 
 export PATHL=$CASSIOPEE/Dist/bin/"$ELSAPROD":$CASSIOPEE/Dist/bin/"$ELSAPROD"/bin
 export LD_LIBRARY_PATHL=$CASSIOPEE/Dist/bin/"$ELSAPROD":$CASSIOPEE/Dist/bin/"$ELSAPROD"/"$pylib"
-export PYTHONPATHL=$CASSIOPEE/Dist/bin/"$ELSAPROD":$CASSIOPEE/Dist/bin/"$ELSAPROD"/"$pylib"/"$pyversion"/"$pysite"
+export PYTHONPATHL=$CASSIOPEE/Dist/bin/"$ELSAPROD":$CASSIOPEE/Dist/bin/"$ELSAPROD"/"$pysite"
 
 if ! [ -z $OLD_PATHL ]; then
     # Remove all occurences of old paths

--- a/Cassiopee/Generator/install
+++ b/Cassiopee/Generator/install
@@ -64,7 +64,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/Generator/pyproject.toml
+++ b/Cassiopee/Generator/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/Generator/setup.py
+++ b/Cassiopee/Generator/setup.py
@@ -1,7 +1,3 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-import os
-
 #=============================================================================
 # Generator requires:
 # ELSAPROD variable defined in environment
@@ -10,26 +6,42 @@ import os
 # Numpy
 # KCore
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
 
-# Write setup.cfg
-import KCore.Dist as Dist
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
-from KCore.config import *
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 libraryDirs = ["build/"+prod, kcoreLibDir]
 libraries = ["generator", "generator2", "generator3", "kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Extensions =================================================================
@@ -50,11 +62,18 @@ setup(
     version="4.1",
     description="*Cassiopee* module of mesh generation.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     packages=['Generator'],
     package_dir={"":"."},
     ext_modules=listExtensions
 )
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/Generator/setup.scons
+++ b/Cassiopee/Generator/setup.scons
@@ -1,6 +1,5 @@
 import os
 import KCore.Dist as Dist
-from KCore.config import *
 #==============================================================================
 # Generator requires:
 # ELSAPROD variable defined in environment
@@ -13,6 +12,11 @@ from KCore.config import *
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+Cppcompiler = Dist.getFromConfigDict("Cppcompiler", None)
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -24,14 +28,14 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ['..', '.', pythonLibDir, kcoreLibDir]
 libraries = ["kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Env =========================================================================

--- a/Cassiopee/Generator/setupLegacy.py
+++ b/Cassiopee/Generator/setupLegacy.py
@@ -11,19 +11,25 @@ import os
 # KCore
 #=============================================================================
 
-# Write setup.cfg
 import KCore.Dist as Dist
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Compilation des fortrans ====================================================
-from KCore.config import *
-if f77compiler == "None":
+if f77compiler is None:
     print("Error: a fortran 77 compiler is required for compiling Generator.")
 args = Dist.getForArgs(); opt = ''
 for c, v in enumerate(args): opt += 'FOPT'+str(c)+'='+v+' '
@@ -34,9 +40,9 @@ if prod is None: prod = 'xx'
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ["build/"+prod, kcoreLibDir]
 libraries = ["GeneratorF", "kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Extensions =================================================================
@@ -58,6 +64,7 @@ setup(
     version="4.1",
     description="*Cassiopee* module of mesh generation.",
     author="ONERA",
+    url="https://onera.github.io/Cassiopee/",
     package_dir={"":"."},
     packages=['Generator'],
     ext_modules=listExtensions

--- a/Cassiopee/Geom/install
+++ b/Cassiopee/Geom/install
@@ -65,7 +65,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/Geom/pyproject.toml
+++ b/Cassiopee/Geom/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/Geom/setup.py
+++ b/Cassiopee/Geom/setup.py
@@ -1,7 +1,3 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-import os
-
 #=============================================================================
 # Geom requires:
 # ELSAPROD variable defined in environment
@@ -10,28 +6,44 @@ import os
 # Numpy
 # KCore library
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
 
-# Write setup.cfg
-import KCore.Dist as Dist
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Compilation des fortrans ===================================================
-from KCore.config import *
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ["build/"+prod, kcoreLibDir]
 libraries = ["geom", "kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # setup ======================================================================
@@ -40,7 +52,7 @@ setup(
     version="4.1",
     description="Geometry definition for *Cassiopee* modules.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     packages=['Geom'],
     package_dir={"":"."},
     ext_modules=[Extension('Geom.geom',
@@ -54,4 +66,11 @@ setup(
 )
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/Geom/setup.scons
+++ b/Cassiopee/Geom/setup.scons
@@ -1,6 +1,5 @@
 import os
 import KCore.Dist as Dist
-from KCore.config import *
 #==============================================================================
 # Geom requires:
 # ELSAPROD variable defined in environment
@@ -13,6 +12,10 @@ from KCore.config import *
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -24,14 +27,14 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ['..', '.', pythonLibDir, kcoreLibDir]
 libraries = ["kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Env =========================================================================

--- a/Cassiopee/Geom/setupLegacy.py
+++ b/Cassiopee/Geom/setupLegacy.py
@@ -11,19 +11,25 @@ import os
 # KCore library
 #=============================================================================
 
-# Write setup.cfg
 import KCore.Dist as Dist
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Compilation des fortrans ===================================================
-from KCore.config import *
-if f77compiler == "None":
+if f77compiler is None:
     print("Error: a fortran 77 compiler is required for compiling Geom.")
 args = Dist.getForArgs(); opt = ''
 for c, v in enumerate(args): opt += 'FOPT'+str(c)+'='+v+' '
@@ -34,9 +40,9 @@ if prod is None: prod = 'xx'
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ["build/"+prod, kcoreLibDir]
 libraries = ["GeomF", "kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # setup ======================================================================
@@ -46,6 +52,7 @@ setup(
     version="4.1",
     description="Geometry definition for *Cassiopee* modules.",
     author="ONERA",
+    url="https://onera.github.io/Cassiopee/",
     package_dir={"":"."},
     packages=['Geom'],
     ext_modules=[Extension('Geom.geom',

--- a/Cassiopee/Initiator/install
+++ b/Cassiopee/Initiator/install
@@ -65,7 +65,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/Initiator/pyproject.toml
+++ b/Cassiopee/Initiator/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/Initiator/setup.py
+++ b/Cassiopee/Initiator/setup.py
@@ -1,7 +1,3 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-import os
-
 #=============================================================================
 # Initiator requires:
 # [ENV] CASSIOPEE, ELSAPROD
@@ -10,28 +6,44 @@ import os
 # Numpy
 # KCore library
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
 
-# Write setup.cfg
-import KCore.Dist as Dist
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Compilation des fortrans ===================================================
-from KCore.config import *
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ["build/"+prod, kcoreLibDir]
 libraries = ["initiator", "kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # setup =======================================================================
@@ -40,7 +52,7 @@ setup(
     version="4.1",
     description="Initiator for *Cassiopee* modules.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     packages=['Initiator'],
     package_dir={"":"."},
     ext_modules=[Extension('Initiator.initiator',
@@ -55,4 +67,11 @@ setup(
 )
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/Initiator/setup.scons
+++ b/Cassiopee/Initiator/setup.scons
@@ -1,6 +1,5 @@
 import os
 import KCore.Dist as Dist
-from KCore.config import *
 #==============================================================================
 # Initiator requires:
 # [ENV] CASSIOPEE, ELSAPROD
@@ -13,6 +12,9 @@ from KCore.config import *
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -24,12 +26,12 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ['..', '.', pythonLibDir, kcoreLibDir]
 libraries = ["kcore"]
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Env =========================================================================

--- a/Cassiopee/Initiator/setupLegacy.py
+++ b/Cassiopee/Initiator/setupLegacy.py
@@ -11,19 +11,25 @@ import os
 # KCore library
 #=============================================================================
 
-# Write setup.cfg
 import KCore.Dist as Dist
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Compilation des fortrans ===================================================
-from KCore.config import *
-if f77compiler == "None":
+if f77compiler is None:
     print("Error: a fortran 77 compiler is required for compiling Initiator.")
 args = Dist.getForArgs(); opt = ''
 for c, v in enumerate(args): opt += 'FOPT'+str(c)+'='+v+' '
@@ -34,9 +40,9 @@ if prod is None: prod = 'xx'
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ["build/"+prod, kcoreLibDir]
 libraries = ["InitiatorF", "kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 import srcs
@@ -47,6 +53,7 @@ setup(
     version="4.1",
     description="Initiator for *Cassiopee* modules.",
     author="ONERA",
+    url="https://onera.github.io/Cassiopee/",
     package_dir={"":"."},
     packages=['Initiator'],
     ext_modules=[Extension('Initiator.initiator',

--- a/Cassiopee/Intersector/install
+++ b/Cassiopee/Intersector/install
@@ -65,7 +65,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/Intersector/pyproject.toml
+++ b/Cassiopee/Intersector/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/Intersector/setup.py
+++ b/Cassiopee/Intersector/setup.py
@@ -1,7 +1,3 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-import os
-
 #=============================================================================
 # Intersector requires:
 # ELSAPROD variable defined in environment
@@ -10,22 +6,37 @@ import os
 # Numpy
 # KCore library
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
 
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Write setup.cfg file
-import KCore.Dist as Dist
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Test if xcore exists =======================================================
-#(xcoreVersion, xcoreIncDir, xcoreLibDir) = Dist.checkXCore()
-
-from KCore.config import *
+#(xcoreVersion, xcoreIncDir, xcoreLibDir) = Dist.checkModuleCassiopee("XCore")()
 
 # Test if libmpi exists ======================================================
 (mpi, mpiIncDir, mpiLibDir, mpiLibs) = Dist.checkMpi(additionalLibPaths,
@@ -34,8 +45,7 @@ from KCore.config import *
                                                         additionalIncludePaths)
 
 # Compilation des fortrans ====================================================
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 
 # Setting libraryDirs, include dirs and libraries =============================
 libraryDirs = ["build/"+prod, kcoreLibDir]
@@ -51,9 +61,9 @@ if mpi4py:
 
 if mpi: libraries += mpiLibs
 
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # setup ======================================================================
@@ -62,7 +72,7 @@ setup(
     version="4.1",
     description="Mesh-intersection-based services in *Cassiopee*.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     packages=['Intersector'],
     package_dir={"":"."},
     ext_modules=[Extension('Intersector.intersector',
@@ -76,4 +86,11 @@ setup(
 )
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/Intersector/setup.scons
+++ b/Cassiopee/Intersector/setup.scons
@@ -1,6 +1,5 @@
 import os
 import KCore.Dist as Dist
-from KCore.config import *
 #==============================================================================
 # Intersector requires:
 # C++ compiler
@@ -12,6 +11,10 @@ from KCore.config import *
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -23,10 +26,10 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Test if xcore exists =======================================================
-#(xcoreVersion, xcoreIncDir, xcoreLibDir) = Dist.checkXCore()
+#(xcoreVersion, xcoreIncDir, xcoreLibDir) = Dist.checkModuleCassiopee("XCore")()
 
 # Test if libmpi exists ======================================================
 (mpi, mpiIncDir, mpiLibDir, mpiLibs) = Dist.checkMpi(additionalLibPaths,
@@ -48,9 +51,9 @@ if mpi4py:
 
 if mpi: libraries += mpiLibs
     
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 

--- a/Cassiopee/Intersector/setupLegacy.py
+++ b/Cassiopee/Intersector/setupLegacy.py
@@ -11,15 +11,23 @@ import os
 # KCore library
 #=============================================================================
 
-# Write setup.cfg
 import KCore.Dist as Dist
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+includeDirs = Dist.getFromConfigDict("includeDirs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Test if libmpi exists ======================================================
 (mpi, mpiIncDir, mpiLibDir, mpiLibs) = Dist.checkMpi(additionalLibPaths,
@@ -28,8 +36,7 @@ Dist.writeSetupCfg()
                                                         additionalIncludePaths)
 
 # Compilation des fortrans ===================================================
-from KCore.config import *
-if f77compiler == "None":
+if f77compiler is None:
     print("Error: a fortran 77 compiler is required for compiling Intersector.")
 args = Dist.getForArgs(); opt = ''
 for c, v in enumerate(args): opt += 'FOPT'+str(c)+'='+v+' '
@@ -40,9 +47,9 @@ if prod is None: prod = 'xx'
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ["build/"+prod, kcoreLibDir]
 libraries = ["intersector", "kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 ADDITIONALCPPFLAGS = []
@@ -60,6 +67,7 @@ setup(
     version="4.1",
     description="Mesh-intersection-based services in *Cassiopee*.",
     author="ONERA",
+    url="https://onera.github.io/Cassiopee/",
     package_dir={"":"."},
     packages=['Intersector'],
     ext_modules=[Extension('Intersector.intersector',

--- a/Cassiopee/KCore/Dist.py
+++ b/Cassiopee/KCore/Dist.py
@@ -1,7 +1,5 @@
 # Functions used in *Cassiopee* modules setup.py
 import os, sys, platform, glob, subprocess, shutil
-#from distutils import sysconfig
-#from distutils.core import Extension
 from setuptools._distutils import sysconfig
 from setuptools import Extension
 
@@ -15,6 +13,72 @@ GDOUBLEINT = False
 
 # Temporary for ADOLC
 ADOLC = False
+
+# System configuration dictionary
+CONFIGDICT = {}
+
+#==============================================================================
+# System configuration using installBase.py / installBaseUser.py
+#==============================================================================
+def setConfigDict(installDict=None):
+    global CONFIGDICT
+    prod = os.getenv("ELSAPROD")
+    if installDict is None:
+        try: import KCore.installBase as installBase
+        except: import installBase
+        installDict = installBase.installDict
+
+    cassProd = None
+    # prod est tout d'abord cherche dans le dictionnaire
+    if prod is not None:
+        prod = prod.replace('_i8', '').replace('_DBG', '')
+        # check if machine contains a branch name and if so, remove it from the prod
+        # this cannot be detected using the ELSAPROD alone as the prefix '_b-' is
+        # replaced with '_' in Envs/sh_Cassiopee_local
+        mac = os.getenv("MACHINE")
+        if mac is not None:
+            mac = mac.replace('_i8', '').replace('_DBG', '').split('_b-')
+            if len(mac) == 2:
+                branchName = mac[1]
+                prod = prod.replace('_' + branchName, '')
+            if mac[0] in installDict: cassProd = mac[0]
+            else:
+                if prod in installDict: cassProd = prod
+        else:
+            if prod in installDict: cassProd = prod
+
+    if cassProd is None:  # not found in installDict
+        print(f"Warning: {prod} not found in KCore/installBase.py.")
+        print("Warning: using default compilers and options.")
+        print("Warning: to change that, add a block in KCore/installBase.py.")
+        cassProd = 'default'
+
+    configKeys = [
+        "description",
+        "f77compiler",
+        "f90compiler",
+        "Cppcompiler",
+        "CppAdditionalOptions",
+        "f77AdditionalOptions",
+        "useOMP",
+        "useStatic",
+        "additionalIncludePaths",
+        "additionalLibs",
+        "additionalLibPaths",
+        "useCuda",
+        "NvccAdditionalOptions"
+    ]
+    CONFIGDICT = dict(zip(configKeys, installDict[cassProd]))
+
+def getConfigDict():
+    global CONFIGDICT
+    if not CONFIGDICT: setConfigDict()
+    return CONFIGDICT
+
+def getFromConfigDict(key=None, default=None):
+    global CONFIGDICT
+    if not CONFIGDICT: setConfigDict()
+    return CONFIGDICT.get(key, default)
 
 #==============================================================================
 # Check module import
@@ -106,7 +170,9 @@ def getDataFolderName(name='Data'):
 # Check all (python, numpy, C++, fortran, hdf, mpi, mpi4py, png, osmesa, mpeg)
 #==============================================================================
 def checkAll(summary=True):
-    from config import additionalLibPaths, additionalIncludePaths, useCuda
+    additionalLibPaths = getFromConfigDict("additionalLibPaths", [])
+    additionalIncludePaths = getFromConfigDict("additionalIncludePaths", [])
+    useCuda = getFromConfigDict("useCuda", False)
 
     out = []
     try:
@@ -120,7 +186,7 @@ def checkAll(summary=True):
     (ok, CppLibs, CppLibPaths) = checkCppLibs(additionalLibPaths, additionalIncludePaths)
     if ok: out += ['C++: OK (%s, %s).'%(CppLibs, CppLibPaths)]
     else: out += ['C++: Fail.']
-    (ok, FLibs, FLibPaths) = checkFortranLibs(additionalLibPaths, additionalIncludePaths)
+    (ok, FLibs, FLibPaths) = checkFortranLibs()
     if ok: out += ['f77: OK (%s, %s).'%(FLibs, FLibPaths)]
     else: out += ['f77: Fail.']
     (ok, hdfIncDir, hdfLibDir, hdflibs) = checkHdf(additionalLibPaths, additionalIncludePaths)
@@ -143,7 +209,7 @@ def checkAll(summary=True):
     else: out += ['mpi4py: missing (%s).'%(mpi4pyIncDir)]
 
     if useCuda:
-        (ok, cudaIncDir, cudaLib, cudaBin) = checkCuda(additionalLibPaths, additionalIncludePaths)
+        (ok, cudaIncDir, cudaLib, cudaBin) = checkCuda()
         if ok: out += ['cuda: used (%s)'%(cudaIncDir)]
         else: out += ['cuda: missing. Not used (%s).'%(cudaIncDir)]
     if summary:
@@ -195,64 +261,16 @@ def checkNumpy():
 # else return dict {'lib': 'lib', 'pyversion': 'python3.12', 'site': 'site-packages'}
 #=============================================================================
 def getInstallPath(prefix, type=0):
-    mySystem = getSystem()[0]; bits = getSystem()[1]
-
     import site
     a = site.getsitepackages()[0].split('/')[-4:]
     if type == 0:
         if a[0] != 'local':
-            installPath = '%s/%s/%s/%s'%(prefix, a[1], a[2], a[3])  # 'prefix/lib/python3.12/site-packages'
+            installPath = os.path.join(prefix, *a[1:4])  # 'prefix/lib/python3.12/site-packages'
         else:
-            installPath = '%s/%s/%s/%s/%s'%(prefix, a[0], a[1], a[2], a[3])  # 'prefix/local/lib/python3.12/site-packages'
+            installPath = os.path.join(prefix, *a[:4])  # 'prefix/local/lib/python3.12/site-packages'
     else:
         installPath = {'lib': a[1], 'pyversion': a[2], 'site': a[3]}  # {'lib': 'lib', 'pyversion': 'python3.12', 'site': 'site-packages'}
     return installPath
-
-    '''
-    # Based on distutils (to be sure)
-    if os.environ['ELSAPROD'][0:6] == 'msys64' or os.environ['ELSAPROD'] == 'win64':
-        pythonLib = sysconfig.get_python_lib()
-        pythonLib = pythonLib.split('/')
-        pythonVersion = pythonLib[-2]
-        Site = pythonLib[-1]
-        Lib = pythonLib[-3]
-        installPath = '%s/%s/%s/site-packages'%(prefix, Lib, pythonVersion)
-    elif os.environ['ELSAPROD'][0:6] == 'ubuntu': # debian style
-        pythonLib = sysconfig.get_python_lib()
-        pythonLib = pythonLib.split('/')
-        pversion = sys.version_info
-        pythonVersion = "python{}.{}".format(pversion[0], pversion[1])
-        Site = pythonLib[-1]
-        Lib = pythonLib[-3]
-        installPath = '%s/local/%s/%s/dist-packages'%(prefix, Lib, pythonVersion)
-    elif mySystem == 'Windows' or mySystem == 'mingw':
-        installPath = prefix + "/Lib/site-packages"
-    elif mySystem == 'Darwin':
-        pythonLib = sysconfig.get_python_lib()
-        pythonLib = pythonLib.split('/')
-        pythonVersion = pythonLib[-2]
-        installPath = prefix + '/lib/python'+pythonVersion+'/site-packages'
-    else: # standard unix
-        pythonLib = sysconfig.get_python_lib()
-        pythonLib = pythonLib.split('/')
-        # Based on python lib
-        #installPath = prefix + '/' + '/'.join(pythonLib[-3:])
-        # Python version
-        pversion = sys.version_info
-        pythonVersion = "python{}.{}".format(pversion[0], pversion[1])
-        Site = pythonLib[-1]
-        Lib = pythonLib[-3]
-        installPath = '%s/%s/%s/site-packages'%(prefix, Lib, pythonVersion)
-
-    # temporary for tests
-    if installPath != retn:
-        print("WARNING: new installPath is not correct.")
-        print("WARNING: old: ", installPath)
-        print("WARNING: new: ", retn)
-
-    if type == 0: return installPath
-    else: return {'lib': Lib, 'pyversion': pythonVersion, 'site': Site}
-    '''
 
 #==============================================================================
 # Functions returning the names of the remote repo & branch and the commit hash
@@ -333,21 +351,6 @@ def writeInstallPath():
     if a[0] != 'local': libPath = '%s/%s'%(prefix, a[1])  # 'prefix/lib'
     else: libPath = '%s/%s/%s'%(prefix, a[0], a[1])  # 'prefix/local/lib'
     p.write('libPath = \'%s\'\n'%libPath)
-
-    '''
-    mySystem = getSystem()[0]; bits = getSystem()[1]
-    if mySystem == 'Windows' or mySystem == 'mingw': Lib = 'Lib'
-    elif mySystem == 'Darwin': Lib = 'lib'
-    else:
-        pythonLib = sysconfig.get_python_lib()
-        pythonLib = pythonLib.split('/')
-        Lib = pythonLib[-3]
-    if os.environ['ELSAPROD'][0:6] == 'ubuntu': # debian style
-        libPath = '%s/local/%s'%(prefix,Lib)
-    else:
-        libPath = '%s/%s'%(prefix,Lib)
-    p.write('libPath = \'%s\'\n'%libPath)
-    '''
 
     cwd = os.getcwd()
     p.write('includePath = \'%s\'\n'%(cwd))
@@ -463,8 +466,7 @@ def writeEnvs():
 # setup.cfg est utilise par setup de python pour choisir le compilo.
 #==============================================================================
 def writeSetupCfg():
-    try: from KCore.config import Cppcompiler
-    except: from config import Cppcompiler
+    Cppcompiler = getFromConfigDict("Cppcompiler", None)
     mySystem = getSystem()
 
     # Windows + mingw
@@ -478,7 +480,7 @@ def writeSetupCfg():
         p.close(); return
 
     # Unix
-    if Cppcompiler == "None" or Cppcompiler == "":
+    if Cppcompiler is None or Cppcompiler == "":
         a = os.access("./setup.cfg", os.F_OK)
         if a: os.remove("./setup.cfg")
     elif Cppcompiler == 'icc' or Cppcompiler == 'icpc':
@@ -520,18 +522,18 @@ def writeSetupCfg():
 
 #==============================================================================
 # Retourne le compilo c, c++ et ses options tels que definis dans distutils
-# ou dans config.py (installBase.py ou installBaseUser.py)
+# ou dans installBase.py / installBaseUser.py
 #==============================================================================
 def getDistUtilsCompilers():
+    Cppcompiler = getFromConfigDict("Cppcompiler", None)
+
     vars = sysconfig.get_config_vars('CC', 'CXX', 'OPT',
                                      'BASECFLAGS', 'CCSHARED',
                                      'LDSHARED', 'SO')
     for i, v in enumerate(vars):
         if v is None: vars[i] = ""
 
-    try: from KCore.config import Cppcompiler
-    except: from config import Cppcompiler
-    if Cppcompiler != 'None' or Cppcompiler != '':
+    if Cppcompiler is not None and Cppcompiler != '':
         if Cppcompiler == 'clang':
             vars[0] = Cppcompiler; vars[1] = Cppcompiler.replace('clang', 'clang++')
         elif Cppcompiler == 'clang++':
@@ -579,11 +581,9 @@ def getDistUtilsCompilers():
 
 #==============================================================================
 # Retourne le pre-processeur utilise pour les fichiers fortrans
-# IN: config.Cppcompiler
 #==============================================================================
 def getPP():
-    try: from KCore.config import Cppcompiler
-    except: from config import Cppcompiler
+    Cppcompiler = getFromConfigDict("Cppcompiler", None)
     sizes = '-DREAL_E="REAL*8"'
     if EDOUBLEINT: sizes += ' -DINTEGER_E="INTEGER*8"'
     else: sizes += ' -DINTEGER_E="INTEGER*4"'
@@ -598,11 +598,9 @@ def getPP():
 
 #==============================================================================
 # Retourne l'achiveur pour faire les librairies statiques
-# IN: config.Cppcompiler
 #==============================================================================
 def getAR():
-    try: from KCore.config import Cppcompiler
-    except: from config import Cppcompiler
+    Cppcompiler = getFromConfigDict("Cppcompiler", None)
     if Cppcompiler == "icl.exe": return 'ar.exe '
     elif Cppcompiler == "x86_64-w64-mingw32-gcc":
         return 'x86_64-w64-mingw32-ar'
@@ -610,11 +608,9 @@ def getAR():
 
 #==============================================================================
 # Retourne le prefix pour le repertoire ou on stocke les modules f90
-# IN: config.f90compiler
 #==============================================================================
 def getFortranModDirPrefix():
-    try: from KCore.config import f90compiler
-    except: from config import f90compiler
+    f90compiler = getFromConfigDict("f90compiler", "gfortran")
     if f90compiler == 'ifort': return '-module'
     elif f90compiler == 'ifort.exe': return '-module'
     elif f90compiler == 'gfortran': return '-J'
@@ -623,31 +619,25 @@ def getFortranModDirPrefix():
 
 #==============================================================================
 # Retourne 1 si oui
-# IN: config.useOMP
 #==============================================================================
 def useOMP():
-    try: from KCore.config import useOMP
-    except: from config import useOMP
+    useOMP = getFromConfigDict("useOMP", True)
     if useOMP: return 1
     else: return 0
 
 #==============================================================================
 # Retourne 1 si on produit des librairies statiques
-# IN: config.useStatic
 #==============================================================================
 def useStatic():
-    try: from KCore.config import useStatic
-    except: from config import useStatic
+    useStatic = getFromConfigDict("useStatic", False)
     if useStatic: return 1
     else: return 0
 
 #==============================================================================
 # Retourne 1 si on dispose de cuda
-# IN: config.useCuda
 #==============================================================================
 def useCuda():
-    try: from KCore.config import useCuda
-    except: from config import useCuda
+    useCuda = getFromConfigDict("useCuda", False)
     if useCuda: return 1
     else: return 0
 
@@ -678,13 +668,11 @@ def getVersion(compiler):
     return (major, minor)
 
 def getCppVersion():
-    try: from KCore.config import Cppcompiler
-    except: from config import Cppcompiler
+    Cppcompiler = getFromConfigDict("Cppcompiler", None)
     return getVersion(Cppcompiler)
 
 def getForVersion():
-    try: from KCore.config import f77compiler
-    except: from config import f77compiler
+    f77compiler = getFromConfigDict("f77compiler", "gfortran")
     return getVersion(f77compiler)
 
 #=============================================================================
@@ -712,8 +700,7 @@ def getSimd():
 # Retourne les options SIMD pour les compilateurs
 # Se base sur les options precedentes qui doivent contenir -DSIMD
 def getSimdOptions():
-    try: from KCore.config import Cppcompiler
-    except: from config import Cppcompiler
+    Cppcompiler = getFromConfigDict("Cppcompiler", None)
     options = getCppAdditionalOptions()
     simd = ''
     for i in options:
@@ -874,29 +861,27 @@ def sortFileListByUse(files):
 # Retourne les options additionelles des compilos definies dans config
 #==============================================================================
 def getCppAdditionalOptions():
-    try: from KCore.config import CppAdditionalOptions
-    except: from config import CppAdditionalOptions
-    return CppAdditionalOptions
+    return getFromConfigDict("CppAdditionalOptions", [])
 
 def getf77AdditionalOptions():
-    try: from KCore.config import f77AdditionalOptions
-    except: from config import f77AdditionalOptions
-    return f77AdditionalOptions
+    return getFromConfigDict("f77AdditionalOptions", [])
 
 #==============================================================================
 # Retourne les arguments pour le compilateur C (utilise aussi pour Cpp)
-# IN: config.Cppcompiler, config.useStatic, config.useOMP,
-# config.CppAdditionalOptions
 #==============================================================================
 def getCArgs():
-    try: from KCore.config import Cppcompiler
-    except: from config import Cppcompiler
+    Cppcompiler = getFromConfigDict("Cppcompiler", None)
+    useOMP = getFromConfigDict("useOMP", True)
+    useStatic = getFromConfigDict("useStatic", False)
+    useCuda = getFromConfigDict("useCuda", False)
+    simdOptions = getSimdOptions()
+
     mySystem = getSystem()
     compiler = Cppcompiler.split('/')
     l = len(compiler)-1
     Cppcompiler = compiler[l]
-    if Cppcompiler == "None": return []
-    options = getCppAdditionalOptions()[:]
+    if Cppcompiler is None: return []
+    options = getCppAdditionalOptions()
     if EDOUBLEINT: options += ['-DE_DOUBLEINT']
     if GDOUBLEINT: options += ['-DG_DOUBLEINT']
     if ADOLC: options += ['-DE_ADOLC']
@@ -915,12 +900,12 @@ def getCArgs():
             options += ['-fp-speculation=strict']
         else:
             options += ['-fp-model=precise'] # modif 2.6
-        if useOMP() == 1:
+        if useOMP == 1:
             if v[0] < 15: options += ['-openmp']
             else: options += ['-qopenmp']
-        if useStatic() == 1: options += ['-static']
+        if useStatic == 1: options += ['-static']
         else: options += ['-fPIC']
-        options += getSimdOptions()
+        options += simdOptions
         return options
     elif Cppcompiler.find("gcc") == 0 or Cppcompiler.find("g++") == 0:
         if DEBUG:
@@ -930,99 +915,95 @@ def getCArgs():
                 options += ['-fsanitize=address']
                 #options += ['-fsanitize=thread']
         else: options += ['-DNDEBUG', '-O3', '-Wall', '-Werror=return-type']
-        if useOMP() == 1: options += ['-fopenmp']
-        if useStatic() == 1: options += ['--static', '-static-libstdc++', '-static-libgcc']
+        if useOMP == 1: options += ['-fopenmp']
+        if useStatic == 1: options += ['--static', '-static-libstdc++', '-static-libgcc']
         else: options += ['-fPIC']
         if mySystem[0] == 'mingw' and mySystem[1] == '32':
             options.remove('-fPIC')
             options += ['-large-address-aware']
-        options += getSimdOptions()
+        options += simdOptions
         return options
     elif Cppcompiler == "icl.exe":
         options += ['/EHsc', '/MT']
-        if useOMP() == 1: options += ['/Qopenmp']
+        if useOMP == 1: options += ['/Qopenmp']
         return options
     elif Cppcompiler == "icx" or Cppcompiler == "icpx":
         if DEBUG: options += ['-g', '-O0', '-fp-trap=divzero,overflow,invalid']
         else: options += ['-DNDEBUG', '-O2',]
         options += ['-fp-model=precise'] # existe encore?
-        if useOMP() == 1: options += ['-qopenmp']
-        if useStatic() == 1: options += ['-static']
+        if useOMP == 1: options += ['-qopenmp']
+        if useStatic == 1: options += ['-static']
         else: options += ['-fPIC']
-        options += getSimdOptions()
+        options += simdOptions
         return options
     elif Cppcompiler == "pgcc" or Cppcompiler == "pgc++":
         if DEBUG: options += ['-g', '-O0']
         else: options += ['-DNDEBUG', '-O3']
-        if useOMP() == 1: options += ['-mp=multicore']
+        if useOMP == 1: options += ['-mp=multicore']
         else: options += ['-nomp']
-        if useStatic() == 1: options += []
+        if useStatic == 1: options += []
         else: options += ['-fPIC']
-        options += getSimdOptions()
-        if useCuda(): options += ['-acc=gpu', '-Minfo:accel']
+        options += simdOptions
+        if useCuda: options += ['-acc=gpu', '-Minfo:accel']
         return options
     elif Cppcompiler == "nvc" or Cppcompiler == "nvc++":
         if DEBUG: options += ['-g', '-O0']
         else: options += ['-DNDEBUG', '-O3']
-        if useOMP() == 1: options += ['-mp=multicore']
+        if useOMP == 1: options += ['-mp=multicore']
         else: options += ['-nomp']
-        if useStatic() == 1: options += ['-static']
+        if useStatic == 1: options += ['-static']
         else: options += ['-fPIC']
-        options += getSimdOptions()
-        if useCuda(): options += ['-acc=gpu', '-Minfo:accel']
+        options += simdOptions
+        if useCuda: options += ['-acc=gpu', '-Minfo:accel']
         return options
     elif Cppcompiler == "x86_64-w64-mingw32-gcc" or Cppcompiler == "x86_64-w64-mingw32-g++":
         options += ['-DMS_WIN64', '-fpermissive', '-D__USE_MINGW_ANSI_STDIO=1']
         if DEBUG: options += ['-g', 'O0', '-D_GLIBCXX_DEBUG_PEDANTIC']
         else: options += ['-DNDEBUG', '-O3']
-        if useOMP() == 1: options += ['-fopenmp']
-        if useStatic() == 1: options += ['--static', '-static-libstdc++', '-static-libgcc']
+        if useOMP == 1: options += ['-fopenmp']
+        if useStatic == 1: options += ['--static', '-static-libstdc++', '-static-libgcc']
         else: options += ['-fPIC']
-        options += getSimdOptions()
+        options += simdOptions
         return options
     elif Cppcompiler == "clang" or Cppcompiler == "clang++":
         if DEBUG: options += ['-g', '-O0', '-Wall', '-D_GLIBCXX_DEBUG_PEDANTIC']
         else: options += ['-DNDEBUG', '-O3', '-Wall']
-        if useOMP() == 1: options += ['-fopenmp']
-        if useStatic() == 1: options += ['--static', '-static-libstdc++', '-static-libgcc']
+        if useOMP == 1: options += ['-fopenmp']
+        if useStatic == 1: options += ['--static', '-static-libstdc++', '-static-libgcc']
         else: options += ['-fPIC']
-        options += getSimdOptions()
+        options += simdOptions
         return options
     elif Cppcompiler == "craycc" or Cppcompiler == "craycxx":
         if DEBUG: options += ['-g', '-O0', '-Wall', '-D_GLIBCXX_DEBUG_PEDANTIC']
         else: options += ['-DNDEBUG', '-O3', '-Wall']
-        if useOMP() == 1: options += ['-fopenmp']
-        if useStatic() == 1: options += ['--static', '-static-libstdc++', '-static-libgcc']
+        if useOMP == 1: options += ['-fopenmp']
+        if useStatic == 1: options += ['--static', '-static-libstdc++', '-static-libgcc']
         else: options += ['-fPIC']
-        options += getSimdOptions()
+        options += simdOptions
         return options
     elif Cppcompiler == "cc":
         if DEBUG: options += ['-g', '-O0', '-Wall', '-D_GLIBCXX_DEBUG_PEDANTIC']
         else: options += ['-DNDEBUG', '-O3', '-Wall']
-        if useOMP() == 1: options += ['-fopenmp']
-        if useStatic() == 1: options += ['--static', '-static-libstdc++', '-static-libgcc']
+        if useOMP == 1: options += ['-fopenmp']
+        if useStatic == 1: options += ['--static', '-static-libstdc++', '-static-libgcc']
         else: options += ['-fPIC']
-        options += getSimdOptions()
+        options += simdOptions
         return options
     else: return options
 
 # Options pour le compilateur C++
 def getCppArgs():
     opt = getCArgs()
-    try: from KCore.config import Cppcompiler
-    except: from config import Cppcompiler
+    Cppcompiler = getFromConfigDict("Cppcompiler", None)
     if Cppcompiler == "icl.exe": opt += ["/std=c++11"]
     else: opt += ["-std=c++11"]
     return opt
 
 #==============================================================================
 # Retourne les arguments pour le compilateur Cuda
-# IN: config.Cppcompiler, config.useStatic, config.useOMP,
-# config.CppAdditionalOptions
 #==============================================================================
 def getCudaArgs():
-    try: from KCore.config import NvccAdditionalOptions
-    except: from config import NvccAdditionalOptions
+    NvccAdditionalOptions = getFromConfigDict("NvccAdditionalOptions", [])
     options = NvccAdditionalOptions
     if DEBUG: options += ['-g', '-O0']
     else: options += ['-DNDEBUG', '-O2']
@@ -1030,27 +1011,29 @@ def getCudaArgs():
 
 #==============================================================================
 # Retourne les arguments pour le compilateur Fortran
-# IN: config.f77compiler
 #==============================================================================
 def getForArgs():
-    try: from KCore.config import f77compiler
-    except: from config import f77compiler
+    f77compiler = getFromConfigDict("f77compiler", "gfortran")
+    useOMP = getFromConfigDict("useOMP", True)
+    useStatic = getFromConfigDict("useStatic", False)
+    simdOptions = getSimdOptions()
+
     mySystem = getSystem()
     compiler = f77compiler.split('/')
     l = len(compiler)-1
     f77compiler = compiler[l]
-    if f77compiler == "None": return []
+    if f77compiler is None: return []
     options = getf77AdditionalOptions()
     if f77compiler == "gfortran":
         if DEBUG: options += ['-Wall', '-g', '-O0', '-fbacktrace', '-fbounds-check', '-ffpe-trap=zero,overflow,invalid']
         else: options += ['-Wall', '-O3']
-        if useOMP() == 1: options += ['-fopenmp']
-        if useStatic() == 1: options += ['--static']
+        if useOMP == 1: options += ['-fopenmp']
+        if useStatic == 1: options += ['--static']
         else: options += ['-fPIC']
         if mySystem[0] == 'mingw' and mySystem[1] == '32':
             options.remove('-fPIC')
             options += ['-large-address-aware']
-        options += getSimdOptions()
+        options += simdOptions
         if EDOUBLEINT: options += ['-fdefault-integer-8']
         options += ['-fdefault-real-8', '-fdefault-double-8']
         return options
@@ -1060,13 +1043,13 @@ def getForArgs():
         v = getForVersion()
         if v[0] < 15: options += ['-fp-speculation=strict']
         else: options += ['-fp-model=precise']
-        if useOMP() == 1:
+        if useOMP == 1:
             v = getForVersion()
             if v[0] < 15: options += ['-openmp']
             else: options += ['-qopenmp']
-        if useStatic() == 1: options += ['-static']
+        if useStatic == 1: options += ['-static']
         else: options += ['-fPIC']
-        options += getSimdOptions()
+        options += simdOptions
         if EDOUBLEINT: options += ['-i8']
         options += ['-r8']
         return options
@@ -1074,73 +1057,73 @@ def getForArgs():
         if DEBUG: options += ['-g', '-O0', '-CB', '-fpe0']
         else: options += ['-O3']
         options += ['-fp-model=precise']
-        if useOMP() == 1: options += ['-qopenmp']
-        if useStatic() == 1: options += ['-static']
+        if useOMP == 1: options += ['-qopenmp']
+        if useStatic == 1: options += ['-static']
         else: options += ['-fPIC']
-        options += getSimdOptions()
+        options += simdOptions
         if EDOUBLEINT: options += ['-i8']
         options += ['-r8']
         return options
     elif f77compiler == "pgfortran":
-        if useStatic() == 1: options += ['-static']
+        if useStatic == 1: options += ['-static']
         else: options += ['-fPIC']
         if DEBUG: options += ['-g', '-O0']
         else: options += ['-O3']
-        if useOMP() == 1: options += ['-mp=multicore']
-        options += getSimdOptions()
+        if useOMP == 1: options += ['-mp=multicore']
+        options += simdOptions
         if EDOUBLEINT: options += ['-i8']
         options += ['-r8']
         return options
     elif f77compiler == "nvfortran":
-        if useStatic() == 1: options += ['-static']
+        if useStatic == 1: options += ['-static']
         else: options += ['-fPIC']
         if DEBUG: options += ['-g', '-O0']
         else: options += ['-O3']
-        if useOMP() == 1: options += ['-mp=multicore']
-        options += getSimdOptions()
+        if useOMP == 1: options += ['-mp=multicore']
+        options += simdOptions
         if EDOUBLEINT: options += ['-i8']
         options += ['-r8']
         return options
     elif f77compiler == "x86_64-w64-mingw32-gfortran":
         if DEBUG: options += ['-g', '-O0']
         else: options += ['-O3']
-        if useOMP() == 1: options += ['-fopenmp']
-        if useStatic() == 1: options += ['--static']
+        if useOMP == 1: options += ['-fopenmp']
+        if useStatic == 1: options += ['--static']
         else: options += ['-fPIC']
-        options += getSimdOptions()
+        options += simdOptions
         if EDOUBLEINT: options += ['-fdefault-integer-8']
         options += ['-fdefault-real-8', '-fdefault-double-8']
         return options
     elif f77compiler == "ifort.exe":
-        if useOMP() == 1: return ['/names:lowercase', '/assume:underscore', '/Qopenmp']
+        if useOMP == 1: return ['/names:lowercase', '/assume:underscore', '/Qopenmp']
         else: return ['/names:lowercase', '/assume:underscore']
     elif f77compiler == "crayftn":
-        if useStatic() == 1: options += ['-static']
+        if useStatic == 1: options += ['-static']
         else: options += ['-fPIC']
         if DEBUG: options += ['-g', '-O0']
         else: options += ['-O3']
-        if useOMP() == 1: options += ['-fopenmp']
-        options += getSimdOptions()
+        if useOMP == 1: options += ['-fopenmp']
+        options += simdOptions
         if EDOUBLEINT: options += ['-i8']
         options += ['-r8']
         return options
     elif f77compiler == "ftn":
-        if useStatic() == 1: options += ['-static']
+        if useStatic == 1: options += ['-static']
         else: options += ['-fPIC']
         if DEBUG: options += ['-g', '-O0']
         else: options += ['-O3']
-        if useOMP() == 1: options += ['-fopenmp']
-        options += getSimdOptions()
+        if useOMP == 1: options += ['-fopenmp']
+        options += simdOptions
         if EDOUBLEINT: options += ['-i8']
         options += ['-r8']
         return options
     elif f77compiler == "flang":
-        if useStatic() == 1: options += ['-static']
+        if useStatic == 1: options += ['-static']
         else: options += ['-fPIC']
         if DEBUG: options += ['-g', '-O0']
         else: options += ['-O3']
-        if useOMP() == 1: options += ['-fopenmp']
-        options += getSimdOptions()
+        if useOMP == 1: options += ['-fopenmp']
+        options += simdOptions
         if EDOUBLEINT: options += ['-fdefault-integer-8']
         options += ['-fdefault-real-8', '-fdefault-double-8']
         return options
@@ -1148,57 +1131,63 @@ def getForArgs():
 
 #==============================================================================
 # Retourne les arguments pour le linker
-# IN: config.Cppcompiler, config.useStatic, config.useOMP
 #==============================================================================
 def getLinkArgs():
-    try: from KCore.config import Cppcompiler
-    except: from config import Cppcompiler
+    Cppcompiler = getFromConfigDict("Cppcompiler", None)
+    useOMP = getFromConfigDict("useOMP", True)
+    useStatic = getFromConfigDict("useStatic", False)
+    useCuda = getFromConfigDict("useCuda", False)
+
     out = []
     if Cppcompiler == 'gcc' or Cppcompiler == 'g++':
-        if useStatic() == 1: out += ['--static']
+        if useStatic == 1: out += ['--static']
     elif Cppcompiler == 'icc' or Cppcompiler == 'icpc':
-        if useStatic() == 1: out += ['-static']
+        if useStatic == 1: out += ['-static']
     elif Cppcompiler == 'icx' or Cppcompiler == 'icpx':
-        if useStatic() == 1: out += ['-static']
+        if useStatic == 1: out += ['-static']
         else: out += ['-shared']
     elif Cppcompiler == "x86_64-w64-mingw32-gcc":
-        if useStatic() == 1: out += ['--static']
+        if useStatic == 1: out += ['--static']
     elif Cppcompiler == 'pgcc' or Cppcompiler == 'pgc++':
-        if useStatic() == 1: out += ['-static']
+        if useStatic == 1: out += ['-static']
         else: out += ['-shared']
-        if useOMP() == 1: out += ['-mp=multicore']
-        if useCuda() == 1: out += ['-acc=gpu', '-Minfo:accel']
+        if useOMP == 1: out += ['-mp=multicore']
+        if useCuda == 1: out += ['-acc=gpu', '-Minfo:accel']
     elif Cppcompiler == 'nvc' or Cppcompiler == 'nvc++':
-        if useStatic() == 1: out += ['-static']
+        if useStatic == 1: out += ['-static']
         else: out += ['-shared']
-        if useOMP() == 1: out += ['-mp=multicore']
-        if useCuda() == 1: out += ['-acc=gpu', '-Minfo:accel']
+        if useOMP == 1: out += ['-mp=multicore']
+        if useCuda == 1: out += ['-acc=gpu', '-Minfo:accel']
     elif Cppcompiler == 'craycc' or Cppcompiler == 'craycxx':
-        if useStatic() == 1: out += ['-static']
+        if useStatic == 1: out += ['-static']
         else: out += ['-shared']
-        if useOMP() == 1: out += ['-fopenmp']
+        if useOMP == 1: out += ['-fopenmp']
     elif Cppcompiler == 'cc':
-        if useStatic() == 1: out += ['-static']
+        if useStatic == 1: out += ['-static']
         else: out += ['-shared']
-        if useOMP() == 1: out += ['-fopenmp']
+        if useOMP == 1: out += ['-fopenmp']
     elif Cppcompiler == 'clang' or Cppcompiler == 'clang++':
-        if useStatic() == 1: out += ['-static']
+        if useStatic == 1: out += ['-static']
         else: out += ['-shared']
-        if useOMP() == 1: out += ['-fopenmp']
+        if useOMP == 1: out += ['-fopenmp']
     mySystem = getSystem()[0]
     if mySystem == 'Darwin':
-        if useStatic() == 0: out += ['-dynamiclib']
+        if useStatic == 0: out += ['-dynamiclib']
     return out
 
 #=============================================================================
 # Check PYTHONPATH
 # Verifie que installPath est dans PYTHONPATH
 #=============================================================================
-def checkPythonPath():
+def checkPythonPath(installPathDict=None):
     import re
-    try: import KCore.installPath as K
-    except: import installPath as K
-    installPathLocal = K.installPath
+    if installPathDict is None:
+        try: import KCore.installPath as K
+        except: import installPath as K
+        installPathLocal = K.installPath
+    else:
+        installPathLocal = installPathDict.get("installPath", "")
+
     a = os.getenv("PYTHONPATH")
     if a is None:
         print('Warning: to use the module, please add: %s to your PYTHONPATH.'%installPathLocal)
@@ -1209,11 +1198,15 @@ def checkPythonPath():
 #=============================================================================
 # Check LD_LIBRARY_PATH
 #=============================================================================
-def checkLdLibraryPath():
+def checkLdLibraryPath(installPathDict=None):
     import re
-    try: import KCore.installPath as K
-    except: import installPath as K
-    libPath = K.libPath
+    if installPathDict is None:
+        try: import KCore.installPath as K
+        except: import installPath as K
+        libPath = K.libPath
+    else:
+        libPath = installPathDict.get("libPath", "")
+
     a = os.getenv("LD_LIBRARY_PATH")
     b = os.getenv("LIBRARY_PATH")
     if a is None and b is None:
@@ -1225,149 +1218,44 @@ def checkLdLibraryPath():
             print("Warning: to use the module, please add: %s to your LD_LIBRARY_PATH (unix) or PATH (windows)."%libPath)
 
 #=============================================================================
-# Check for KCore (Cassiopee core)
+# Check the correct installation of any module of Cassiopee or Fast
 #=============================================================================
-def checkKCore():
+def checkModuleCassiopee(modname):
     try:
-        import KCore
+        import importlib
+        module = importlib.import_module(modname)
         import KCore.installPath
-        kcoreIncDir = KCore.installPath.includePath
-        kcoreIncDir = os.path.join(kcoreIncDir, 'KCore')
-        kcoreLibDir = KCore.installPath.libPath
-        return (KCore.__version__, kcoreIncDir, kcoreLibDir)
+        modIncDir = KCore.installPath.includePath
+        modIncDir = os.path.dirname(modIncDir)
+        modIncDir = os.path.join(modIncDir, modname, modname)
+        modLibDir = KCore.installPath.libPath
+        version = getattr(module, "__version__", None)
+        return version, modIncDir, modLibDir
 
-    except ImportError:
-        raise SystemError("Error: kcore library is required for the compilation of this module.")
+    except ImportError as e:
+        raise SystemError(
+            f"Error: {modname.lower()} library is required for the compilation "
+            "of this module."
+        ) from e
 
-#=============================================================================
-# Check for XCore (Parallel core)
-#=============================================================================
-def checkXCore():
+def checkModuleFast(modname):
     try:
-        import XCore
-        import KCore.installPath
-        xcoreIncDir = KCore.installPath.includePath
-        xcoreIncDir = os.path.dirname(xcoreIncDir)
-        xcoreIncDir = os.path.join(xcoreIncDir, 'XCore/XCore')
-        xcoreLibDir = KCore.installPath.libPath
-        return (XCore.__version__, xcoreIncDir, xcoreLibDir)
-
-    except ImportError:
-        raise SystemError("Error: xcore library is required for the compilation of this module.")
-
-#=============================================================================
-# Check for Generator
-#=============================================================================
-def checkGenerator():
-    try:
-        import Generator
-        import KCore.installPath
-        generatorIncDir = KCore.installPath.includePath
-        generatorIncDir = os.path.dirname(generatorIncDir)
-        generatorIncDir = os.path.join(generatorIncDir, 'Generator/Generator')
-        generatorLibDir = KCore.installPath.libPath
-        return (Generator.__version__, generatorIncDir, generatorLibDir)
-
-    except ImportError:
-        raise SystemError("Error: generator library is required for the compilation of this module.")
-
-#=============================================================================
-# Check for FastC module
-#=============================================================================
-def checkFastC():
-    try:
+        import importlib
+        module = importlib.import_module(modname)
         import FastC.installPath
         import KCore.installPath
-        fastcIncDir = FastC.installPath.includePath
-        fastcLibDir = KCore.installPath.libPath
-        return (FastC.__version__, fastcIncDir, fastcLibDir)
+        modIncDir = FastC.installPath.includePath
+        modIncDir = os.path.dirname(modIncDir)
+        modIncDir = os.path.join(modIncDir, modname, modname)
+        modLibDir = FastC.installPath.libPath
+        version = getattr(module, "__version__", None)
+        return version, modIncDir, modLibDir
 
-    except ImportError:
-        raise SystemError("Error: fastc library is required for the compilation of this module.")
-
-#=============================================================================
-# Check for FastS module
-#=============================================================================
-def checkFastS():
-    try:
-        import FastS
-        import FastC.installPath
-        import KCore.installPath
-        fastsIncDir = FastC.installPath.includePath
-        fastsIncDir = os.path.dirname(fastsIncDir)
-        fastsIncDir = os.path.join(fastsIncDir, 'FastS')
-        fastsLibDir = KCore.installPath.libPath
-        return (FastS.__version__, fastsIncDir, fastsLibDir)
-
-    except ImportError:
-        raise SystemError("Error: fasts library is required for the compilation of this module.")
-
-#=============================================================================
-# Check for FastP module
-#=============================================================================
-def checkFastP():
-    try:
-        import FastP
-        import FastC.installPath
-        import KCore.installPath
-        fastpIncDir = FastC.installPath.includePath
-        fastpIncDir = os.path.dirname(fastpIncDir)
-        fastpIncDir = os.path.join(fastpIncDir, 'FastP')
-        fastpLibDir = KCore.installPath.libPath
-        return (FastP.__version__, fastpIncDir, fastpLibDir)
-
-    except ImportError:
-        raise SystemError("Error: fastp library is required for the compilation of this module.")
-
-#=============================================================================
-# Check for FastLBM module
-#=============================================================================
-def checkFastLBM():
-    try:
-        import FastLBM
-        import FastC.installPath
-        import KCore.installPath
-        fastlbmIncDir = FastC.installPath.includePath
-        fastlbmIncDir = os.path.dirname(fastlbmIncDir)
-        fastlbmIncDir = os.path.join(fastlbmIncDir, 'FastLBM')
-        fastlbmLibDir = KCore.installPath.libPath
-        return (FastLBM.__version__, fastlbmIncDir, fastlbmLibDir)
-
-    except ImportError:
-        raise SystemError("Error: fastlbm library is required for the compilation of this module.")
-
-#=============================================================================
-# Check for FastASLBM module
-#=============================================================================
-def checkFastASLBM():
-    try:
-        import FastASLBM
-        import FastC.installPath
-        import KCore.installPath
-        fastaslbmIncDir = FastC.installPath.includePath
-        fastaslbmIncDir = os.path.dirname(fastaslbmIncDir)
-        fastaslbmIncDir = os.path.join(fastaslbmIncDir, 'FastASLBM')
-        fastaslbmLibDir = KCore.installPath.libPath
-        return (FastASLBM.__version__, fastaslbmIncDir, fastaslbmLibDir)
-
-    except ImportError:
-        raise SystemError("Error: fastaslbm library is required for the compilation of this module.")
-
-#=============================================================================
-# Check for Connector module
-#=============================================================================
-def checkConnector():
-    try:
-        import Connector
-        import KCore.installPath
-        ConnectorIncDir = KCore.installPath.includePath
-        ConnectorIncDir = os.path.dirname(ConnectorIncDir)
-        ConnectorIncDir = os.path.join(ConnectorIncDir, 'Connector/Connector')
-        ConnectorLibDir = KCore.installPath.libPath
-        return (Connector.__version__, ConnectorIncDir, ConnectorLibDir)
-
-    except ImportError:
-        raise SystemError("Error: Connector library is required for the compilation of this module.")
+    except ImportError as e:
+        raise SystemError(
+            f"Error: {modname.lower()} library is required for the compilation "
+            "of this module."
+        ) from e
 
 #=============================================================================
 # Check for Cassiopee Kernel in Dist/ or Kernel/
@@ -1897,11 +1785,13 @@ def checkMpi4py(additionalLibPaths=[], additionalIncludePaths=[]):
 # Retourne : (True/False, chemin des includes, chemin de la librairie, chemin
 #             executable nvcc)
 #=============================================================================
-def checkCuda(additionalLibPaths=[], additionalIncludePaths=[]):
+def checkCuda():
+    additionalIncludePaths = getFromConfigDict("additionalIncludePaths", [])
+    additionalLibPaths = getFromConfigDict("additionalLibPaths", [])
+    useCuda = getFromConfigDict("useCuda", False)
+
     # Check if the user want cuda supported
     # -------------------------------------
-    try: from KCore.config import useCuda
-    except: from config import useCuda
     if not useCuda:
         #print('Info: cuda is not activated. No cuda support.')
         return (False, None, None, None, None)
@@ -1990,9 +1880,11 @@ def checkParadigma(additionalLibPaths=[], additionalIncludePaths=[]):
 # Retourne: (True/False, chemin des includes, chemin de la librairie,
 # option de compile, nom de la librarie)
 #=============================================================================
-def checkBlas(additionalLibPaths=[], additionalIncludePaths=[]):
-    try: from KCore.config import Cppcompiler
-    except: from config import Cppcompiler
+def checkBlas():
+    Cppcompiler = getFromConfigDict("Cppcompiler", None)
+    additionalLibPaths = getFromConfigDict("additionalLibPaths", [])
+    additionalIncludePaths = getFromConfigDict("additionalIncludePaths", [])
+
     if Cppcompiler == 'icc' or Cppcompiler == 'icpc' or Cppcompiler == 'icx': # intel - cherche dans MKL
         libPrefix = 'libmkl_'; includePrefix = 'mkl_'; compOpt = '-mkl'
     else: # cherche std
@@ -2045,9 +1937,11 @@ def checkBlas(additionalLibPaths=[], additionalIncludePaths=[]):
 # Retourne: (True/False, chemin des includes, chemin de la librairie,
 # option de compile, nom de la librarie)
 #=============================================================================
-def checkLapack(additionalLibPaths=[], additionalIncludePaths=[]):
-    try: from KCore.config import Cppcompiler
-    except: from config import Cppcompiler
+def checkLapack():
+    Cppcompiler = getFromConfigDict("Cppcompiler", None)
+    additionalLibPaths = getFromConfigDict("additionalLibPaths", [])
+    additionalIncludePaths = getFromConfigDict("additionalIncludePaths", [])
+
     if Cppcompiler == 'icc' or Cppcompiler == 'icpc' or Cppcompiler == 'icx': # intel - cherche dans MKL
         libPrefix = 'libmkl_'; includePrefix = 'mkl_'; compOpt = '-mkl'
     else: # cherche std
@@ -2122,18 +2016,12 @@ def cythonize(src):
 # additionalLibPaths: chemins d'installation des libraries non standards: ['/home/toto',...]
 # Retourne (True, [librairies utiles pour le fortran], [paths des librairies])
 #=============================================================================
-def checkFortranLibs(additionalLibs=[], additionalLibPaths=[],
-                     f77compiler=None, useOMP=None):
-    if f77compiler is None:
-        try: from KCore.config import f77compiler
-        except:
-            try: from config import f77compiler
-            except: f77compiler = 'gfortran'
-    if useOMP is None:
-        try: from KCore.config import useOMP
-        except:
-            try: from config import useOMP
-            except: useOMP = True
+def checkFortranLibs():
+    additionalLibs = getFromConfigDict("additionalLibs", [])
+    additionalLibPaths = getFromConfigDict("additionalLibPaths", [])
+    f77compiler = getFromConfigDict("f77compiler", "gfortran")
+    useOMP = getFromConfigDict("useOMP", True)
+
     ret = True; libs = []; paths = []
 
     # librairies speciales (forcees sans check)
@@ -2287,19 +2175,11 @@ def checkFortranLibs(additionalLibs=[], additionalLibPaths=[],
 # additionalLibPaths: si chemins des libraries necessaires non standards : ['/home/toto',...]
 # Retourne (True, [librairies utiles a cpp], [paths des librairies])
 #=============================================================================
-def checkCppLibs(additionalLibs=[], additionalLibPaths=[], Cppcompiler=None,
-                 useOMP=None):
-
-    if Cppcompiler is None:
-        try: from KCore.config import Cppcompiler
-        except:
-            try: from config import Cppcompiler
-            except: Cppcompiler = 'gcc'
-    if useOMP is None:
-        try: from KCore.config import useOMP
-        except:
-            try: from config import useOMP
-            except: useOMP = True
+def checkCppLibs():
+    additionalLibs = getFromConfigDict("additionalLibs", [])
+    additionalLibPaths = getFromConfigDict("additionalLibPaths", [])
+    Cppcompiler = getFromConfigDict("Cppcompiler", "gcc")
+    useOMP = getFromConfigDict("useOMP", True)
 
     ret = True; libs = []; paths = []
 
@@ -2615,8 +2495,8 @@ def writeBuildInfo():
     p = open("buildInfo.py", 'w')
     if p is None:
         raise SystemError("Error: can not open file buildInfo.py for writing.")
-    try: import KCore.config as config
-    except: import config
+    additionalIncludePaths = getFromConfigDict("additionalIncludePaths", [])
+    additionalLibPaths = getFromConfigDict("additionalLibPaths", [])
 
     dict = {}
     # Date
@@ -2635,38 +2515,37 @@ def writeBuildInfo():
     else: dict['numpy'] = "None"
 
     # Check png
-    #(png, pngIncDir, pngLib) = checkPng(config.additionalLibPaths,
-    #                                    config.additionalIncludePaths)
+    #(png, pngIncDir, pngLib) = checkPng(additionalLibPaths,
+    #                                    additionalIncludePaths)
     #if png: dict['png'] = pngLib
     #else: dict['png'] = "None"
 
     # Check ffmpeg
-    (mpeg, mpegIncDir, mpegLib) = checkMpeg(config.additionalLibPaths,
-                                            config.additionalIncludePaths)
+    (mpeg, mpegIncDir, mpegLib) = checkMpeg(additionalLibPaths,
+                                            additionalIncludePaths)
     if mpeg: dict['mpeg'] = mpegLib
     else: dict['mpeg'] = "None"
 
     # Check hdf5
-    (hdf, hdfIncDir, hdfLib, hdflibnames) = checkHdf(config.additionalLibPaths,
-                                                     config.additionalIncludePaths)
+    (hdf, hdfIncDir, hdfLib, hdflibnames) = checkHdf(additionalLibPaths,
+                                                     additionalIncludePaths)
     if hdf: dict['hdf'] = hdfLib
     else: dict['hdf'] = "None"
 
     # Check netcdf
-    (netcdf, netcdfIncDir, netcdfLib, netcdflibnames) = checkNetcdf(config.additionalLibPaths,
-                                                                    config.additionalIncludePaths)
+    (netcdf, netcdfIncDir, netcdfLib, netcdflibnames) = checkNetcdf(additionalLibPaths,
+                                                                    additionalIncludePaths)
     if netcdf: dict['netcdf'] = netcdfLib
     else: dict['netcdf'] = "None"
 
     # Check mpi
-    (mpi, mpiIncDir, mpiLib, mpiLibs) = checkMpi(config.additionalLibPaths,
-                                                 config.additionalIncludePaths)
+    (mpi, mpiIncDir, mpiLib, mpiLibs) = checkMpi(additionalLibPaths,
+                                                 additionalIncludePaths)
     if mpi: dict['mpi'] = mpiLib
     else: dict['mpi'] = "None"
 
     # Check cuda
-    (cuda, cudaIndDir, cudaLib, cudalibNames, cudaexec) = checkCuda(config.additionalLibPaths,
-                                                                    config.additionalIncludePaths)
+    (cuda, cudaIndDir, cudaLib, cudalibNames, cudaexec) = checkCuda()
     if cuda: dict['cuda'] = cudaLib
     else: dict['cuda'] = "None"
 
@@ -2676,8 +2555,7 @@ def writeBuildInfo():
     p.close()
 
 #==============================================================================
-# Ecrit la base d'installation (ancien config.py) dans le fichier
-# installBase.py
+# Ecrit la base d'installation dans le fichier installBase.py
 # IN: dict: dictionnaire d'install
 #==============================================================================
 def writeInstallBase(dict):

--- a/Cassiopee/KCore/install
+++ b/Cassiopee/KCore/install
@@ -70,7 +70,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/KCore/pyproject.toml
+++ b/Cassiopee/KCore/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/KCore/setup.py
+++ b/Cassiopee/KCore/setup.py
@@ -1,62 +1,87 @@
-import os
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-
 #=============================================================================
 # KCore requires:
 # C++ compiler
-# Fortran compiler: defined in config.py
+# Fortran compiler
 # Numpy
 # Scons
 #=============================================================================
-# Compiler settings must be set in config.py
-from config import *
-import Dist
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
+
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('Dist')
+installBase = loadModuleFromPath('installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Write setup.cfg file
 Dist.writeSetupCfg()
 
-# Test if numpy exists =======================================================
-(numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
+# Test if numpy exists
+numpyVersion, numpyIncDir, numpyLibDir = Dist.checkNumpy()
 
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
-
-# Setting libraries path =====================================================
-libraryDirs = ["build/"+prod]
+prod = os.getenv("ELSAPROD") or "xx"
+# Setting libraries path
+libraryDirs = ["build/" + prod]
 libraries = ["kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
-libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
-libraryDirs += paths; libraries += libs
+
+ok, libs, paths = Dist.checkFortranLibs()
+libraryDirs += paths
+libraries += libs
+
+ok, libs, paths = Dist.checkCppLibs()
+libraryDirs += paths
+libraries += libs
 
 if Dist.ADOLC:
-    (adolc, adolcIncDir, adolcLibDir, adolcLib) = Dist.checkAdolc(additionalLibPaths, additionalIncludePaths)
+    adolc, adolcIncDir, adolcLibDir, adolcLib = Dist.checkAdolc(
+        additionalLibPaths,
+        additionalIncludePaths,
+    )
     if adolc:
-        libraryDirs += adolcLibDir; libraries += [adolcLib]
+        libraryDirs += adolcLibDir
+        libraries.append(adolcLib)
 
-# Extensions =================================================================
-extensions = [
-    Extension('KCore.kcore',
-              sources=['KCore/kcore.cpp'],
-              include_dirs=["KCore"]+additionalIncludePaths+[numpyIncDir],
-              library_dirs=additionalLibPaths+libraryDirs,
-              libraries=libraries+additionalLibs,
-              extra_compile_args=Dist.getCppArgs(),
-              extra_link_args=Dist.getLinkArgs())
+# Extensions
+listExtensions = [
+    Extension(
+        "KCore.kcore",
+        sources=["KCore/kcore.cpp"],
+        include_dirs=["KCore"] + additionalIncludePaths + [numpyIncDir],
+        library_dirs=additionalLibPaths + libraryDirs,
+        libraries=libraries + additionalLibs,
+        extra_compile_args=Dist.getCppArgs(),
+        extra_link_args=Dist.getLinkArgs(),
+    )
 ]
 
-# Setup ======================================================================
 setup(
     name="KCore",
     version="4.1",
     description="Core for *Cassiopee* modules.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     packages=['KCore'],
-    package_dir={"":"."},
-    ext_modules=extensions
+    ext_modules=listExtensions
 )
 
 # Check PYTHONPATH
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/KCore/setup.scons
+++ b/Cassiopee/KCore/setup.scons
@@ -1,16 +1,19 @@
 import os
 import Dist
-from config import *
 #==============================================================================
 # KCore requires:
 # C++ compiler
-# Fortran compiler: defined in config.py
+# Fortran compiler
 # Numpy
 #==============================================================================
 
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -24,9 +27,9 @@ installPath = Dist.getInstallPath(prefix)
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ['..', '.', pythonLibDir]
 libraries = []
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Env =========================================================================

--- a/Cassiopee/KCore/setupLegacy.py
+++ b/Cassiopee/KCore/setupLegacy.py
@@ -1,18 +1,23 @@
-#from distutils.core import setup, Extension
 from setuptools import setup, Extension
 import os
 
 #=============================================================================
 # KCore requires:
+# ELSAPROD variable defined in environment
 # C++ compiler
-# Fortran compiler: defined in config.py
+# Fortran compiler
 # Numpy
 #=============================================================================
-# Compiler settings must be set in config.py
-from config import *
+
+import Dist
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Write KCore installation path to installPath.py
-import Dist
 Dist.writeInstallPath()
 
 # Write setup.cfg file
@@ -22,7 +27,7 @@ Dist.writeSetupCfg()
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Fortran compilation ========================================================
-if f77compiler == "None":
+if f77compiler is None:
     print("Error: a fortran 77 compiler is required for compiling KCore.")
 args = Dist.getForArgs(); opt = ''
 for c, v in enumerate(args): opt += 'FOPT%d=%s '%(c, v)
@@ -38,9 +43,9 @@ if prod is None: prod = 'xx'
 # Setting libraries path =====================================================
 libraryDirs = ["build/"+prod]
 libraries = ["Fld", "Interp", "Metric", "CompGeom", "Loc", "Linear"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Extensions =================================================================
@@ -62,6 +67,7 @@ setup(
     version="4.1",
     description="Core for *Cassiopee* modules.",
     author="ONERA",
+    url="https://onera.github.io/Cassiopee/",
     package_dir={"":"."},
     packages=['KCore'],
     ext_modules=extensions

--- a/Cassiopee/Modeler/install
+++ b/Cassiopee/Modeler/install
@@ -62,7 +62,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/Modeler/pyproject.toml
+++ b/Cassiopee/Modeler/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/Modeler/setup.py
+++ b/Cassiopee/Modeler/setup.py
@@ -1,7 +1,3 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-import os
-
 #=============================================================================
 # Modeler requires:
 # ELSAPROD variable defined in environment
@@ -9,36 +5,51 @@ import os
 # Numpy
 # KCore, Converter, Generator, Transform
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
+
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Write setup.cfg file
-import KCore.Dist as Dist
 Dist.writeSetupCfg()
-
-from KCore.config import *
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Test if open-cascade is already installed ==================================
 (OCCPresent, OCCIncDir, OCCLibDir) = Dist.checkOCC(additionalLibPaths,
                                                    additionalIncludePaths)
 
-import srcs
+srcs = loadModuleFromPath('srcs')
 if srcs.TIGL and not OCCPresent:
     print("Warning: open cascade not found on your system. Modeler.Tigl not installed.")
     os._exit(0)
 
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 
 # Setting libraryDirs, include dirs and libraries =============================
 libraryDirs = ["build/"+prod, kcoreLibDir]
 includeDirs = [numpyIncDir, kcoreIncDir]
 libraries = ["kcore", "modeler", "modeler"]
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 if OCCPresent:
@@ -50,7 +61,6 @@ if OCCPresent and Dist.getSystem()[0] == 'mingw':
     libOCC = [i+".dll" for i in libOCC]
 if OCCPresent: libraries += libOCC + libOCC
 
-import srcs
 if srcs.TIXI: libraries += ["curl", "xml2", "xslt"]
 if srcs.TIGL: libraries += ["boost_system", "boost_filesystem", "boost_date_time"]
 #if srcs.TIGL: libraries += ["boost_filesystem-mt", "boost_date_time-mt"]
@@ -73,11 +83,18 @@ setup(
     version="4.1",
     description="Modeler module.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     packages=['Modeler', 'Modeler.CPACS'],
     package_dir={"":"."},
     ext_modules=listExtensions
 )
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/Modeler/setup.scons
+++ b/Cassiopee/Modeler/setup.scons
@@ -1,5 +1,4 @@
 import KCore.Dist as Dist
-from KCore.config import *
 import os
 #==============================================================================
 # Modeler requires:
@@ -12,6 +11,9 @@ import os
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -23,14 +25,14 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ['..', '.', pythonLibDir, kcoreLibDir]
 libraries = ["kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Test if open-cascade is installed ===========================================

--- a/Cassiopee/OCC/install
+++ b/Cassiopee/OCC/install
@@ -68,7 +68,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/OCC/pyproject.toml
+++ b/Cassiopee/OCC/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/OCC/setup.py
+++ b/Cassiopee/OCC/setup.py
@@ -1,27 +1,40 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-from KCore.config import *
-import os
-
 #=============================================================================
 # OCC requires:
 # ELSAPROD variable defined in environment
 # C++ compiler
 # KCore library
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
 
-# Write setup.cfg
-import KCore.Dist as Dist
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Test if generator exists ===================================================
-(generatorVersion, generatorIncDir, generatorLibDir) = Dist.checkGenerator()
+(generatorVersion, generatorIncDir, generatorLibDir) = Dist.checkModuleCassiopee("Generator")
 
 # Test if open-cascade is already installed ==================================
 (OCCPresent, OCCIncDir, OCCLibDir) = Dist.checkOCC(additionalLibPaths,
@@ -32,8 +45,7 @@ if not OCCPresent:
     os._exit(0)
 
 # Compilation des fortrans ===================================================
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ["build/"+prod, kcoreLibDir, generatorLibDir]
@@ -44,15 +56,15 @@ if OCCPresent:
     libraryDirs += [OCCLibDir]
     includeDirs += [OCCIncDir]
 
-import srcs
+srcs = loadModuleFromPath('srcs')
 libOCC = srcs.allMods
 if OCCPresent and Dist.getSystem()[0] == 'mingw':
     libOCE = [i+".dll" for i in libOCC]
 libraries += libOCC + libOCC
 
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # setup ======================================================================
@@ -61,7 +73,7 @@ setup(
     version="4.1",
     description="OpenCascade python module.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     packages=['OCC'],
     package_dir={"":"."},
     ext_modules=[Extension('OCC.occ',
@@ -75,4 +87,11 @@ setup(
 )
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/OCC/setup.scons
+++ b/Cassiopee/OCC/setup.scons
@@ -1,6 +1,5 @@
 import os
 import KCore.Dist as Dist
-from KCore.config import *
 
 #==============================================================================
 # OCC requires:
@@ -14,6 +13,9 @@ from KCore.config import *
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -25,10 +27,10 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists ========================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Test if generator exists ====================================================
-(generatorVersion, generatorIncDir, generatorLibDir) = Dist.checkGenerator()
+(generatorVersion, generatorIncDir, generatorLibDir) = Dist.checkModuleCassiopee("Generator")
 
 # Test if open-cascade is installed ===========================================
 (OCCPresent, OCCIncDir, OCCLibDir) = Dist.checkOCC(additionalLibPaths, 
@@ -48,7 +50,7 @@ if not OCCPresent:
 libraryDirs = ['..', '.', pythonLibDir, kcoreLibDir, generatorLibDir]
 includeDirs = [OCCIncDir, generatorIncDir, pythonIncDir, numpyIncDir, kcoreIncDir]
 libraries = ["generator", "kcore"]
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Env =========================================================================

--- a/Cassiopee/OCC/setupLegacy.py
+++ b/Cassiopee/OCC/setupLegacy.py
@@ -18,18 +18,18 @@ prod = os.getenv("ELSAPROD")
 if prod is None: prod = 'xx'
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Test if generator exists ===================================================
-(generatorVersion, generatorIncDir, generatorLibDir) = Dist.checkGenerator()
+(generatorVersion, generatorIncDir, generatorLibDir) = Dist.checkModuleCassiopee("Generator")
 
 # Setting libraryDirs and libraries ==========================================
 libraryDirs = ["build/"+prod, kcoreLibDir, generatorLibDir]
 includeDirs = [kcoreIncDir, generatorIncDir]
 libraries = ["generator", "kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # setup ======================================================================

--- a/Cassiopee/Post/install
+++ b/Cassiopee/Post/install
@@ -66,7 +66,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/Post/pyproject.toml
+++ b/Cassiopee/Post/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/Post/setup.py
+++ b/Cassiopee/Post/setup.py
@@ -1,7 +1,3 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-import os
-
 #=============================================================================
 # Post requires:
 # C++ compiler
@@ -9,27 +5,43 @@ import os
 # Numpy
 # KCore
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
 
-# Write setup.cfg
-import KCore.Dist as Dist
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
-from KCore.config import *
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ["build/"+prod, kcoreLibDir]
 libraries = ["post", "kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 if Dist.ADOLC:
@@ -37,7 +49,7 @@ if Dist.ADOLC:
     if adolc:
         libraryDirs += adolcLibDir; libraries += [adolcLib]
 
-import srcs
+srcs = loadModuleFromPath('srcs')
 
 # extensions =================================================================
 listExtensions = []
@@ -57,11 +69,18 @@ setup(
     version="4.1",
     description="Post-processing of CFD solutions.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     packages=['Post'],
     package_dir={"":"."},
     ext_modules=listExtensions
 )
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/Post/setup.scons
+++ b/Cassiopee/Post/setup.scons
@@ -1,6 +1,5 @@
 import os
 import KCore.Dist as Dist
-from KCore.config import *
 #==============================================================================
 # Post requires:
 # C++ compiler
@@ -12,6 +11,12 @@ from KCore.config import *
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+Cppcompiler = Dist.getFromConfigDict("Cppcompiler", None)
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+f90compiler = Dist.getFromConfigDict("f90compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -23,14 +28,14 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ['..', '.', pythonLibDir, kcoreLibDir]
 libraries = ["kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Env =========================================================================

--- a/Cassiopee/Post/setupLegacy.py
+++ b/Cassiopee/Post/setupLegacy.py
@@ -10,26 +10,33 @@ import os, sys
 # KCore
 #=============================================================================
 
-# Write setup.cfg
 import KCore.Dist as Dist
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+f90compiler = Dist.getFromConfigDict("f90compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Compilation des fortrans ===================================================
-from KCore.config import *
-if f77compiler == "None":
+if f77compiler is None:
     print("Error: a fortran 77 compiler is required for compiling Post.")
     sys.exit()
 args = Dist.getForArgs(); opt = ''
 for c, v in enumerate(args): opt += 'FOPT'+str(c)+'='+v+' '
 os.system("make -e FC="+f77compiler+" F90=true WDIR=Post/Fortran "+opt)
 os.system("make -e FC="+f77compiler+" F90=true WDIR=Post/zipper "+opt)
-if f90compiler != "None" and os.access('Post/usurp', os.F_OK):
+if f90compiler is not None and os.access('Post/usurp', os.F_OK):
     os.system("(cd Post/usurp; make -e FC="+f77compiler+" F90="+f90compiler+" "+opt+")")
 prod = os.getenv("ELSAPROD")
 if prod is None: prod = 'xx'
@@ -37,12 +44,12 @@ if prod is None: prod = 'xx'
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ["build/"+prod, kcoreLibDir]
 libraries = ["PostF", "kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
-if f90compiler != "None" and os.access('Post/usurp', os.F_OK): libraries.append("UsurpF")
+if f90compiler is not None and os.access('Post/usurp', os.F_OK): libraries.append("UsurpF")
 
 import srcs
 
@@ -64,6 +71,7 @@ setup(
     version="4.1",
     description="Post-processing of CFD solutions.",
     author="ONERA",
+    url="https://onera.github.io/Cassiopee/",
     package_dir={"":"."},
     packages=['Post'],
     ext_modules=listExtensions

--- a/Cassiopee/RigidMotion/install
+++ b/Cassiopee/RigidMotion/install
@@ -62,7 +62,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/RigidMotion/pyproject.toml
+++ b/Cassiopee/RigidMotion/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/RigidMotion/setup.py
+++ b/Cassiopee/RigidMotion/setup.py
@@ -1,7 +1,3 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-import os
-
 #=============================================================================
 # RigidMotion requires:
 # C++ compiler
@@ -9,28 +5,44 @@ import os
 # Numpy
 # KCore
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
 
-# Write setup.cfg
-import KCore.Dist as Dist
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Compilation des fortrans ===================================================
-from KCore.config import *
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ["build/"+prod, kcoreLibDir]
 libraries = ["rigidMotion", "kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 includeDirs=[numpyIncDir, kcoreIncDir]
@@ -52,11 +64,18 @@ setup(
     version="4.1",
     description="Compute/define rigid motion.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     packages=['RigidMotion'],
     package_dir={"":"."},
     ext_modules=listExtensions
 )
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/RigidMotion/setup.scons
+++ b/Cassiopee/RigidMotion/setup.scons
@@ -1,6 +1,5 @@
 import os
 import KCore.Dist as Dist
-from KCore.config import *
 #==============================================================================
 # RigidMotion requires:
 # C++ compiler
@@ -12,6 +11,10 @@ from KCore.config import *
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -23,14 +26,14 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ['..','.', pythonLibDir, kcoreLibDir]
 libraries = ["kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Env =========================================================================

--- a/Cassiopee/RigidMotion/setupLegacy.py
+++ b/Cassiopee/RigidMotion/setupLegacy.py
@@ -13,19 +13,25 @@ import os
 # elsA/Kernel
 #=============================================================================
 
-# Write setup.cfg
 import KCore.Dist as Dist
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Compilation des fortrans ===================================================
-from KCore.config import *
-if f77compiler == "None":
+if f77compiler is None:
     print("Error: a fortran 77 compiler is required for compiling RigidMotion.")
 args = Dist.getForArgs(); opt = ''
 for c, v in enumerate(args): opt += 'FOPT'+str(c)+'='+v+' '
@@ -36,9 +42,9 @@ if prod is None: prod = 'xx'
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ["build/"+prod,kcoreLibDir]
 libraries = ["RigidMotionF","kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Extensions =================================================================
@@ -48,6 +54,7 @@ setup(
     version="4.1",
     description="Rigid motion module.",
     author="ONERA",
+    url="https://onera.github.io/Cassiopee/",
     package_dir={"":"."},
     packages=['RigidMotion'],
     ext_modules=[Extension('RigidMotion.rigidMotion',

--- a/Cassiopee/Roms/install
+++ b/Cassiopee/Roms/install
@@ -62,7 +62,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/Roms/pyproject.toml
+++ b/Cassiopee/Roms/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/Roms/setup.py
+++ b/Cassiopee/Roms/setup.py
@@ -1,37 +1,48 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-import os
-
 #=============================================================================
 # Roms requires:
 # C++ compiler
 # Numpy
 # KCore, Compressor
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
+
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Write setup.cfg file
-import KCore.Dist as Dist
 Dist.writeSetupCfg()
-
-from KCore.config import *
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 
 # Setting libraryDirs, include dirs and libraries =============================
 libraryDirs = ["build/"+prod, kcoreLibDir]
 includeDirs = [numpyIncDir, kcoreIncDir]
 libraries = ["kcore", "roms"]
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
-import srcs
+srcs = loadModuleFromPath('srcs')
 
 # Extensions ==================================================================
 listExtensions = []
@@ -51,11 +62,18 @@ setup(
     version="4.1",
     description="Roms module.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     packages=['Roms', 'Roms.DB', 'Roms.LA', 'Roms.Models', 'Roms.Optim'],
     package_dir={"":"."},
     ext_modules=listExtensions
 )
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/Roms/setup.scons
+++ b/Cassiopee/Roms/setup.scons
@@ -1,5 +1,4 @@
 import KCore.Dist as Dist
-from KCore.config import *
 import os
 #==============================================================================
 # Roms requires:
@@ -11,6 +10,9 @@ import os
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -22,14 +24,14 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ['..', '.', pythonLibDir, kcoreLibDir]
 libraries = ["kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Env =========================================================================

--- a/Cassiopee/Template/install
+++ b/Cassiopee/Template/install
@@ -62,7 +62,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/Template/pyproject.toml
+++ b/Cassiopee/Template/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/Template/setup.py
+++ b/Cassiopee/Template/setup.py
@@ -1,7 +1,3 @@
-import os, sys
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-
 #=============================================================================
 # Template requires:
 # ELSAPROD variable defined in environment
@@ -11,28 +7,44 @@ from setuptools import setup, Extension
 # KCore
 # Scons
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
+
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Write setup.cfg file
-import KCore.Dist as Dist
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Compilation des fortrans ===================================================
-from KCore.config import *
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ["build/"+prod, kcoreLibDir]
 libraries = ["template", "kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # setup =======================================================================
@@ -58,4 +70,11 @@ setup(
     ext_modules=listExtensions)
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/Template/setup.scons
+++ b/Cassiopee/Template/setup.scons
@@ -1,6 +1,5 @@
 import os
 import KCore.Dist as Dist
-from KCore.config import *
 
 #==============================================================================
 # Template requires:
@@ -13,6 +12,10 @@ from KCore.config import *
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -24,14 +27,14 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ['..', '.', pythonLibDir, kcoreLibDir]
 libraries = ["kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Env =========================================================================

--- a/Cassiopee/Template/setupLegacy.py
+++ b/Cassiopee/Template/setupLegacy.py
@@ -11,20 +11,26 @@ import os
 # KCore
 #=============================================================================
 
-# Write setup.cfg file
 import KCore.Dist as Dist
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+# f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
-from KCore.config import *
 
 # Compilation des fortrans ====================================================
-#if f77compiler == "None":
+#if f77compiler is None:
 #    print("Error: a fortran 77 compiler is required for compiling Fast.")
 #args = Dist.getForArgs(); opt = ''
 #for c in range(len(args)):
@@ -37,9 +43,9 @@ if prod is None: prod = 'xx'
 libraryDirs = ["build/"+prod, kcoreLibDir]
 includeDirs = [numpyIncDir, kcoreIncDir]
 libraries = ["kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Extensions ==================================================================

--- a/Cassiopee/Transform/install
+++ b/Cassiopee/Transform/install
@@ -64,7 +64,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/Transform/pyproject.toml
+++ b/Cassiopee/Transform/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/Transform/setup.py
+++ b/Cassiopee/Transform/setup.py
@@ -1,7 +1,3 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-import os
-
 #=============================================================================
 # Transform requires:
 # ELSAPROD variable defined in environment
@@ -10,28 +6,44 @@ import os
 # Numpy
 # KCore library
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
+
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Write setup.cfg file
-import KCore.Dist as Dist
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLib) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLib) = Dist.checkModuleCassiopee("KCore")
 
-from KCore.config import *
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 
 # Setting libraryDirs, include dirs and libraries =============================
 libraryDirs = ["build/"+prod, kcoreLib]
 includeDirs = [numpyIncDir, kcoreIncDir]
 libraries = ["transform", "kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Extensions ==================================================================
@@ -52,11 +64,18 @@ setup(
     version="4.1",
     description="Transformations of arrays/pyTrees for *Cassiopee* modules.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     package_dir={"":"."},
     packages=['Transform'],
     ext_modules=listExtensions
 )
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/Transform/setup.scons
+++ b/Cassiopee/Transform/setup.scons
@@ -1,6 +1,5 @@
 import os
 import KCore.Dist as Dist
-from KCore.config import *
 #==============================================================================
 # Transform requires:
 # ELSAPROD variable defined in environment
@@ -13,6 +12,10 @@ from KCore.config import *
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -24,14 +27,14 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ['..', '.', pythonLibDir, kcoreLibDir]
 libraries = ["kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Env =========================================================================

--- a/Cassiopee/Transform/setupLegacy.py
+++ b/Cassiopee/Transform/setupLegacy.py
@@ -11,19 +11,25 @@ import os
 # KCore
 #=============================================================================
 
-# Write setup.cfg
 import KCore.Dist as Dist
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+f77compiler = Dist.getFromConfigDict("f77compiler", "gfortran")
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+
+# Write setup.cfg file
 Dist.writeSetupCfg()
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLib) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLib) = Dist.checkModuleCassiopee("KCore")
 
 # Compilation des fortrans ===================================================
-from KCore.config import *
-if f77compiler == "None":
+if f77compiler is None:
     print("Error: a fortran 77 compiler is required for compiling Transform.")
 args = Dist.getForArgs(); opt = ''
 for c, v in enumerate(args): opt += 'FOPT'+str(c)+'='+v+' '
@@ -34,9 +40,9 @@ if prod is None: prod = 'xx'
 # Setting libraryDirs and libraries ===========================================
 libraryDirs = ["build/"+prod, kcoreLib]
 libraries = ["TransformF", "kcore"]
-(ok, libs, paths) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkFortranLibs()
 libraryDirs += paths; libraries += libs
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # setup =======================================================================
@@ -46,6 +52,7 @@ setup(
     version="4.1",
     description="Transformations of arrays/pyTrees for *Cassiopee* modules.",
     author="ONERA",
+    url="https://onera.github.io/Cassiopee/",
     package_dir={"":"."},
     packages=['Transform'],
     ext_modules=[Extension('Transform.transform',

--- a/Cassiopee/XCore/install
+++ b/Cassiopee/XCore/install
@@ -70,7 +70,7 @@ if [ $PRODMODE -ge 0 ]; then
         python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 2 ]; then # pip+wheel
-        TMPDIR=$INSTALLPATH python -m pip install --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
+        TMPDIR=$INSTALLPATH python -m pip install --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" --no-clean .
         [ $? != 0 ] && exit 1;
     elif [ $PRODMODE -eq 3 ]; then # pip no isolation
         python -m pip install --disable-pip-version-check --no-deps --only-binary=:all: --no-build-isolation --ignore-installed --upgrade --prefix="$INSTALLPATH" .

--- a/Cassiopee/XCore/pyproject.toml
+++ b/Cassiopee/XCore/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=45",
+  "wheel",
+  "numpy>=1.23.3",
+  "scons>=4.4.0"
+]
+build-backend = "setuptools.build_meta"

--- a/Cassiopee/XCore/setup.py
+++ b/Cassiopee/XCore/setup.py
@@ -1,7 +1,3 @@
-#from distutils.core import setup, Extension
-from setuptools import setup, Extension
-import os
-
 #=============================================================================
 # XCore requires:
 # ELSAPROD variable defined in environment
@@ -9,12 +5,28 @@ import os
 # Numpy, MPI
 # KCore library
 #=============================================================================
+import os
+from setuptools import setup, Extension
+from importlib.util import spec_from_file_location, module_from_spec
+
+def loadModuleFromPath(modname):
+    # Load a Python file by filesystem path (PEP-517 isolated build requirement)
+    helper = os.path.join(os.path.dirname(__file__), modname + ".py")
+    spec = spec_from_file_location(modname, helper)
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+# Compiler settings must be set in installBase.py / installBaseUser.py
+Dist = loadModuleFromPath('../KCore/Dist')
+installBase = loadModuleFromPath('../KCore/installBase')
+Dist.setConfigDict(installBase.installDict)
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Write setup.cfg file
-import KCore.Dist as Dist
 Dist.writeSetupCfg()
-
-from KCore.config import *
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -26,10 +38,10 @@ from KCore.config import *
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Test if fortran exists
-(ok, fortranLibs, fortranLibDir) = Dist.checkFortranLibs([], additionalLibPaths)
+(ok, fortranLibs, fortranLibDir) = Dist.checkFortranLibs()
 
 # Test if libmpi exists ======================================================
 (mpi, mpiIncDir, mpiLibDir, mpiLibs) = Dist.checkMpi(additionalLibPaths,
@@ -37,14 +49,13 @@ from KCore.config import *
 (mpi4py, mpi4pyIncDir, mpi4pyLibDir) = Dist.checkMpi4py(additionalLibPaths,
                                                         additionalIncludePaths)
 
-prod = os.getenv("ELSAPROD")
-if prod is None: prod = 'xx'
+prod = os.getenv("ELSAPROD") or "xx"
 
 # Setting libraryDirs, include dirs and libraries =============================
 libraryDirs = ["build/"+prod, kcoreLibDir]+fortranLibDir
 includeDirs = [numpyIncDir, kcoreIncDir]
 
-import srcs
+srcs = loadModuleFromPath('srcs')
 libraries = ["xcore"]
 if srcs.ZOLTAN and mpi: libraries += ["zoltan"]
 if srcs.SCOTCH: libraries += ["scotch1", "scotch2"]
@@ -71,7 +82,7 @@ if mpi4py:
     includeDirs.append(mpi4pyIncDir)
 if mpi: libraries += mpiLibs
 
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Extensions ==================================================================
@@ -91,10 +102,10 @@ cython = Dist.checkCython(additionalLibPaths, additionalIncludePaths)
 
 if cython and mpi and mpi4py:
     if srcs.PARADIGMA == 2:
-        import srcs_paradigma23 as srcs_paradigma
+        srcs_paradigma = loadModuleFromPath('srcs_paradigma23')
         paradigmaDir = "XCore/paradgima"
     elif srcs.PARADIGMA == 1:
-        import srcs_paradigma
+        srcs_paradigma = loadModuleFromPath('srcs_paradigma')
         paradigmaDir = "XCore/paradigma23"
     if srcs.PARADIGMA != 0:
         PPATH = srcs_paradigma.PPATH
@@ -126,11 +137,18 @@ setup(
     version="4.1",
     description="XCore for *Cassiopee* modules.",
     author="ONERA",
-    url="https://cassiopee.onera.fr",
+    url="https://onera.github.io/Cassiopee/",
     packages=['XCore'],
     package_dir={"":"."},
     ext_modules=listExtensions+cythonize(listExtensionsPyx,include_path=[paradigmaDir])
 )
 
 # Check PYTHONPATH ===========================================================
-Dist.checkPythonPath(); Dist.checkLdLibraryPath()
+installPath = loadModuleFromPath('../KCore/installPath')
+installPathDict = {
+    "installPath": installPath.installPath,
+    "libPath": installPath.libPath,
+    "includePath": installPath.includePath
+}
+Dist.checkPythonPath(installPathDict)
+Dist.checkLdLibraryPath(installPathDict)

--- a/Cassiopee/XCore/setup.scons
+++ b/Cassiopee/XCore/setup.scons
@@ -1,6 +1,5 @@
 import os
 import KCore.Dist as Dist
-from KCore.config import *
 #==============================================================================
 # XCore requires:
 # C++ compiler
@@ -11,6 +10,10 @@ from KCore.config import *
 # Get prefix from command line
 prefix = ARGUMENTS.get('prefix', '')
 installPath = Dist.getInstallPath(prefix)
+Cppcompiler = Dist.getFromConfigDict("Cppcompiler", None)
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
 
 # Get compilers from Distutils ================================================
 (cc, cxx, opt, basecflags, ccshared, ldshared, so_ext) = Dist.getDistUtilsCompilers()
@@ -22,7 +25,7 @@ installPath = Dist.getInstallPath(prefix)
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Test if libmpi exists ======================================================
 (mpi, mpiIncDir, mpiLibDir, mpiLibs) = Dist.checkMpi(additionalLibPaths,
@@ -52,7 +55,7 @@ if mpi4py:
     includeDirs.append(mpiIncDir)
 if mpi: libraries += mpiLibs
 
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Specific options for scotch

--- a/Cassiopee/XCore/setupLegacy.py
+++ b/Cassiopee/XCore/setupLegacy.py
@@ -1,4 +1,3 @@
-#from distutils.core import setup, Extension
 from setuptools import setup, Extension
 import os
 
@@ -9,18 +8,20 @@ import os
 # Numpy, MPI
 # KCore library
 #=============================================================================
+# Compiler settings must be set in installBase.py / installBaseUser.py
+import KCore.Dist as Dist
+additionalIncludePaths = Dist.getFromConfigDict("additionalIncludePaths", [])
+additionalLibPaths = Dist.getFromConfigDict("additionalLibPaths", [])
+additionalLibs = Dist.getFromConfigDict("additionalLibs", [])
 
 # Write setup.cfg file
-import KCore.Dist as Dist
 Dist.writeSetupCfg()
-
-from KCore.config import *
 
 # Test if numpy exists =======================================================
 (numpyVersion, numpyIncDir, numpyLibDir) = Dist.checkNumpy()
 
 # Test if kcore exists =======================================================
-(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkKCore()
+(kcoreVersion, kcoreIncDir, kcoreLibDir) = Dist.checkModuleCassiopee("KCore")
 
 # Test if libmpi exists ======================================================
 (mpi, mpiIncDir, mpiLibDir, mpiLibs) = Dist.checkMpi(additionalLibPaths,
@@ -45,7 +46,7 @@ if mpi4py:
     includeDirs.append(mpi4pyIncDir)
 if mpi: libraries += mpiLibs
 
-(ok, libs, paths) = Dist.checkCppLibs([], additionalLibPaths)
+(ok, libs, paths) = Dist.checkCppLibs()
 libraryDirs += paths; libraries += libs
 
 # Extensions ==================================================================
@@ -67,6 +68,7 @@ setup(
     version="4.1",
     description="Parallel core for *Cassiopee* modules.",
     author="ONERA",
+    url="https://onera.github.io/Cassiopee/",
     package_dir={"":"."},
     packages=['XCore'],
     ext_modules=listExtensions

--- a/Dockerfile
+++ b/Dockerfile
@@ -159,6 +159,7 @@ SHELL ["/bin/bash", "-c"]
 RUN . /etc/cassiopee-machine.env && echo "Using MACHINE=${MACHINE}" \
     && . $CASSIOPEE/Cassiopee/Envs/sh_Cassiopee_r8 \
     && export PRODMODE=3 \
+    && export OMP_NUM_THREADS=2 \
     && cd $CASSIOPEE/Cassiopee \
     && ./install
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: cassiopee
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.8
+  - numpy>=1.23.3
+  - mpi4py>=3.1.3
+  - scons>=4.4.0
+  - matplotlib>=3.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "setuptools>=45",
     "setuptools_scm[toml]>=6.2",
+    "numpy>=1.23.3",
     "scons>=4.4.0"
 ]
 build-backend = "setuptools.build_meta"
@@ -11,7 +12,7 @@ version_scheme = "post-release"
 local_scheme = "node-and-date"
 
 [project]
-name = "Cassiopee"
+name = "cassiopee"
 version = "4.1"
 authors = [
     {name="ONERA", email="christophe.benoit@onera.fr"},
@@ -52,7 +53,9 @@ include = [
     "Modeler",
     "Intersector",
     "Apps",
-    "CPlot" 
+    "Roms",
+    "CPlot",
+    "OCC"
 ]
 
 [tool.setuptools.data-files]


### PR DESCRIPTION
No regressions (ld, juno)
Install scripts of Fast and other modules must be edited.

- PyPI: Modeller and OCC not installed, these libraries cannot be found on CentOS

```
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: cannot find -lTKQADraw
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: cannot find -lTKRWMesh
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: cannot find -lTKStdL
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: cannot find -lTKStd
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: cannot find -lTKVCAF
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: cannot find -lTKQADraw
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: cannot find -lTKRWMesh
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: cannot find -lTKStdL
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: cannot find -lTKStd
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: cannot find -lTKVCAF
```

- Issues to investigate in conda but that aren't blocking:

```
CPlot : displayOSMesa_m1.py : 0m1.5s : 0m1.58s : 16/07/25 10h27 : 0% : : FAILED
CPlot : displayOSMesa_m2.py : 0m3.61s : 0m3.85s : 16/07/25 10h27 : 0% : : FAILED
Compressor : pack_t1.py : 0m0.31s : 0m0.25s : 16/07/25 10h27 : 0% : : FAILED
Connector : connectMatchPT_m1.py : 0m2.25s : 0m2.17s : 16/07/25 10h29 : 0% : : FAILED
Connector : connectMatchPeriodicPT_m1.py : 0m2.22s : 0m1.12s : 16/07/25 10h29 : 0% : : FAILED
Connector : connectMatchPeriodicPT_m2.py : 0m2.25s : 0m1.06s : 16/07/25 10h29 : 0% : : FAILED
Connector : optimizeOverlapPT_m1.py : 0m2.23s : 0m0.68s : 16/07/25 10h30 : 0% : : FAILED
Connector : prepAMRFull_m1.py : 0m2.31s : 0m9.61s : 30/01/26 10h26 : 0% : : FAILED
Connector : prepAMRFull_t1.py : Unknown : 0m9.03s : 30/01/26 10h26 : 0% : : FAILED
Connector : prepAMRFull_t2.py : Unknown : 0m9.35s : 30/01/26 10h27 : 0% : : FAILED
Connector : setInterpData2PT_m1.py : 0m2.25s : 0m2.19s : 16/07/25 10h30 : 0% : : FAILED
Converter : addBXZonesPT_m1.py : 0m2.24s : 0m2.2s : 16/07/25 10h30 : 0% : : FAILED
Converter : addMXZonesPT_m1.py : 0m2.22s : 0m0.66s : 16/07/25 10h31 : 0% : : FAILED
Converter : addXZonesPT_m1.py : 0m2.23s : 0m0.65s : 16/07/25 10h31 : 0% : : FAILED
Converter : allgatherTreePT_m1.py : 0m2.21s : 0m0.64s : 16/07/25 10h31 : 0% : : FAILED
Converter : center2NodePT_m1.py : 0m2.29s : 0m0.74s : 16/07/25 10h31 : 0% : : FAILED
Converter : computeGraphPT_m1.py : 0m2.25s : 0m0.66s : 16/07/25 10h31 : 0% : : FAILED
Converter : convert2PartialTreePT_m1.py : 0m2.22s : 0m0.64s : 16/07/25 10h31 : 0% : : FAILED
Converter : convertArrays2File_t1.py : 0m0.34s : 0m0.3s : 16/07/25 10h31 : 0% : : FAILED
Converter : createBBoxTreePT_m1.py : 0m2.24s : 0m2.13s : 16/07/25 10h31 : 0% : : FAILED
Converter : loadAndDistributePT_m1.py : 0m2.25s : 0m0.67s : 16/07/25 10h32 : 0% : : FAILED
Converter : loadAndSplitPT_m1.py : 0m2.21s : 0m0.8s : 16/07/25 10h32 : 0% : : FAILED
Converter : loadFromProcPT_m1.py : 0m2.22s : 0m0.65s : 16/07/25 10h32 : 0% : : FAILED
Converter : readZonesPT_m1.py : 0m2.23s : 0m2.14s : 16/07/25 10h32 : 0% : : FAILED
Converter : rmXZonesPT_m1.py : 0m2.21s : 0m0.64s : 16/07/25 10h32 : 0% : : FAILED
Converter : writePyTreeFromFilterPT_m1.py : 0m2.21s : 0m0.66s : 16/07/25 10h32 : 0% : : FAILED
Distributor2 : distributePT_m1.py : 0m2.31s : 0m2.25s : 16/07/25 10h33 : 0% : : FAILED
Distributor2 : distributePT_m2.py : 0m2.32s : 0m0.75s : 16/07/25 10h33 : 0% : : FAILED
Distributor2 : distributePT_m3.py : 0m2.27s : 0m0.74s : 16/07/25 10h33 : 0% : : FAILED
Distributor2 : redispatchPT_m1.py : 0m2.31s : 0m0.71s : 16/07/25 10h33 : 0% : : FAILED
Generator : adaptMeshPT_m1.py : 0m2.26s : 0m0.75s : 16/07/25 10h33 : 0% : : FAILED
Generator : checkCartesian_m1.py : 0m2.27s : 0m0.71s : 16/07/25 10h34 : 0% : : FAILED
Generator : checkMeshPT_t1.py : 0m0.35s : 0m0.27s : 16/07/25 10h34 : 0% : : FAILED
Generator : checkMeshPT_t2.py : 0m0.41s : 0m0.36s : 16/07/25 10h34 : 0% : : FAILED
Generator : generateAMRMeshMultiRes3DPT_t1.py : 0m6.56s : 0m6.75s : 03/12/25 11h23 : 0% : : FAILED
Generator : generateAMRMeshPT_m1.py : 0m2.42s : 0m3.22s : 05/12/25 08h15 : 0% : : FAILED
Generator : generateAMRMeshPT_t1.py : 0m2.67s : 0m3.53s : 09/01/26 18h53 : 0% : : FAILED
OCC : convertCAD2Arrays_t1.py : 0m5.66s : 0m4.24s : 16/07/25 10h38 : 0% : : FAILED
Post : computeGradLSQPT_m1.py : 0m2.27s : 0m2.15s : 16/07/25 10h38 : 0% : : FAILED
Post : exteriorVerticesPT_t1.py : 0m1.41s : 0m0.25s : 30/01/26 10h11 : 0% : : FAILED
Post : extractMeshPT_m1.py : 0m2.32s : 0m1.02s : 16/07/25 10h39 : 0% : : FAILED
Post : probePT_m1.py : 0m2.32s : 0m2.3s : 09/01/26 18h42 : 0% : : FAILED
Post : probePT_m2.py : 0m2.24s : 0m0.84s : 16/07/25 10h39 : 0% : : FAILED
Post : probePT_m3.py : 0m2.29s : 0m0.94s : 16/07/25 10h39 : 0% : : FAILED
Post : probePT_m4.py : 0m2.23s : 0m0.69s : 16/07/25 10h39 : 0% : : FAILED
Post : probePT_m5.py : 0m2.27s : 0m0.9s : 30/01/26 10h27 : 0% : : FAILED
XCore : adaptMeshPT_m1.py : 0m2.28s : 0m0.86s : 16/07/25 10h43 : 0% : : FAILED
XCore : chunk2partPT_m2.py : 0m2.27s : 0m2.15s : 16/07/25 10h42 : 0% : : FAILED
XCore : xmpi_m1.py : 0m2.23s : 0m0.61s : 16/07/25 10h42 : 0% : : FAILED
```