### PR TITLE
Apps/Post/Generator: AMR changes

### DIFF
--- a/Cassiopee/Apps/Apps/Coda/Post.py
+++ b/Cassiopee/Apps/Apps/Coda/Post.py
@@ -191,6 +191,116 @@ def computeSurfValues(fileNameResultIn, tb, CODAInputs, dim=3, fileNameIBMPnts=N
     else:
         return zw, coefs
 
+
+def computeSurfValuesFSUI(fileNameResultIn, tb, fileNameRelations, dim=3, fileNameIBMPnts=None, fileNameResultOut=None, localDir='./', check=False, verbose=False):
+    """ Surface quantity post-processing for CODA IBM computation using FSUI-CODA.
+    Usage: computeSurfValues(fileNameResultIn, tb, fileNameRelations, dim, fileNameIBMPnts, fileNameResultOut, localDir, check, verbose)"""
+    import json
+
+    ## fileNameResultIn  = (e.g) solution.h5    (the h5 from the fsui-coda run)
+    ## fileNameRelations = (e.g) relations.json (the json file created after fsui-coda create)
+    if isinstance(tb, str): tb = C.convertFile2PyTree(tb)
+    else: tb = Internal.copyTree(tb)
+
+    if not isinstance(fileNameResultIn,str):
+        ValueError('fileNameResultIn MUST be the name of the file. Importing of this file is done in this file through "fsmesh.ImportMeshHDF5".')
+    if not isinstance(fileNameRelations,str):
+        ValueError('fileNameRelations MUST be the name of the file. Importing of this file is done in this file through "open(RelationsFileName)".')
+
+    ## READ relations.json file
+    with open(fileNameRelations, 'r') as f: data = json.load(f)
+
+    discSelectionParaDict = data['CFD']['GeomIBM']['DiscretizationSelection']
+    discParaDictTmp       = data['CFD']['GeomIBM']['DiscretizationPara']
+    domain                = data['CFD']['GeomIBM']['Domain']
+    # Convert domain to boundary treatments
+    IBMMarkers = []
+    bndy_treat  = []
+    for boundary_name, boundary_data in domain.items():
+        treatment = {
+            "treatment type": boundary_data["FlowSolverBCType"],
+            "boundary markers": boundary_data["CADGroupID"]
+        }
+        if 'Immersed' in boundary_data["FlowSolverBCType"]:
+            IBMMarkers.append(boundary_data["CADGroupID"][0])
+        # Check if there's a wall model in the CFD section
+        if "CFD" in boundary_data and "wall model" in boundary_data["CFD"]:
+            treatment["wall model"] = boundary_data["CFD"]["wall model"]
+        bndy_treat.append(treatment)
+
+    discParaDict = {
+      **discParaDictTmp,
+      "boundary treatments": bndy_treat
+      }
+
+    alpha    = discParaDict["reference state"]["flow direction specification"]["angle of attack"]
+    beta     = discParaDict["reference state"]["flow direction specification"]["angle of sideslip"]
+    Mach     = discParaDict["reference state"]["flow speed specification"]["Mach"]
+    Reynolds = discParaDict["reference state"]["viscosity specification"]["Reynolds"]
+    Lref     = discParaDict["reference state"]["viscosity specification"]["Reynolds_Length"]
+    Aref     = discParaDict["boundary integral quantities"]["Coef_Area"]
+    ## Post Values
+    pressureRef    = 1
+    densityRef     = 1
+    gammaRef       = 1.4
+    aRef           = (gammaRef*pressureRef/densityRef)**0.5
+    velooRef       = Mach*aRef
+
+    alpha_rad = numpy.deg2rad(alpha)
+    beta_rad  = numpy.deg2rad(beta)
+    velXRef = velooRef*numpy.cos(alpha_rad)*numpy.cos(beta_rad)
+    velYRef = velooRef*numpy.cos(alpha_rad)*numpy.sin(beta_rad)
+    velZRef = velooRef*numpy.sin(alpha_rad)
+
+    dictReferenceQuantities = {
+      "Mach_ref" : Mach,
+      "Reynolds_ref" : Reynolds,
+      "pressure_ref" : pressureRef,
+      "density_ref" : densityRef,
+      "velX_ref" : velXRef,
+      "velY_ref" : velYRef,
+      "velZ_ref" : velZRef,
+      "alpha" : alpha,
+      "beta" : beta,
+      "Sref": Aref,
+    }
+
+    clac   = FSClac()
+    fsmesh = FSMesh(clac)
+    fsmesh.ImportMeshHDF5(Filename=fileNameResultIn) or FSError.PrintAndExit()
+
+    # Reconstruction of the solution at the donor points (in parallel).
+    donorPointsNumpy, wallPointsNumpy, augStateNumpy = interpolationDonorPoints(fsmesh, clac, discParaDict, discSelectionParaDict,
+                                                                                IBMMarkers, localDir=localDir, check=check)
+
+    # Serial part of the post-processing.
+    zw = None
+    if Cmpi.master:
+        pytree = P_AMR.createPyTreeForIBMWallFieldsExtraction(numpy.concatenate(donorPointsNumpy),
+                                                              numpy.concatenate(wallPointsNumpy),
+                                                              numpy.concatenate(augStateNumpy),
+                                                              discSelectionParaDict)
+        if fileNameIBMPnts is not None: C.convertPyTree2File(pytree, fileNameIBMPnts)
+        zw = P_AMR.extractIBMWallFields(pytree, tb, discSelectionParaDict)
+
+    zw       = Cmpi.bcast(zw, root=0)
+    zw,coefs = P_AMR.computeBoundaryQuantities(zw, dictReferenceQuantities, dim=dim, verbose=verbose) #ok
+
+    if Cmpi.master:
+        print("\nIntegrated coefficients:")
+        print("CD=      %g"%coefs[0])
+        print("CDfric=  %g"%coefs[2])
+        print("CDpres=  %g"%coefs[3])
+        print("CL=      %g"%coefs[1])
+        print("CLfric=  %g"%coefs[4])
+        print("CLpres=  %g"%coefs[5])
+
+    if fileNameResultOut is not None:
+        if Cmpi.master: C.convertPyTree2File(zw, fileNameResultOut)
+        return None
+    else:
+        return zw, coefs
+
 ##========================================================================
 ##========================================================================
 

--- a/Cassiopee/Apps/Apps/Coda/Post.py
+++ b/Cassiopee/Apps/Apps/Coda/Post.py
@@ -229,9 +229,9 @@ def computeSurfValuesFSUI(fileNameResultIn, tb, fileNameRelations, dim=3, fileNa
         bndy_treat.append(treatment)
 
     discParaDict = {
-      **discParaDictTmp,
-      "boundary treatments": bndy_treat
-      }
+        **discParaDictTmp,
+        "boundary treatments": bndy_treat
+    }
 
     alpha    = discParaDict["reference state"]["flow direction specification"]["angle of attack"]
     beta     = discParaDict["reference state"]["flow direction specification"]["angle of sideslip"]
@@ -253,16 +253,16 @@ def computeSurfValuesFSUI(fileNameResultIn, tb, fileNameRelations, dim=3, fileNa
     velZRef = velooRef*numpy.sin(alpha_rad)
 
     dictReferenceQuantities = {
-      "Mach_ref" : Mach,
-      "Reynolds_ref" : Reynolds,
-      "pressure_ref" : pressureRef,
-      "density_ref" : densityRef,
-      "velX_ref" : velXRef,
-      "velY_ref" : velYRef,
-      "velZ_ref" : velZRef,
-      "alpha" : alpha,
-      "beta" : beta,
-      "Sref": Aref,
+        "Mach_ref" : Mach,
+        "Reynolds_ref" : Reynolds,
+        "pressure_ref" : pressureRef,
+        "density_ref" : densityRef,
+        "velX_ref" : velXRef,
+        "velY_ref" : velYRef,
+        "velZ_ref" : velZRef,
+        "alpha" : alpha,
+        "beta" : beta,
+        "Sref": Aref,
     }
 
     clac   = FSClac()

--- a/Cassiopee/Apps/Apps/Coda/Post_IBM_CODA.py
+++ b/Cassiopee/Apps/Apps/Coda/Post_IBM_CODA.py
@@ -236,7 +236,7 @@ def extractIBMWallFields(pytree,tb,discSelectionParaDict,tempViscFlag=False):
     #This is a workaround for the function P_IBM.extractIBMWallFields, which projects the variable "Temperature" and not the "ViscosityMolecular". -> We put then the viscosity into a node called "Temperature".
     if tempViscFlag:
         Internal.getNodeFromName(info,"Temperature")[1] = Internal.getNodeFromName(info,"ViscosityMolecular")[1]
-    zw = P_IBM.extractIBMWallFields(z, tb=tb, famZones=[])#, front=1)
+    zw = P_IBM.extractIBMWallFields(z, tb=tb, famZones=[], isRevertToOld=True, isPreProjectOrtho=True)#, front=1)
     if discSelectionParaDict["PDE"]=="Euler":
         C._initVars(zw,"utau",0)
         C._initVars(zw,"yplus",0)
@@ -497,6 +497,7 @@ def intersectObstacleMesh(t, surf_detail,list_bcs):
         zbc = T.join(zbc)
         zbcs.append(zbc)
         if bctype.startswith("BCWall"):
+            nobc = i
             wall_clean = zbc
 
     #4: intersect surfaces

--- a/Cassiopee/Generator/Generator/AMR.py
+++ b/Cassiopee/Generator/Generator/AMR.py
@@ -204,15 +204,13 @@ def generateListOfOffsets__(tb, snears, offsetValues=[], dim=3, opt=False, numTb
         hj_core = (ymax_core-ymin_core)/(nj_core-1)
         hk_core = (zmax_core-zmin_core)/(nk_core-1)
         h_core = min(hi_core, hj_core)
-        if dim == 3:
-            h_core = min(h_core, hk_core)
-            h_core = min(h_core, 8.*minSnear)
+        if dim == 3: h_core = min(h_core, hk_core)
         if dim == 2:
             zmin = 0; zmax = 0
             zmin_core = 0.; zmax_core = 0.
             hk_core = 0.
-            # Pull request note: h_core may cause regressions in the mesh generation
-            h_core = min(h_core, 16.*minSnear)
+        # Pull request note: h_core may cause regressions in the mesh generation
+        h_core = min(h_core, 4.*minSnear)
 
         # Do not extend the CartCore beyond the symmetry plane (symClose)
         if dir_sym > 0 and tbLocal[0] in listShiftBase:

--- a/Cassiopee/Post/Post/AMR.py
+++ b/Cassiopee/Post/Post/AMR.py
@@ -76,7 +76,7 @@ def extractIBMWallFields(pytree, tb, discSelectionParaDict, ibctype=3):
     info[2].append(FS[2][1:])
     info[2] = info[2][0]
 
-    zw = P_IBM.extractIBMWallFields(z, tb=tb, famZones=[])
+    zw = P_IBM.extractIBMWallFields(z, tb=tb, famZones=[], isRevertToOld=True, isPreProjectOrtho=True)
 
     return zw
 


### PR DESCRIPTION
- Apps: Post processing  - improved approach & considered FSUI approach also.
- Post: Post processing - improved approach
- Generator: Mesh generation 
    - more refined center mesh in the CartRX for the generation of offsets
    - needed for CRM

For Post & Apps: needed to revert to the old projection approach (mainly extrapolation) as it created regions of non-physical values for the CRM & Helicopter case. This needs to be looked into. Given that it is a recurring issue (also present in FastIBM) I am setting the old approach as the default for now & fixing it in the future.