### PR TITLE
Converter: add relative tol to C.identify nodes/faces/elements

### DIFF
--- a/Cassiopee/Converter/Converter/Converter.py
+++ b/Cassiopee/Converter/Converter/Converter.py
@@ -1659,40 +1659,40 @@ def freeHook(hook):
 #==============================================================================
 # Fonctions d'identification geometrique
 #==============================================================================
-def identifyNodes(hook, a, tol=1.e-11):
+def identifyNodes(hook, a, tol=1.e-11, rtol=1.e-14):
     """Identify nodes of a in KDT. return identified indices.
     Usage: identifyNodes(hook, a)"""
     if isinstance(a[0], list):
         b = []
         for i in a:
-            b.append(converter.identifyNodes(hook, i, tol))
+            b.append(converter.identifyNodes(hook, i, tol, rtol))
         return b
     else:
-        return converter.identifyNodes(hook, a, tol)
+        return converter.identifyNodes(hook, a, tol, rtol)
 
-def identifyFaces(hook, a, tol=1.e-11):
+def identifyFaces(hook, a, tol=1.e-11, rtol=1.e-12):
     """Identify face centers of a in KDT. return identified indices.
     Usage: identifyFaces(hook, a)"""
     if isinstance(a[0], list):
         b = []
         for i in a:
-            b.append(converter.identifyFaces(hook, convertArray2NGon(i), tol))
+            b.append(converter.identifyFaces(hook, convertArray2NGon(i), tol, rtol))
         return b
     else:
-        return converter.identifyFaces(hook, convertArray2NGon(a), tol)
+        return converter.identifyFaces(hook, convertArray2NGon(a), tol, rtol)
 
-def identifyElements(hook, a, tol=1.e-11):
+def identifyElements(hook, a, tol=1.e-11, rtol=1.e-12):
     """Identify element centers of a in KDT. return identified indices.
     Usage: identifyElement(hook, a)"""
     if isinstance(a[0], list):
         b = []
         for i in a:
             # if len(i) == 5: i = convertArray2Hexa(i)
-            b.append(converter.identifyElements(hook, i, tol))
+            b.append(converter.identifyElements(hook, i, tol, rtol))
         return b
     else:
         # if len(a) == 5: a = convertArray2Hexa(a)
-        return converter.identifyElements(hook, a, tol)
+        return converter.identifyElements(hook, a, tol, rtol)
 
 #=============================================================================
 def identifySolutions(coordsRcv, solDnr, hookDnr, vars=[], tol=1.e6):

--- a/Cassiopee/Converter/Converter/PyTree.py
+++ b/Cassiopee/Converter/Converter/PyTree.py
@@ -7207,28 +7207,28 @@ def freeHook(hook):
 #==============================================================================
 
 # -- identifyNodes: identifie les noeuds de a dans hook
-def identifyNodes(hook, a, tol=1.e-11):
+def identifyNodes(hook, a, tol=1.e-11, rtol=1.e-14):
     """Find in a hook nearest points of nodes of a. return identified node indices.
     Usage: identifyNodes(hook, a)"""
     fields = getFields(Internal.__GridCoordinates__, a, api=3)
-    if len(fields) == 1: return Converter.identifyNodes(hook, fields[0], tol)
-    else: return Converter.identifyNodes(hook, fields, tol)
+    if len(fields) == 1: return Converter.identifyNodes(hook, fields[0], tol, rtol)
+    else: return Converter.identifyNodes(hook, fields, tol, rtol)
 
 # -- identifyFaces: identifie les centres de faces de a dans hook
-def identifyFaces(hook, a, tol=1.e-11):
+def identifyFaces(hook, a, tol=1.e-11, rtol=1.e-12):
     """Find in a hook nearest points of face centers of a. return identified face indices.
     Usage: identifyFaces(hook, a)"""
     fields = getFields(Internal.__GridCoordinates__, a, api=3)
-    if len(fields) == 1: return Converter.identifyFaces(hook, fields[0], tol)
-    else: return Converter.identifyFaces(hook, fields, tol)
+    if len(fields) == 1: return Converter.identifyFaces(hook, fields[0], tol, rtol)
+    else: return Converter.identifyFaces(hook, fields, tol, rtol)
 
 # -- identifyElements: identifie le centre des elements de a dans hook
-def identifyElements(hook, a, tol=1.e-11):
+def identifyElements(hook, a, tol=1.e-11, rtol=1.e-12):
     """Find in a hook nearest points of element centers of a. return identified element indices.
     Usage: identifyElements(hook, a)"""
     fields = getFields(Internal.__GridCoordinates__, a, api=3)
-    if len(fields) == 1: return Converter.identifyElements(hook, fields[0], tol)
-    else: return Converter.identifyElements(hook, fields, tol)
+    if len(fields) == 1: return Converter.identifyElements(hook, fields[0], tol, rtol)
+    else: return Converter.identifyElements(hook, fields, tol, rtol)
 
 # -- identifySolutions: recopie la solution de tDnr dans tRcv par identification
 # des noeuds et des centres

--- a/Cassiopee/Converter/Converter/identify.cpp
+++ b/Cassiopee/Converter/Converter/identify.cpp
@@ -19,6 +19,7 @@
 
 // Routines d'identification geometrique
 
+# include "Connect/connect.h"
 # include "converter.h"
 using namespace K_FUNC;
 using namespace K_FLD;
@@ -33,8 +34,10 @@ using namespace ExtendedArithmetics;
 // ============================================================================
 PyObject* K_CONVERTER::identifyNodes(PyObject* self, PyObject* args)
 {  
-  PyObject* array; PyObject* hook; E_Float tol;
-  if (!PYPARSETUPLE_(args, OO_ R_, &hook, &array, &tol)) return NULL;
+  PyObject* array; PyObject* hook;
+  E_Float atol;  // absolute tolerance
+  E_Float rtol;  // relative tolerance
+  if (!PYPARSETUPLE_(args, OO_ RR_, &hook, &array, &atol, &rtol)) return NULL;
 
   // recupere le hook
   void** packet = NULL;
@@ -59,10 +62,10 @@ PyObject* K_CONVERTER::identifyNodes(PyObject* self, PyObject* args)
 
   // Recupere l'array a identifier
   E_Int nil, njl, nkl, res;
-  FldArrayF* f; FldArrayI* cnl;
+  FldArrayF* f; FldArrayI* cn;
   char* varString; char* eltType;
   res = K_ARRAY::getFromArray3(array, varString, 
-                               f, nil, njl, nkl, cnl, eltType);
+                               f, nil, njl, nkl, cn, eltType);
 
   if (res != 1 && res != 2)
   {
@@ -77,7 +80,7 @@ PyObject* K_CONVERTER::identifyNodes(PyObject* self, PyObject* args)
   posz = K_ARRAY::isCoordinateZPresent(varString);
   if (posx == -1 || posy == -1 || posz == -1)
   {
-    RELEASESHAREDB(res,array, f, cnl);
+    RELEASESHAREDB(res, array, f, cn);
     PyErr_SetString(PyExc_TypeError, 
                     "identifyNodes: array must have coordinates.");
     return NULL; 
@@ -96,11 +99,64 @@ PyObject* K_CONVERTER::identifyNodes(PyObject* self, PyObject* args)
   PyObject* ac = K_NUMPY::buildNumpyArray(npts, 1, 1);
   E_Int* nptr = K_NUMPY::getNumpyPtrI(ac);
 
+  E_Float etol = atol;  // effective tolerance
+  if (!K_FUNC::fEqualZero(rtol, K_CONST::E_ZERO_MACHINE))
+  {
+    // Compute the maximum delta in x-, y-, z-coordinates
+    // and add rtol*max(dx, dy, dz) to the absolute tolerance
+    const E_Int nthreads = __NUMTHREADS__;
+    E_Float dx, dy, dz;
+    E_Float xmin = K_CONST::E_MAX_FLOAT; E_Float xmax = -K_CONST::E_MAX_FLOAT;
+    E_Float ymin = K_CONST::E_MAX_FLOAT; E_Float ymax = -K_CONST::E_MAX_FLOAT;
+    E_Float zmin = K_CONST::E_MAX_FLOAT; E_Float zmax = -K_CONST::E_MAX_FLOAT;
+    E_Float* txmin = new E_Float [nthreads]; E_Float* txmax = new E_Float [nthreads];
+    E_Float* tymin = new E_Float [nthreads]; E_Float* tymax = new E_Float [nthreads];
+    E_Float* tzmin = new E_Float [nthreads]; E_Float* tzmax = new E_Float [nthreads];
+
+    for (E_Int tid = 0; tid < nthreads; tid++)
+    {
+      txmin[tid] = K_CONST::E_MAX_FLOAT; txmax[tid] = -K_CONST::E_MAX_FLOAT;
+      tymin[tid] = K_CONST::E_MAX_FLOAT; tymax[tid] = -K_CONST::E_MAX_FLOAT;
+      tzmin[tid] = K_CONST::E_MAX_FLOAT; tzmax[tid] = -K_CONST::E_MAX_FLOAT;
+    }
+
+    #pragma omp parallel
+    {
+      const E_Int tid = __CURRENT_THREAD__;
+      #pragma omp for
+      for (E_Int i = 0; i < npts; i++)
+      {
+        txmin[tid] = K_FUNC::E_min(txmin[tid], xp[i]);
+        txmax[tid] = K_FUNC::E_max(txmax[tid], xp[i]);
+        tymin[tid] = K_FUNC::E_min(tymin[tid], yp[i]);
+        tymax[tid] = K_FUNC::E_max(tymax[tid], yp[i]);
+        tzmin[tid] = K_FUNC::E_min(tzmin[tid], zp[i]);
+        tzmax[tid] = K_FUNC::E_max(tzmax[tid], zp[i]);
+      }
+    }
+
+    for (E_Int tid = 0; tid < nthreads; tid++)
+    {
+      xmin = K_FUNC::E_min(txmin[tid], xmin);
+      xmax = K_FUNC::E_max(txmax[tid], xmax);
+      ymin = K_FUNC::E_min(tymin[tid], ymin);
+      ymax = K_FUNC::E_max(tymax[tid], ymax);
+      zmin = K_FUNC::E_min(tzmin[tid], zmin);
+      zmax = K_FUNC::E_max(tzmax[tid], zmax);
+    }
+
+    dx = xmax - xmin; dy = ymax - ymin; dz = zmax - zmin;
+    etol += rtol*K_FUNC::E_max(dx, K_FUNC::E_max(dy, dz));
+    delete[] txmin; delete[] txmax;
+    delete[] tymin; delete[] tymax;
+    delete[] tzmin; delete[] tzmax;
+  }
+
   // Remplissage
-#pragma omp parallel default(shared)
+#pragma omp parallel
   {
     E_Float pt[3];
-    E_Float xf,yf,zf,dx,dy,dz;
+    E_Float xf, yf, zf, dx, dy, dz, dist;
     E_Int ind;
 
 #pragma omp for schedule(dynamic)
@@ -110,11 +166,12 @@ PyObject* K_CONVERTER::identifyNodes(PyObject* self, PyObject* args)
       pt[0] = xf; pt[1] = yf; pt[2] = zf;
       ind = globalKdt->getClosest(pt); // closest pt
       dx = xt[ind]-xf; dy = yt[ind]-yf; dz = zt[ind]-zf;
-      if (K_FUNC::E_abs(dx) < tol && K_FUNC::E_abs(dy) < tol && K_FUNC::E_abs(dz) < tol) nptr[i] = ind+1;
+      dist = sqrt(dx*dx + dy*dy + dz*dz);
+      if (dist < etol) nptr[i] = ind+1;
       else nptr[i] = -1;
     }
   }
-  RELEASESHAREDB(res, array, f, cnl);
+  RELEASESHAREDB(res, array, f, cn);
   return ac;
 }
 
@@ -127,8 +184,9 @@ PyObject* K_CONVERTER::identifyNodes(PyObject* self, PyObject* args)
 PyObject* K_CONVERTER::identifyFaces(PyObject* self, PyObject* args)
 { 
   PyObject* array; PyObject* hook;
-  E_Float tol;
-  if (!PYPARSETUPLE_(args, OO_ R_, &hook, &array, &tol)) return NULL;
+  E_Float atol;  // absolute tolerance
+  E_Float rtol;  // relative tolerance
+  if (!PYPARSETUPLE_(args, OO_ RR_, &hook, &array, &atol, &rtol)) return NULL;
 
   // recupere le hook
   void** packet = NULL;
@@ -138,7 +196,7 @@ PyObject* K_CONVERTER::identifyFaces(PyObject* self, PyObject* args)
   packet = (void**) PyCapsule_GetPointer(hook, NULL);
 #endif
   E_Int* type = (E_Int*)packet[0];
-  if (*type != 0 && *type != 2 && *type != 3&&
+  if (*type != 0 && *type != 2 && *type != 3 &&
       *type != 100 && *type != 102 && *type != 103)
   {
     PyErr_SetString(PyExc_TypeError, 
@@ -151,10 +209,10 @@ PyObject* K_CONVERTER::identifyFaces(PyObject* self, PyObject* args)
 
   // Recupere l'array a identifier
   E_Int nil, njl, nkl, res;
-  FldArrayF* f; FldArrayI* cnl;
+  FldArrayF* f; FldArrayI* cn;
   char* varString; char* eltType;
   res = K_ARRAY::getFromArray3(array, varString, 
-                               f, nil, njl, nkl, cnl, eltType);
+                               f, nil, njl, nkl, cn, eltType);
 
   if (res != 1 && res != 2)
   {
@@ -171,7 +229,7 @@ PyObject* K_CONVERTER::identifyFaces(PyObject* self, PyObject* args)
   }
   if (strcmp(eltType, "NGON") != 0)
   {
-    RELEASESHAREDU(array, f, cnl);
+    RELEASESHAREDU(array, f, cn);
     PyErr_SetString(PyExc_TypeError, 
                     "identifyFaces: array must be a NGON.");
     return NULL; 
@@ -183,7 +241,7 @@ PyObject* K_CONVERTER::identifyFaces(PyObject* self, PyObject* args)
   posz = K_ARRAY::isCoordinateZPresent(varString);
   if (posx == -1 || posy == -1 || posz == -1)
   {
-    RELEASESHAREDU(array, f, cnl);
+    RELEASESHAREDU(array, f, cn);
     PyErr_SetString(PyExc_TypeError, 
                     "identifyFaces: array must have coordinates.");
     return NULL; 
@@ -191,7 +249,7 @@ PyObject* K_CONVERTER::identifyFaces(PyObject* self, PyObject* args)
   posx++; posy++; posz++;
 
   // Cree le numpy de sortie
-  E_Int nfaces = cnl->getNFaces();
+  E_Int nfaces = cn->getNFaces();
   E_Float* xp = f->begin(posx);
   E_Float* yp = f->begin(posy);
   E_Float* zp = f->begin(posz);
@@ -203,33 +261,45 @@ PyObject* K_CONVERTER::identifyFaces(PyObject* self, PyObject* args)
   E_Int* nptr = K_NUMPY::getNumpyPtrI(ac);
 
   // Acces non universel sur les ptrs
-  E_Int* ngon = cnl->getNGon();
-  E_Int* indPG = cnl->getIndPG();
+  E_Int* ngon = cn->getNGon();
+  E_Int* indPG = cn->getIndPG();
 
 #pragma omp parallel default(shared)
   {
-    E_Int ind, nv, indk;
-    E_Float inv, xf, yf, zf, dx, dy, dz;
+    E_Int v1, v2, nv, ind;
+    E_Float inv, xf, yf, zf, dx, dy, dz, len, lmax, dist, etol;
     E_Float pt[3];
 #ifdef QUADDOUBLE
-    quad_double qxf, qyf, qzf;
+    quad_double qxf, qyf, qzf, qdx, qdy, qdz, qlen;
     quad_double qinv;
 #endif
 
 #pragma omp for schedule(dynamic)
     for (E_Int i = 0; i < nfaces; i++)
     {
+      lmax = -K_CONST::E_MAX_FLOAT;
+          
       // Acces universel face i
-      E_Int* face = cnl->getFace(i, nv, ngon, indPG);
+      E_Int* face = cn->getFace(i, nv, ngon, indPG);
 
 #ifdef QUADDOUBLE
       qxf = 0.; qyf = 0.; qzf = 0.;
-      for (E_Int n = 0; n < nv; n++)
+      for (E_Int j = 0; j < nv; j++)
       {
-        ind = face[n]-1;
-        qxf = qxf+quad_double(xp[ind]); 
-        qyf = qyf+quad_double(yp[ind]); 
-        qzf = qzf+quad_double(zp[ind]); 
+        v1 = face[j]-1;
+        qxf += quad_double(xp[v1]); 
+        qyf += quad_double(yp[v1]); 
+        qzf += quad_double(zp[v1]);
+
+        // local max edge length
+        if (j == nv-1) v2 = face[0]-1;
+        else v2 = face[j+1]-1;
+        qdx = quad_double(xp[v2]) - quad_double(xp[v1]);
+        qdy = quad_double(yp[v2]) - quad_double(yp[v1]);
+        qdz = quad_double(zp[v2]) - quad_double(zp[v1]);
+        qlen = sqrt(qdx*qdx + qdy*qdy + qdz*qdz);
+        len = E_Float(qlen);
+        lmax = K_FUNC::E_max(lmax, len);
       }
       qinv = quad_double(nv); qxf = qxf/qinv; qyf = qyf/qinv; qzf = qzf/qinv;
       xf = E_Float(qxf); yf = E_Float(qyf); zf = E_Float(qzf);
@@ -239,24 +309,33 @@ PyObject* K_CONVERTER::identifyFaces(PyObject* self, PyObject* args)
         #ifdef __INTEL_COMPILER
         #pragma float_control(precise, on)
         #endif
-        for (E_Int n = 0; n < nv; n++)
+        for (E_Int j = 0; j < nv; j++)
         {
-          ind = face[n]-1;
-          xf += xp[ind]; yf += yp[ind]; zf += zp[ind];
+          v1 = face[j]-1;
+          xf += xp[v1]; yf += yp[v1]; zf += zp[v1];
+
+          // local max edge length
+          if (j == nv-1) v2 = face[0]-1;
+          else v2 = face[j+1]-1;
+          dx = xp[v2]-xp[v1]; dy = yp[v2]-yp[v1]; dz = zp[v2]-zp[v1];
+          len = sqrt(dx*dx + dy*dy + dz*dz);
+          lmax = K_FUNC::E_max(lmax, len);
         }
         inv = 1./E_Float(nv); xf *= inv; yf *= inv; zf *= inv;
       }
 #endif
       pt[0] = xf; pt[1] = yf; pt[2] = zf;
-      indk = globalKdt->getClosest(pt); // closest pt
-      dx = xt[indk]-xf; dy = yt[indk]-yf; dz = zt[indk]-zf;
-      // std::cout << "dx, dy, dz " << dx << " " << dy << " " << dz << std::endl;
-      if (K_FUNC::E_abs(dx) < tol && K_FUNC::E_abs(dy) < tol && K_FUNC::E_abs(dz) < tol) nptr[i] = indk+1; 
+      ind = globalKdt->getClosest(pt); // closest pt
+      dx = xt[ind]-xf; dy = yt[ind]-yf; dz = zt[ind]-zf;
+      dist = sqrt(dx*dx + dy*dy + dz*dz);
+      // local effective tolerance
+      etol = atol + rtol*lmax;
+      if (dist < etol) nptr[i] = ind+1; 
       else nptr[i] = -1;
     }
   }
 
-  RELEASESHAREDU(array, f, cnl);
+  RELEASESHAREDU(array, f, cn);
   return ac;
 }
 
@@ -269,8 +348,9 @@ PyObject* K_CONVERTER::identifyFaces(PyObject* self, PyObject* args)
 PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
 { 
   PyObject* array; PyObject* hook;
-  E_Float tol;
-  if (!PYPARSETUPLE_(args, OO_ R_, &hook, &array, &tol)) return NULL;
+  E_Float atol;  // absolute tolerance
+  E_Float rtol;  // relative tolerance
+  if (!PYPARSETUPLE_(args, OO_ RR_, &hook, &array, &atol, &rtol)) return NULL;
 
   // recupere le hook
   void** packet = NULL;
@@ -280,7 +360,7 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
   packet = (void**) PyCapsule_GetPointer(hook, NULL);
 #endif
   E_Int* type = (E_Int*)packet[0];
-  if (*type != 0 && *type != 2 && *type != 3&&
+  if (*type != 0 && *type != 2 && *type != 3 &&
       *type != 100 && *type != 102 && *type != 103) 
   {
     PyErr_SetString(PyExc_TypeError, 
@@ -295,10 +375,10 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
 
   // Recupere l'array a identifier
   E_Int nil, njl, nkl, res;
-  FldArrayF* f; FldArrayI* cnl;
+  FldArrayF* f; FldArrayI* cn;
   char* varString; char* eltType;
   res = K_ARRAY::getFromArray3(array, varString, 
-                               f, nil, njl, nkl, cnl, eltType);
+                               f, nil, njl, nkl, cn, eltType);
 
   if (res != 1 && res != 2)
   {
@@ -313,7 +393,7 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
   posz = K_ARRAY::isCoordinateZPresent(varString);
   if (posx == -1 || posy == -1 || posz == -1)
   {
-    RELEASESHAREDU(array, f, cnl);
+    RELEASESHAREDU(array, f, cn);
     PyErr_SetString(PyExc_TypeError, 
                     "identifyElts: array must have coordinates.");
     return NULL; 
@@ -343,44 +423,99 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
 
 #pragma omp parallel default(shared)
     {
-      E_Float xf,yf,zf,dx,dy,dz;
-      E_Int ind;
+      E_Float xf, yf, zf, dx, dy, dz, dist, lmax, len, etol;
+      E_Int ind, ind1, ind2, ind3, ind4, ind5, ind6, ind7, ind8;
       E_Float pt[3];
       E_Int ic = 0;
 
-#pragma omp for collapse(3)
+#pragma omp for schedule(dynamic) collapse(3)
       for (E_Int k = 0; k < nke; k++)
       for (E_Int j = 0; j < nje; j++)
       for (E_Int i = 0; i < nie; i++)
       {
+        lmax = -K_CONST::E_MAX_FLOAT;
+        etol = atol;
+
         ic = i+j*nie+k*nie*nje;
         xf = 0.; yf = 0.; zf = 0.;
-        ind = i+j*nil+k*nijl;
-        xf += xp[ind]; yf += yp[ind]; zf += zp[ind];
-        ind = i+inci+j*nil+k*nijl;
-        xf += xp[ind]; yf += yp[ind]; zf += zp[ind];
-        ind = i+(j+incj)*nil+k*nijl;
-        xf += xp[ind]; yf += yp[ind]; zf += zp[ind];
-        ind = i+inci+(j+incj)*nil+k*nijl;
-        xf += xp[ind]; yf += yp[ind]; zf += zp[ind];
-        ind = i+j*nil+(k+inck)*nijl;
-        xf += xp[ind]; yf += yp[ind]; zf += zp[ind];
-        ind = i+inci+j*nil+(k+inck)*nijl;
-        xf += xp[ind]; yf += yp[ind]; zf += zp[ind];
-        ind = i+(j+incj)*nil+(k+inck)*nijl;
-        xf += xp[ind]; yf += yp[ind]; zf += zp[ind];
-        ind = i+inci+(j+incj)*nil+(k+inck)*nijl;
-        xf += xp[ind]; yf += yp[ind]; zf += zp[ind];
+        ind1 = i+j*nil+k*nijl;
+        xf += xp[ind1]; yf += yp[ind1]; zf += zp[ind1];
+        ind2 = i+inci+j*nil+k*nijl;
+        xf += xp[ind2]; yf += yp[ind2]; zf += zp[ind2];
+        ind3 = i+(j+incj)*nil+k*nijl;
+        xf += xp[ind3]; yf += yp[ind3]; zf += zp[ind3];
+        ind4 = i+inci+(j+incj)*nil+k*nijl;
+        xf += xp[ind4]; yf += yp[ind4]; zf += zp[ind4];
+        ind5 = i+j*nil+(k+inck)*nijl;
+        xf += xp[ind5]; yf += yp[ind5]; zf += zp[ind5];
+        ind6 = i+inci+j*nil+(k+inck)*nijl;
+        xf += xp[ind6]; yf += yp[ind6]; zf += zp[ind6];
+        ind7 = i+(j+incj)*nil+(k+inck)*nijl;
+        xf += xp[ind7]; yf += yp[ind7]; zf += zp[ind7];
+        ind8 = i+inci+(j+incj)*nil+(k+inck)*nijl;
+        xf += xp[ind8]; yf += yp[ind8]; zf += zp[ind8];
 
         xf = xf/8.; yf = yf/8.; zf = zf/8.;
         pt[0] = xf; pt[1] = yf; pt[2] = zf;
 
+        if (!K_FUNC::fEqualZero(rtol, K_CONST::E_ZERO_MACHINE))
+        {
+          // Edge (ind1, ind2)
+          dx = xp[ind2]-xp[ind1]; dy = yp[ind2]-yp[ind1]; dz = zp[ind2]-zp[ind1];
+          len = sqrt(dx*dx + dy*dy + dz*dz);
+          lmax = K_FUNC::E_max(lmax, len);
+          // Edge (ind1, ind3)
+          dx = xp[ind3]-xp[ind1]; dy = yp[ind3]-yp[ind1]; dz = zp[ind3]-zp[ind1];
+          len = sqrt(dx*dx + dy*dy + dz*dz);
+          lmax = K_FUNC::E_max(lmax, len);
+          // Edge (ind1, ind5)
+          dx = xp[ind5]-xp[ind1]; dy = yp[ind5]-yp[ind1]; dz = zp[ind5]-zp[ind1];
+          len = sqrt(dx*dx + dy*dy + dz*dz);
+          lmax = K_FUNC::E_max(lmax, len);
+          // Edge (ind2, ind4)
+          dx = xp[ind4]-xp[ind2]; dy = yp[ind4]-yp[ind2]; dz = zp[ind4]-zp[ind2];
+          len = sqrt(dx*dx + dy*dy + dz*dz);
+          lmax = K_FUNC::E_max(lmax, len);
+          // Edge (ind2, ind6)
+          dx = xp[ind6]-xp[ind2]; dy = yp[ind6]-yp[ind2]; dz = zp[ind6]-zp[ind2];
+          len = sqrt(dx*dx + dy*dy + dz*dz);
+          lmax = K_FUNC::E_max(lmax, len);
+          // Edge (ind3, ind4)
+          dx = xp[ind4]-xp[ind3]; dy = yp[ind4]-yp[ind3]; dz = zp[ind4]-zp[ind3];
+          len = sqrt(dx*dx + dy*dy + dz*dz);
+          lmax = K_FUNC::E_max(lmax, len);
+          // Edge (ind3, ind7)
+          dx = xp[ind7]-xp[ind3]; dy = yp[ind7]-yp[ind3]; dz = zp[ind7]-zp[ind3];
+          len = sqrt(dx*dx + dy*dy + dz*dz);
+          lmax = K_FUNC::E_max(lmax, len);
+          // Edge (ind4, ind8)
+          dx = xp[ind8]-xp[ind4]; dy = yp[ind8]-yp[ind4]; dz = zp[ind8]-zp[ind4];
+          len = sqrt(dx*dx + dy*dy + dz*dz);
+          lmax = K_FUNC::E_max(lmax, len);
+          // Edge (ind5, ind6)
+          dx = xp[ind6]-xp[ind5]; dy = yp[ind6]-yp[ind5]; dz = zp[ind6]-zp[ind5];
+          len = sqrt(dx*dx + dy*dy + dz*dz);
+          lmax = K_FUNC::E_max(lmax, len);
+          // Edge (ind5, ind7)
+          dx = xp[ind7]-xp[ind5]; dy = yp[ind7]-yp[ind5]; dz = zp[ind7]-zp[ind5];
+          len = sqrt(dx*dx + dy*dy + dz*dz);
+          lmax = K_FUNC::E_max(lmax, len);
+          // Edge (ind6, ind8)
+          dx = xp[ind8]-xp[ind6]; dy = yp[ind8]-yp[ind6]; dz = zp[ind8]-zp[ind6];
+          len = sqrt(dx*dx + dy*dy + dz*dz);
+          lmax = K_FUNC::E_max(lmax, len);
+          // Edge (ind7, ind8)
+          dx = xp[ind8]-xp[ind7]; dy = yp[ind8]-yp[ind7]; dz = zp[ind8]-zp[ind7];
+          len = sqrt(dx*dx + dy*dy + dz*dz);
+          lmax = K_FUNC::E_max(lmax, len);
+          // Effective tolerance
+          etol += rtol*lmax;
+        }
+
         ind = globalKdt->getClosest(pt); // closest pt
         dx = xt[ind]-xf; dy = yt[ind]-yf; dz = zt[ind]-zf;
-        //d = dx*dx + dy*dy + dz*dz;
-        //if (d < tol) nptr[i] = ind+1;
-        //else nptr[i] = -1;
-        if (K_FUNC::E_abs(dx) < tol && K_FUNC::E_abs(dy) < tol && K_FUNC::E_abs(dz) < tol) nptr[ic] = ind+1;
+        dist = sqrt(dx*dx + dy*dy + dz*dz);
+        if (dist < etol) nptr[ic] = ind+1;
         else nptr[ic] = -1;
       }
     }
@@ -388,7 +523,7 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
   else if (strcmp(eltType, "NGON") == 0)
   {  
     // Cree le numpy de sortie
-    E_Int nelts = cnl->getNElts();
+    E_Int nelts = cn->getNElts();
     E_Float* xt = centers->begin(1);
     E_Float* yt = centers->begin(2);
     E_Float* zt = centers->begin(3);
@@ -397,41 +532,54 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
     E_Int* nptr = K_NUMPY::getNumpyPtrI(ac);
 
     // Acces non universel sur les ptrs
-    E_Int* ngon = cnl->getNGon();
-    E_Int* nface = cnl->getNFace();
-    E_Int* indPG = cnl->getIndPG();
-    E_Int* indPH = cnl->getIndPH();
+    E_Int* ngon = cn->getNGon();
+    E_Int* nface = cn->getNFace();
+    E_Int* indPG = cn->getIndPG();
+    E_Int* indPH = cn->getIndPH();
     
 #pragma omp parallel default(shared)
     {
       E_Float pt[3];
-      E_Int nf, c, nv, ind, indp;
+      E_Int nf, c, nv, ind, v1, v2;
       E_Float xf, yf, zf, inv, dx, dy, dz;
+      E_Float lmax, len, dist, etol;
+
 #ifdef QUADDOUBLE
-      quad_double qxf, qyf, qzf;
+      quad_double qxf, qyf, qzf, qdx, qdy, qdz, qlen;
       quad_double qinv;
 #endif
 
 #pragma omp for schedule(dynamic)
       for (E_Int i = 0; i < nelts; i++)
       {
+        lmax = -K_CONST::E_MAX_FLOAT;
+
         // Acces universel element i
-        E_Int* elem = cnl->getElt(i, nf, nface, indPH);
+        E_Int* elem = cn->getElt(i, nf, nface, indPH);
         xf = 0.; yf = 0.; zf = 0.; c = 0;
 
 #ifdef QUADDOUBLE
         qxf = 0.; qyf = 0.; qzf = 0.;
         for (E_Int n = 0; n < nf; n++)
         { 
-          // Acces universel face elem[n]-1
-          E_Int* face = cnl->getFace(elem[n]-1, nv, ngon, indPG);
-          for (E_Int p = 0; p < nv; p++)
+          E_Int* face = cn->getFace(elem[n]-1, nv, ngon, indPG);
+          for (E_Int j = 0; j < nv; j++)
           {
-            indp = face[p]-1;
-            qxf = qxf+quad_double(xp[indp]); 
-            qyf = qyf+quad_double(yp[indp]);
-            qzf = qzf+quad_double(zp[indp]); 
+            v1 = face[j]-1;
+            qxf += quad_double(xp[v1]);
+            qyf += quad_double(yp[v1]);
+            qzf += quad_double(zp[v1]);
             c++;
+
+            // local max edge length
+            if (j == nv-1) v2 = face[0]-1;
+            else v2 = face[j+1]-1;
+            qdx = quad_double(xp[v2]) - quad_double(xp[v1]);
+            qdy = quad_double(yp[v2]) - quad_double(yp[v1]);
+            qdz = quad_double(zp[v2]) - quad_double(zp[v1]);
+            qlen = sqrt(qdx*qdx + qdy*qdy + qdz*qdz);
+            len = E_Float(qlen);
+            lmax = K_FUNC::E_max(lmax, len);
           }
         }
         qinv = quad_double(c); qxf = qxf/qinv; qyf = qyf/qinv; qzf = qzf/qinv;
@@ -442,21 +590,32 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
           #pragma float_control(precise, on)
           #endif
           for (E_Int n = 0; n < nf; n++)
-          { 
-            // Acces universel face elem[n]-1
-            E_Int* face = cnl->getFace(elem[n]-1, nv, ngon, indPG);
-            for (E_Int p = 0; p < nv; p++)
+          {
+            E_Int* face = cn->getFace(elem[n]-1, nv, ngon, indPG);
+            for (E_Int j = 0; j < nv; j++)
             {
-              indp = face[p]-1; xf += xp[indp]; yf += yp[indp]; zf += zp[indp]; c++;
+              v1 = face[j]-1;
+              xf += xp[v1]; yf += yp[v1]; zf += zp[v1]; c++;
+
+              // local max edge length
+              if (j == nv-1) v2 = face[0]-1;
+              else v2 = face[j+1]-1;
+              dx = xp[v2]-xp[v1]; dy = yp[v2]-yp[v1]; dz = zp[v2]-zp[v1];
+              len = sqrt(dx*dx + dy*dy + dz*dz);
+              lmax = K_FUNC::E_max(lmax, len);
             }
           }
           inv = 1./E_Float(c); xf *= inv; yf *= inv; zf *= inv;
         }
 #endif
+
         pt[0] = xf; pt[1] = yf; pt[2] = zf;
         ind = globalKdt->getClosest(pt); // closest pt
         dx = xt[ind]-xf; dy = yt[ind]-yf; dz = zt[ind]-zf;
-        if (K_FUNC::E_abs(dx) < tol && K_FUNC::E_abs(dy) < tol && K_FUNC::E_abs(dz) < tol) nptr[i] = ind+1;
+        dist = sqrt(dx*dx + dy*dy + dz*dz);
+        // local effective tolerance
+        etol = atol + rtol*lmax;
+        if (dist < etol) nptr[i] = ind+1;
         else nptr[i] = -1;
       }
     }
@@ -468,18 +627,29 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
     E_Float* zt = centers->begin(3);
 
     // Acces universel sur BE/ME
-    E_Int nc = cnl->getNConnect();
+    E_Int nc = cn->getNConnect();
     // Acces universel aux eltTypes
     std::vector<char*> eltTypes;
     K_ARRAY::extractVars(eltType, eltTypes);
     std::vector<E_Int> nepc(nc+1, 0);
+
+    // Number of faces per element for each connectivity
+    std::vector<E_Int> nfpe;
+    E_Int ierr = K_CONNECT::getNFPE(nfpe, eltType, true);
+    if (ierr != 0)
+    {
+      PyErr_SetString(PyExc_TypeError, 
+                      "identifyElements: cannot determine the number of faces "
+                      "per element.");
+      return NULL;
+    }
 
     // Boucle sur toutes les connectivites une premiere fois pour savoir si
     // elles sont valides et calculer le nombre total d'elements - permet
     // d'allouer ac
     for (E_Int ic = 0; ic < nc; ic++)
     {
-      FldArrayI& cm = *(cnl->getConnect(ic));
+      FldArrayI& cm = *(cn->getConnect(ic));
       char* eltTypConn = eltTypes[ic];
       // Check that this connectivity is valid
       if (not(strcmp(eltTypConn,"BAR")==0 || strcmp(eltTypConn,"TRI")==0 || 
@@ -487,7 +657,7 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
               strcmp(eltTypConn,"HEXA")==0 || strcmp(eltTypConn,"PENTA")==0 ||
               strcmp(eltTypConn,"PYRA")==0))
       {
-        RELEASESHAREDB(res, array, f, cnl);
+        RELEASESHAREDB(res, array, f, cn);
         PyErr_SetString(PyExc_TypeError,
                         "identifyElements: invalid type of array.");
         return NULL;
@@ -495,48 +665,70 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
       nepc[ic+1] += nepc[ic] + cm.getSize();
     }
 
-    for (size_t ic = 0; ic < eltTypes.size(); ic++) delete [] eltTypes[ic];
-
     ac = K_NUMPY::buildNumpyArray(nepc[nc], 1, 1);
     E_Int* nptr = K_NUMPY::getNumpyPtrI(ac);
 
     // Boucle sur toutes les connectivites pour remplir ac
 #pragma omp parallel default(shared)
     {
+      E_Int nvpf;
+      std::vector<std::vector<E_Int> > facets;
+
       for (E_Int ic = 0; ic < nc; ic++)
       {
-        FldArrayI& cm = *(cnl->getConnect(ic));
+        FldArrayI& cm = *(cn->getConnect(ic));
         E_Int nelts = cm.getSize();
         E_Int offset = nepc[ic];
         E_Int nvpe = cm.getNfld();
         E_Float inv = 1./E_Float(nvpe);
+        K_CONNECT::getEVFacets(facets, eltTypes[ic], false);
+  
 #ifdef QUADDOUBLE
         quad_double qinv = quad_double(nvpe);
 #endif
 
         E_Float pt[3];
-        E_Float xf,yf,zf,dx,dy,dz;
-        E_Int ind;
+        E_Float xf, yf, zf, dx, dy, dz, lmax, len, dist, etol;
+        E_Int ind, v1, v2;
 #ifdef QUADDOUBLE
-        quad_double qxf, qyf, qzf;
+        quad_double qxf, qyf, qzf, qdx, qdy, qdz, qlen;
 #endif
 
 #pragma omp for schedule(dynamic)
         for (E_Int i = 0; i < nelts; i++)
         {
+          lmax = -K_CONST::E_MAX_FLOAT;
+
 #ifdef QUADDOUBLE
-          qxf = 0.; qyf =0.; qzf = 0.;
+          qxf = 0.; qyf = 0.; qzf = 0.;
           for (E_Int n = 1; n <= nvpe; n++)
           {
-            ind = cm(i,n)-1;
-            qxf = qxf+quad_double(xp[ind]);
-            qyf = qyf+quad_double(yp[ind]); 
-            qzf = qzf+quad_double(zp[ind]); 
+            v1 = cm(i,n)-1;
+            qxf += quad_double(xp[v1]);
+            qyf += quad_double(yp[v1]); 
+            qzf += quad_double(zp[v1]); 
           }
           qxf = qxf/qinv; qyf = qyf/qinv; qzf = qzf/qinv;
-          xf = E_Float(qxf);
-          yf = E_Float(qyf);
-          zf = E_Float(qzf);
+          xf = E_Float(qxf); yf = E_Float(qyf); zf = E_Float(qzf);
+
+          // Loop over each facet of this element
+          for (E_Int f = 0; f < nfpe[ic]; f++)
+          {
+            // Number of vertices per face
+            nvpf = facets[f].size();
+            for (E_Int j = 0; j < nvpf; j++)
+            {
+              v1 = cm(i, facets[f][j]) - 1;
+              if (j == nvpf-1) v2 = cm(i, facets[f][0]) - 1;
+              else v2 = cm(i, facets[f][j+1]) - 1;
+              qdx = quad_double(xp[v2]) - quad_double(xp[v1]);
+              qdy = quad_double(yp[v2]) - quad_double(yp[v1]);
+              qdz = quad_double(zp[v2]) - quad_double(zp[v1]);
+              qlen = sqrt(qdx*qdx + qdy*qdy + qdz*qdz);
+              len = E_Float(qlen);
+              lmax = K_FUNC::E_max(lmax, len);
+            }
+          }
 #else
           xf = 0.; yf = 0.; zf = 0.;
           {
@@ -545,26 +737,43 @@ PyObject* K_CONVERTER::identifyElements(PyObject* self, PyObject* args)
             #endif
             for (E_Int n = 1; n <= nvpe; n++)
             {
-              ind = cm(i,n)-1; 
-              xf += xp[ind]; yf += yp[ind]; zf += zp[ind];        
+              v1 = cm(i,n)-1; 
+              xf += xp[v1]; yf += yp[v1]; zf += zp[v1];
             }
             xf *= inv; yf *= inv; zf *= inv;
           }
+
+          // Loop over each facet of this element
+          for (E_Int f = 0; f < nfpe[ic]; f++)
+          {
+            // Number of vertices per face
+            nvpf = facets[f].size();
+            for (E_Int j = 0; j < nvpf; j++)
+            {
+              v1 = cm(i, facets[f][j]) - 1;
+              if (j == nvpf-1) v2 = cm(i, facets[f][0]) - 1;
+              else v2 = cm(i, facets[f][j+1]) - 1;
+              dx = xp[v2]-xp[v1]; dy = yp[v2]-yp[v1]; dz = zp[v2]-zp[v1];
+              len = sqrt(dx*dx + dy*dy + dz*dz);
+              lmax = K_FUNC::E_max(lmax, len);
+            }
+          }
 #endif
           pt[0] = xf; pt[1] = yf; pt[2] = zf;
-
           ind = globalKdt->getClosest(pt); // closest pt
           dx = xt[ind]-xf; dy = yt[ind]-yf; dz = zt[ind]-zf;
-          //d = dx*dx + dy*dy + dz*dz;
-          //if (d < tol) nptr[offset+i] = ind+1;
-          //else nptr[offset+i] = -1;
-          if (K_FUNC::E_abs(dx) < tol && K_FUNC::E_abs(dy) < tol && K_FUNC::E_abs(dz) < tol) nptr[offset+i] = ind+1;
+          dist = sqrt(dx*dx + dy*dy + dz*dz);
+          // local effective tolerance
+          etol = atol + rtol*lmax;
+          if (dist < etol) nptr[offset+i] = ind+1;
           else nptr[offset+i] = -1;
         }
       }
     }
+
+    for (size_t ic = 0; ic < eltTypes.size(); ic++) delete [] eltTypes[ic];
   }
 
-  RELEASESHAREDB(res, array, f, cnl);
+  RELEASESHAREDB(res, array, f, cn);
   return ac;
 }

--- a/Cassiopee/Converter/doc/source/Converter.rst
+++ b/Cassiopee/Converter/doc/source/Converter.rst
@@ -2660,7 +2660,7 @@ Geometrical identification
     :type a: [array,list of arrays] or [pyTree, base, zone, list of zones]
     :param tol: matching absolute tolerance
     :type rtol: float
-    :param rtol: relative tolerance based on the largest edge of the mesh bounding box
+    :param rtol: relative tolerance
     :type tol: float
     :return: indices of identified points
     :rtype: numpy array or list of numpy arrays
@@ -2694,7 +2694,7 @@ Geometrical identification
     :type a: [array,list of arrays] or [pyTree, base, zone, list of zones]
     :param tol: matching absolute tolerance
     :type tol: float
-    :param rtol: relative tolerance based on the largest edge of a given face
+    :param rtol: relative tolerance
     :type rtol: float
     :return: indices of identified faces
     :rtype: numpy array or list of numpy arrays
@@ -2724,7 +2724,7 @@ Geometrical identification
     :type a: [array,list of arrays] or [pyTree, base, zone, list of zones]
     :param tol: matching absolute tolerance
     :type tol: float
-    :param rtol: relative tolerance based on the largest edge of a given element
+    :param rtol: relative tolerance
     :type rtol: float
     :return: indices of identified elements
     :rtype: numpy array or list of numpy arrays

--- a/Cassiopee/Converter/doc/source/Converter.rst
+++ b/Cassiopee/Converter/doc/source/Converter.rst
@@ -2647,17 +2647,20 @@ and Post.
 Geometrical identification
 ----------------------------
 
-.. py:function:: Converter.identifyNodes(hook, a, tol=1.e-11)
+.. py:function:: Converter.identifyNodes(hook, a, tol=1.e-11, rtol=1.e-14)
 
     Identify nodes of a with nodes stored in hook. Return the indices of hook 
-    corresponding to the nodes of a. If a point is not identified,
-    its returned index is -1.
+    corresponding to the nodes of a. If a point is not identified, its returned index is -1.
+    The effective tolerance is computed as tol + rtol*L where L is the largest
+    edge of the mesh bounding box.
 
     :param hook: hook
     :type hook: created by createHook
     :param a: input data
     :type a: [array,list of arrays] or [pyTree, base, zone, list of zones]
-    :param tol: matching tolerance
+    :param tol: matching absolute tolerance
+    :type rtol: float
+    :param rtol: relative tolerance based on the largest edge of the mesh bounding box
     :type tol: float
     :return: indices of identified points
     :rtype: numpy array or list of numpy arrays
@@ -2678,18 +2681,21 @@ Geometrical identification
 
 ------------------------------------------------------------------------------------------
 
-.. py:function:: Converter.identifyFaces(hook, a, tol=1.e-11)
+.. py:function:: Converter.identifyFaces(hook, a, tol=1.e-11, rtol=1.e-12)
 
     Identify face centers of a with points stored in hook. Return the indices of hook 
-    corresponding to the faces of a. If a face is not identified,
-    its returned index is -1.
+    corresponding to the faces of a. If a face is not identified, its returned index is -1.
+    The effective tolerance is computed as tol + rtol*L where L is the largest
+    edge of a given face.
 
     :param hook: hook
     :type hook: created by createHook
     :param a: input data
     :type a: [array,list of arrays] or [pyTree, base, zone, list of zones]
-    :param tol: matching tolerance
+    :param tol: matching absolute tolerance
     :type tol: float
+    :param rtol: relative tolerance based on the largest edge of a given face
+    :type rtol: float
     :return: indices of identified faces
     :rtype: numpy array or list of numpy arrays
 
@@ -2705,18 +2711,21 @@ Geometrical identification
 
 ------------------------------------------------------------------------------------------
 
-.. py:function:: Converter.identifyElements(hook, a, tol=1.e-11)
+.. py:function:: Converter.identifyElements(hook, a, tol=1.e-11, rtol=1.e-12)
 
     Identify element centers of a with points stored in hook. Return the indices of hook 
-    corresponding to the elements of a. If a elements is not identified,
-    its returned index is -1.
+    corresponding to the elements of a. If a elements is not identified, its returned index is -1.
+    The effective tolerance is computed as tol + rtol*L where L is the largest
+    edge of a given element.
 
     :param hook: hook
     :type hook: created by createHook
     :param a: input data
     :type a: [array,list of arrays] or [pyTree, base, zone, list of zones]
-    :param tol: matching tolerance
+    :param tol: matching absolute tolerance
     :type tol: float
+    :param rtol: relative tolerance based on the largest edge of a given element
+    :type rtol: float
     :return: indices of identified elements
     :rtype: numpy array or list of numpy arrays
 


### PR DESCRIPTION
Please SQUASH
No regressions

**Add relative tol to C.identify nodes/faces/elements**

Useful when the mesh is given in mm for ex.

The scale, `L`, by which is multiplied the relative tolerance is:
- nodes) the largest edge of the mesh bounding box
- faces) the largest edge of a given face
- elements) the largest edge of a given element

The effective tolerance is then computed as: `atol + rtol*L`

The default relative tolerances are:
- nodes) 1e-14
- faces) 1e-12
- elements) 1e-12

and may need tuning @benoit128 (1e-12 OK for OAT15A, 1e-13 isn't)
