### PR TITLE
Generator: BE/ME extension for getRegularityMap

### DIFF
--- a/Cassiopee/Generator/Generator/PyTree.py
+++ b/Cassiopee/Generator/Generator/PyTree.py
@@ -1887,7 +1887,7 @@ def getRegularityMap(t, addGC=False):
     """Return the regularity map in an array.
     Usage: getRegularityMap(t)"""
     if addGC: t = Internal.addGhostCells(t, t, 1, adaptBCs=0, modified=[], fillCorner=1)
-    t = C.TZGC1(t, 'centers', True, Generator.getRegularityMap)
+    t = C.TZGC3(t, 'centers', True, Generator.getRegularityMap)
     if addGC: t = Internal.rmGhostCells(t, t, 1, adaptBCs=0, modified=[])
     return t
 
@@ -1895,7 +1895,7 @@ def _getRegularityMap(t, addGC=False):
     """Return the regularity map in an array.
     Usage: getRegularityMap(t)"""
     if addGC: Internal._addGhostCells(t, t, 1, adaptBCs=0, modified=[], fillCorner=1)
-    C._TZGC1(t, 'centers', False, Generator.getRegularityMap)
+    C._TZGC3(t, 'centers', False, Generator.getRegularityMap)
     if addGC: Internal._rmGhostCells(t, t, 1, adaptBCs=0, modified=[])
     return None
 

--- a/Cassiopee/Generator/Generator/getRegularityMap.cpp
+++ b/Cassiopee/Generator/Generator/getRegularityMap.cpp
@@ -599,40 +599,37 @@ PyObject* K_GENERATOR::getRegularityMap(PyObject* self, PyObject* args)
     }
 
     // Pre-compute total number of elements and facets
+    E_Int ierr;
+    E_Int ntotFacets = 0, ntotElts = 0;
     E_Int nc = cn->getNConnect();
     std::vector<char*> eltTypes;
     K_ARRAY::extractVars(eltType, eltTypes);
 
-    E_Int ntotFacets = 0, ntotElts = 0;
-    std::vector<E_Int> nfpe(nc);  // number of facets per element
+    // Number of facets per element
+    std::vector<E_Int> nfpe;
+    ierr = K_CONNECT::getNFPE(nfpe, eltType, false);
+    if (ierr != 0)
+    {
+      PyErr_SetString(PyExc_TypeError,
+                      "getRegularityMap: Error computing nfpe.");
+      for (size_t ic = 0; ic < eltTypes.size(); ic++) delete [] eltTypes[ic];
+      RELEASESHAREDS(tpl, f2);
+      RELEASESHAREDU(array, f, cn);
+      return NULL;
+    }
 
+    // Total number of elements/facets
     for (E_Int ic = 0; ic < nc; ic++)
     {
       K_FLD::FldArrayI& cm = *(cn->getConnect(ic));
       E_Int nelts = cm.getSize();
-      if (strcmp(eltTypes[ic], "BAR") == 0) nfpe[ic] = 1;
-      else if (strcmp(eltTypes[ic], "TRI") == 0) nfpe[ic] = 1;
-      else if (strcmp(eltTypes[ic], "QUAD") == 0) nfpe[ic] = 1;
-      else if (strcmp(eltTypes[ic], "TETRA") == 0) nfpe[ic] = 4;
-      else if (strcmp(eltTypes[ic], "PYRA") == 0) nfpe[ic] = 5;
-      else if (strcmp(eltTypes[ic], "PENTA") == 0) nfpe[ic] = 5;
-      else if (strcmp(eltTypes[ic], "HEXA") == 0) nfpe[ic] = 6;
-      else
-      {
-        PyErr_SetString(PyExc_TypeError,
-                        "getRegularityMap: Unknown type of BE element.");
-        for (size_t ic = 0; ic < eltTypes.size(); ic++) delete [] eltTypes[ic];
-        RELEASESHAREDS(tpl, f2);
-        RELEASESHAREDU(array, f, cn);
-        return NULL;
-      }
       ntotFacets += nfpe[ic]*nelts;
       ntotElts += nelts;
     }
 
     // Calcul de la connectivite element -> elements voisins
     std::vector<std::vector<E_Int> > cEEN(ntotElts);
-    E_Int ierr = K_CONNECT::connectEV2EENbrs(eltType, npts, *cn, cEEN);
+    ierr = K_CONNECT::connectEV2EENbrs(eltType, npts, *cn, cEEN);
     if (ierr == 0)
     {
       PyErr_SetString(PyExc_TypeError,

--- a/Cassiopee/Generator/Generator/getRegularityMap.cpp
+++ b/Cassiopee/Generator/Generator/getRegularityMap.cpp
@@ -51,16 +51,6 @@ inline E_Float ratioMax6(E_Float v, E_Float v1, E_Float v2, E_Float v3, E_Float 
   return K_FUNC::E_max(ratioMax3(v, v1, v2, v3), ratioMax3(v, v4, v5, v6));
 }
 
-extern "C"
-{
-  void k6compunstrmetric_(E_Int& npts, E_Int& nelts, E_Int& nedges, 
-                          E_Int& nnodes, E_Int* cn, 
-                          E_Float* coordx, E_Float* coordy, E_Float* coordz, 
-                          E_Float* xint, E_Float* yint, E_Float* zint, 
-                          E_Float* snx, E_Float* sny, E_Float* snz, 
-                          E_Float* surf, E_Float* vol);
-}
-
 // ============================================================================
 /* Return regularity map */
 // ============================================================================
@@ -591,265 +581,117 @@ PyObject* K_GENERATOR::getRegularityMap(PyObject* self, PyObject* args)
   }
   else // cas non structure
   {
-    E_Float etVol; E_Int eti; E_Int indi;
-    E_Int nelts = cn->getSize(); // nb d'elements
-    E_Int nnodes = cn->getNfld();
-
-    // Construction du tableau numpy stockant le ratio max de volumes entre elements voisins, 
-    // definissant la regularite
-    PyObject* tpl = K_ARRAY::buildArray3(1, "regularity", npts, *cn, eltType, 1, api, true);
-    FldArrayF* f2;
+    // Construction du tableau numpy stockant le ratio max de volumes entre
+    // elements voisins, definissant la regularite
+    PyObject* tpl = K_ARRAY::buildArray3(
+      1, "regularity", npts, *cn, eltType, 1, api, true
+    );
     K_ARRAY::getFromArray3(tpl, f2);
     E_Float* reg = f2->begin(1);
 
-    // Calcul de la connectivite vertex->elements
-    std::vector< std::vector<E_Int> > cVE(npts); 
-    K_CONNECT::connectEV2VE(*cn, cVE);
-  
-    // Rapport MAX de volumes entre un element et ses voisins. Resultat au "centre"
-    if (strcmp(eltType, "TRI") == 0)
+    if (strcmp(eltType, "NGON") == 0)
     {
-      E_Float maxratio;
-      // Calcul du volume des elements
-      FldArrayF snx(nelts);
-      FldArrayF sny(nelts);
-      FldArrayF snz(nelts);
-      FldArrayF vol(nelts);
-      FldArrayF volDummy(nelts);
-      E_Int nedges = 1;
-      //tableau local au fortran
-      FldArrayF xint(nelts,nedges);
-      FldArrayF yint(nelts,nedges);
-      FldArrayF zint(nelts,nedges);
-      //
-      k6compunstrmetric_(npts, nelts, nedges, nnodes, cn->begin(), 
-                         xp, yp, zp, xint.begin(), yint.begin(), zint.begin(),
-                         snx.begin(), sny.begin(), 
-                         snz.begin(), vol.begin(), volDummy.begin());
-      
-      // Calcul du ratio maximum 
-      // entre les volumes des elements voisins et celui de l'element courant
-      for (E_Int et = 0; et < nelts; et++)
-      {
-        etVol = vol[et];
-        maxratio = 0;
-        for (E_Int i = 0; i < nedges; i++)
-        {
-          E_Int* cni = cn->begin(i+1);
-          indi = cni[et]-1;
-          std::vector<E_Int>& cVEi = cVE[indi]; E_Int sizei = cVEi.size();
-          for (E_Int noeti = 0; noeti < sizei; noeti++)
-          {
-            eti = cVEi[noeti];
-            maxratio = K_FUNC::E_max(maxratio,K_FUNC::E_abs(vol[eti]-etVol)/K_FUNC::E_max(etVol,K_CONST::E_GEOM_CUTOFF));
-          }
-        }
-        reg[et] = maxratio;
-      }
-    }
-    else if (strcmp(eltType, "QUAD") == 0)
-    {
-      E_Float maxratio;
-      // Calcul du volume des elements
-      FldArrayF snx(nelts);
-      FldArrayF sny(nelts);
-      FldArrayF snz(nelts);
-      FldArrayF vol(nelts);
-      FldArrayF volDummy(nelts);
-      E_Int nedges = 1;
-      // tableau local au fortran
-      FldArrayF xint(nelts,nedges);
-      FldArrayF yint(nelts,nedges);
-      FldArrayF zint(nelts,nedges);
-      //
-      k6compunstrmetric_(npts, nelts, nedges, nnodes, cn->begin(), 
-                         xp, yp, zp,
-                         xint.begin(), yint.begin(), zint.begin(),
-                         snx.begin(), sny.begin(), 
-                         snz.begin(), vol.begin(), volDummy.begin());
-
-      // Calcul du ratio maximum 
-      // entre les volumes des elements voisins et celui de l'element courant
-      for (E_Int et = 0; et < nelts; et++)
-      {
-        etVol = vol[et];
-        maxratio = 0;
-        for (E_Int i = 0; i < nedges; i++)
-        {
-          E_Int* cni = cn->begin(i+1);
-          indi = cni[et]-1;
-          std::vector<E_Int>& cVEi = cVE[indi]; E_Int sizei = cVEi.size();
-          for (E_Int noeti = 0; noeti < sizei; noeti++)
-          {
-            eti = cVEi[noeti];
-            maxratio = K_FUNC::E_max(maxratio,K_FUNC::E_abs(vol[eti]-etVol)/K_FUNC::E_max(etVol,K_CONST::E_GEOM_CUTOFF));
-          }
-        }
-        reg[et] = maxratio;
-      }
-   }
-    else if (strcmp(eltType, "TETRA") == 0)
-    {
-      E_Int nedges = 4;
-      E_Float maxratio;
-      // Calcul du volume des elements
-      FldArrayF snx(nelts, nedges);
-      FldArrayF sny(nelts, nedges);
-      FldArrayF snz(nelts, nedges);
-      FldArrayF surf(nelts, nedges);
-      FldArrayF vol(nelts);
-      //tableau local au fortran
-      FldArrayF xint(nelts,nedges);
-      FldArrayF yint(nelts,nedges);
-      FldArrayF zint(nelts,nedges);
-      //
-      k6compunstrmetric_(npts, nelts, nedges, nnodes, cn->begin(), 
-                         xp, yp, zp,
-                         xint.begin(), yint.begin(), zint.begin(),
-                         snx.begin(), sny.begin(), 
-                         snz.begin(), surf.begin(), vol.begin());
-      
-      // Calcul du ratio maximum 
-      // entre les volumes des elements voisins et celui de l'element courant
-      for (E_Int et = 0; et < nelts; et++)
-      {
-        etVol = vol[et];
-        maxratio = 0;
-        for (E_Int i = 0; i < nedges; i++)
-        {
-          E_Int* cni = cn->begin(i+1);
-          indi = cni[et]-1;
-          std::vector<E_Int>& cVEi = cVE[indi]; E_Int sizei = cVEi.size();
-          for (E_Int noeti = 0; noeti < sizei; noeti++)
-          {
-            eti = cVEi[noeti];
-            maxratio = K_FUNC::E_max(maxratio,K_FUNC::E_abs(vol[eti]-etVol)/K_FUNC::E_max(etVol,K_CONST::E_GEOM_CUTOFF));
-          }
-        }
-        reg[et] = maxratio;
-      }
-    }
-    else if (strcmp(eltType, "PYRA") == 0)
-    {
-      // volume computation not implemented for PYRA
       PyErr_SetString(PyExc_TypeError,
-                      "getRegularityMap: not yet implemented for PYRA.");
+                      "getRegularityMap: not implemented for NGON arrays.");
       RELEASESHAREDS(tpl, f2);
-      RELEASESHAREDU(array, f, cn); 
+      RELEASESHAREDU(array, f, cn);
       return NULL;
     }
-    else if (strcmp(eltType, "PENTA") == 0)
-    {
-      E_Int nedges = 5;
-      E_Float maxratio;
 
-      // Calcul du volume des elements
-      FldArrayF snx(nelts, nedges);
-      FldArrayF sny(nelts, nedges);
-      FldArrayF snz(nelts, nedges);
-      FldArrayF surf(nelts, nedges);
-      FldArrayF vol(nelts);
-      //tableau local au fortran
-      FldArrayF xint(nelts,nedges);
-      FldArrayF yint(nelts,nedges);
-      FldArrayF zint(nelts,nedges);
-      //
-      k6compunstrmetric_(npts, nelts, nedges, nnodes, cn->begin(), 
-                         xp, yp, zp,
-                         xint.begin(), yint.begin(), zint.begin(),
-                         snx.begin(), sny.begin(), 
-                         snz.begin(), surf.begin(), vol.begin());
+    // Pre-compute total number of elements and facets
+    E_Int nc = cn->getNConnect();
+    std::vector<char*> eltTypes;
+    K_ARRAY::extractVars(eltType, eltTypes);
 
-      // Calcul du ratio maximum 
-      // entre les volumes des elements voisins et celui de l'element courant
-      for (E_Int et = 0; et < nelts; et++)
-      {
-        etVol = vol[et];
-        maxratio = 0;
-        for (E_Int i = 0; i < nedges; i++)
-        {
-          E_Int* cni = cn->begin(i+1);
-          indi = cni[et]-1;
-          std::vector<E_Int>& cVEi = cVE[indi]; E_Int sizei = cVEi.size();
-          for (E_Int noeti = 0; noeti < sizei; noeti++)
-          {
-            eti = cVEi[noeti];
-            maxratio = K_FUNC::E_max(maxratio,K_FUNC::E_abs(vol[eti]-etVol)/K_FUNC::E_max(etVol,K_CONST::E_GEOM_CUTOFF));
-          }
-        }
-        reg[et] = maxratio;
-      }
-   }
-    else if (strcmp(eltType, "HEXA") == 0)
+    E_Int ntotFacets = 0, ntotElts = 0;
+    std::vector<E_Int> nfpe(nc);  // number of facets per element
+
+    for (E_Int ic = 0; ic < nc; ic++)
     {
-      E_Int nedges = 6;
-      E_Float maxratio;
-      // Calcul du volume des elements
-      FldArrayF snx(nelts, nedges);
-      FldArrayF sny(nelts, nedges);
-      FldArrayF snz(nelts, nedges);
-      FldArrayF surf(nelts, nedges);
-      FldArrayF vol(nelts);
-      //tableau local au fortran
-      FldArrayF xint(nelts,nedges);
-      FldArrayF yint(nelts,nedges);
-      FldArrayF zint(nelts,nedges);
-      //
-      k6compunstrmetric_(npts, nelts, nedges, nnodes, cn->begin(), 
-                         xp, yp, zp,
-                         xint.begin(), yint.begin(), zint.begin(),
-                         snx.begin(), sny.begin(), 
-                         snz.begin(), surf.begin(), vol.begin());
-      
-      // Calcul du ratio maximum 
-      // entre les volumes des elements voisins et celui de l'element courant
-      for (E_Int et = 0; et < nelts; et++)
+      K_FLD::FldArrayI& cm = *(cn->getConnect(ic));
+      E_Int nelts = cm.getSize();
+      if (strcmp(eltTypes[ic], "BAR") == 0) nfpe[ic] = 1;
+      else if (strcmp(eltTypes[ic], "TRI") == 0) nfpe[ic] = 1;
+      else if (strcmp(eltTypes[ic], "QUAD") == 0) nfpe[ic] = 1;
+      else if (strcmp(eltTypes[ic], "TETRA") == 0) nfpe[ic] = 4;
+      else if (strcmp(eltTypes[ic], "PYRA") == 0) nfpe[ic] = 5;
+      else if (strcmp(eltTypes[ic], "PENTA") == 0) nfpe[ic] = 5;
+      else if (strcmp(eltTypes[ic], "HEXA") == 0) nfpe[ic] = 6;
+      else
       {
-        etVol = vol[et];
-        maxratio = 0;
-        for (E_Int i = 0; i < nedges; i++)
-        {
-          E_Int* cni = cn->begin(i+1);
-          indi = cni[et]-1;
-          std::vector<E_Int>& cVEi = cVE[indi]; E_Int sizei = cVEi.size();
-          for (E_Int noeti = 0; noeti < sizei; noeti++)
-          {
-            eti = cVEi[noeti];
-            maxratio = K_FUNC::E_max(maxratio,K_FUNC::E_abs(vol[eti]-etVol)/K_FUNC::E_max(etVol,K_CONST::E_GEOM_CUTOFF));
-          }
-        }
-        reg[et] = maxratio;
-      }
-    }
-    else if (strcmp(eltType, "BAR") == 0)
-    {
-      // Calcul du volume des elements
-      E_Int* cn1 = cn->begin(1);
-      E_Int* cn2 = cn->begin(2);
-      FldArrayF vol(nelts);
-      E_Int ind1, ind2;
-      E_Float dx, dy, dz;
-      for (E_Int i = 0; i < nelts; i++)
-      {
-        ind1 = cn1[i]-1; 
-        ind2 = cn2[i]-1;
-        dx = xp[ind2]-xp[ind1];
-        dy = yp[ind2]-yp[ind1];
-        dz = zp[ind2]-zp[ind1];
-        vol[i] = sqrt(dx*dx + dy*dy + dz*dz);
-      } 
-    }
-    else
-    {
         PyErr_SetString(PyExc_TypeError,
-                        "getRegularityMap: unknown type of element.");
+                        "getRegularityMap: Unknown type of BE element.");
+        for (size_t ic = 0; ic < eltTypes.size(); ic++) delete [] eltTypes[ic];
         RELEASESHAREDS(tpl, f2);
         RELEASESHAREDU(array, f, cn);
         return NULL;
+      }
+      ntotFacets += nfpe[ic]*nelts;
+      ntotElts += nelts;
     }
+
+    // Calcul de la connectivite element -> elements voisins
+    std::vector<std::vector<E_Int> > cEEN(ntotElts);
+    E_Int ierr = K_CONNECT::connectEV2EENbrs(eltType, npts, *cn, cEEN);
+    if (ierr == 0)
+    {
+      PyErr_SetString(PyExc_TypeError,
+                      "getRegularityMap: Error computing cEEN.");
+      for (size_t ic = 0; ic < eltTypes.size(); ic++) delete [] eltTypes[ic];
+      RELEASESHAREDS(tpl, f2);
+      RELEASESHAREDU(array, f, cn);
+      return NULL;
+    }
+
+    // Get dimensionality
+    E_Int dim = K_CONNECT::getDimME(eltType);
     
+    K_FLD::FldArrayF snx(ntotFacets), sny(ntotFacets), snz(ntotFacets);
+    K_FLD::FldArrayF surf(ntotFacets);
+    K_FLD::FldArrayF vol(ntotElts);
+
+    if (dim == 3)
+    {
+      K_METRIC::compMetricUnstruct(
+        *cn, eltType, xp, yp, zp,
+        snx.begin(), sny.begin(), snz.begin(), surf.begin(), vol.begin()
+      );
+    }
+    else // 1D/2D
+    {
+      K_METRIC::compSurfUnstruct(
+        *cn, eltType, xp, yp, zp,
+        snx.begin(), sny.begin(), snz.begin(), vol.begin()
+      );
+    }
+
+    // Calcul du ratio maximum 
+    // entre les volumes des elements voisins et celui de l'element courant
+    #pragma omp parallel
+    {
+      E_Int nneis, inei;
+      E_Float maxr, voli;
+
+      #pragma omp for
+      for (E_Int i = 0; i < ntotElts; i++)
+      {
+        maxr = 0.;
+        voli = vol[i];
+        // Loop over neighbouring elements
+        const std::vector<E_Int>& cEENi = cEEN[i];
+        nneis = cEENi.size(); // number of neighboring cells
+        for (E_Int n = 0; n < nneis; n++)
+        {
+          inei = cEENi[n]; // neighbor index
+          maxr = K_FUNC::E_max(maxr, ratioMax1(voli, vol[inei]));
+        }
+        reg[i] = maxr;
+      }
+    }     
+
+    for (size_t ic = 0; ic < eltTypes.size(); ic++) delete [] eltTypes[ic];
     RELEASESHAREDS(tpl, f2);
-    RELEASESHAREDU(array, f, cn); 
+    RELEASESHAREDU(array, f, cn);
     return tpl;
   }
 }

--- a/Cassiopee/Generator/test/getRegularityMapPT_t2.py
+++ b/Cassiopee/Generator/test/getRegularityMapPT_t2.py
@@ -1,0 +1,84 @@
+# - getRegularityMap (pyTree) -
+import Generator.PyTree as G
+import Converter.PyTree as C
+import Geom.PyTree as D
+import KCore.test as test
+
+# --- BE ---
+# 1D unstructured bar
+a = D.line((0,0,0), (1,0,0), 11)
+a = C.convertArray2Tetra(a)
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getRegularityMap(a)
+test.testT(t, 1)
+
+# 2D unstructured tri
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,1), (10,10,1))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getRegularityMap(a)
+test.testT(t, 2)
+
+# 2D unstructured quad
+a = G.cartHexa((0.,0.,0.), (0.1,0.1,1), (10,10,1))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getRegularityMap(a)
+test.testT(t, 3)
+
+# 3D unstructured hexa
+a = G.cartHexa((0.,0.,0.), (0.1,0.1,0.1), (10,10,10))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getRegularityMap(a)
+test.testT(t, 4)
+
+# 3D unstructured tetra
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,0.1), (10,10,10))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getRegularityMap(a)
+test.testT(t, 5)
+
+# 3D unstructured pyra
+a = G.cartPyra((0.,0.,0.), (0.1,0.1,0.1), (10,10,10))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getRegularityMap(a)
+test.testT(t, 6)
+
+# 3D unstructured penta
+a = G.cartPenta((0.,0.,0.), (0.1,0.1,0.1), (10,10,10))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getRegularityMap(a)
+test.testT(t, 7)
+
+# --- ME ---
+# 1D unstructured ME
+a = G.cartHexa((0.,0.,0.), (0.1,0.0,0.0), (5,1,1))
+b = G.cartHexa((0.4,0.,0.), (0.0,0.1,0.0), (1,11,1))
+c = G.cartHexa((0.4,1.,0.), (0.1,0.0,0.), (4,1,1))
+d = G.cartHexa((0.7,1.,0.), (0.1,0.1,0.05), (1,1,12))
+a = C.mergeConnectivity([a, b, c, d], None)
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getRegularityMap(a)
+test.testT(t, 8)
+
+# 2D unstructured ME: tri-quad-tri
+#                          |
+#                         tri
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,0.2), (5,10,1))
+b = G.cartHexa((0.4,0.,0.), (0.1,0.1,0.2), (5,10,1))
+c = G.cartTetra((0.8,0.,0.), (0.1,0.1,0.2), (5,10,1))
+d = G.cartTetra((0.4,-0.9,0.), (0.1,0.1,0.2), (5,10,1))
+a = C.mergeConnectivity([a, b, c, d], None)
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getRegularityMap(a)
+test.testT(t, 9)
+
+# 3D unstructured ME: tetra   pyra
+#                              |
+#                     penta - hexa
+a = G.cartTetra((-0.05,0.45,0.05), (0.1,0.1,0.1), (5,5,5))
+b = G.cartPyra((0.4,0.4,0.), (0.1,0.1,0.1), (5,5,5))
+c = G.cartPenta((0.,0.,0.), (0.1,0.1,0.1), (5,5,5))
+d = G.cartHexa((0.4,0.,0.), (0.1,0.1,0.1), (5,5,5))
+a = C.mergeConnectivity([a, b, c, d], None)
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getRegularityMap(a)
+test.testT(t, 10)

--- a/Cassiopee/Generator/test/getRegularityMapPT_t3.py
+++ b/Cassiopee/Generator/test/getRegularityMapPT_t3.py
@@ -1,0 +1,28 @@
+# - getRegularityMap (pyTree) -
+import Generator.PyTree as G
+import Converter.PyTree as C
+import Geom.PyTree as D
+import Transform.PyTree as T
+import KCore.test as test
+
+h = 0.2 # minimum spacing
+r = 1.1 # 10% stretching
+
+# TEST 1D BAR with constant stretching
+a = [(0.+h*r**i,0.,0.) for i in range(10)]
+a = D.polyline(a)
+a = C.convertArray2Hexa(a)
+G._getRegularityMap(a)
+test.testT(a, 1)
+
+# Test 2D QUAD with constant stretching
+a = G.cartRx3((-1,-1,0), (1,1,0), (h,h,1), (-5,-5,0), (5,5,0), (r,r,1), dim=2)
+a = C.convertArray2Hexa(a)
+G._getRegularityMap(a)
+test.testT(a, 2)
+
+# Test 3D HEXA with constant stretching
+a = G.cartRx3((-1,-1,-1), (1,1,1), (h,h,h), (-5,-5,-5), (5,5,5), (r,r,r), dim=3)
+a = C.convertArray2Hexa(a)
+G._getRegularityMap(a)
+test.testT(a, 3)

--- a/Cassiopee/KCore/KCore/Connect/getNFPE.cpp
+++ b/Cassiopee/KCore/KCore/Connect/getNFPE.cpp
@@ -45,7 +45,8 @@ E_Int K_CONNECT::getNFPE(
         K_STRING::cmp(eltTypeConn, "BAR*") == 0)
     {
       if (expandToLowerDim) nfpe[ic] = 2;
-      else nfpe[ic] = 0;
+      else nfpe[ic] = 1; // having nfpe = 0 would prevent the computation of 
+      // fctOffset within various unstructured functions of the code that support ME.
     }
     else if (K_STRING::cmp(eltTypeConn, "TRI") == 0 ||
              K_STRING::cmp(eltTypeConn, "TRI*") == 0)


### PR DESCRIPTION
No regression.
I've added two new test-cases: getRegularityMapPT_t2.py (test all BE/ME possibilites) and getRegularityMapPT_t3.py (test QUAD/HEXA mesh with constant stretching).

NB: This was the last call of k6compunstrmetric (from CompUnstrMetricF.for). The Fortran file will be deleted in a separate PR!