### PR TITLE
Generator: bug fix getVolumeMap for gcc compiler

### DIFF
--- a/Cassiopee/Generator/Generator/getVolumeMap.cpp
+++ b/Cassiopee/Generator/Generator/getVolumeMap.cpp
@@ -120,7 +120,7 @@ PyObject* K_GENERATOR::getVolumeMapOfMesh(PyObject* self, PyObject* args)
     RELEASESHAREDS(array, f);
     return tpl;
   }
-  else if (res == 2) // cas non-structure
+  else // cas non-structure
   {
     // Build array contenant le volume des elements au centre des elements
     tpl = K_ARRAY::buildArray3(


### PR DESCRIPTION
getVolumeMapOfMesh returns a pyObject. While icc (juno) doesn't mind having a chain of if/else if statements without a final else, gcc (juno_coda) returns an error that prevents Generator module from installing correctly.