### PR TITLE
Converter: getBCNodesFrom Name/Type/NameAndType, improve C._initBCDataSet

### DIFF
--- a/Cassiopee/CPlot/apps/tkBC.py
+++ b/Cassiopee/CPlot/apps/tkBC.py
@@ -121,7 +121,7 @@ def updateFamilyBCNameList2_2(event=None):
 # Pour set BC
 def updateFamilyBCNameList3(event=None):
     if CTK.t == []: return
-    varsl = C.getFamilyBCNamesOfType(CTK.t)
+    varsl = Internal.getFamilyBCNamesOfType(CTK.t)
     m = WIDGETS['BCs2'].children['menu']
     m.delete(0, TK.END)
     varsp = Internal.KNOWNBCS[:]
@@ -131,7 +131,7 @@ def updateFamilyBCNameList3(event=None):
 
 def updateFamilyBCNameList3_2(event=None):
     if CTK.t == []: return
-    varsl = C.getFamilyBCNamesOfType(CTK.t)
+    varsl = Internal.getFamilyBCNamesOfType(CTK.t)
     varsp = Internal.KNOWNBCS[:]
     if len(varsl) != 0:
         varsl.sort(key=str.lower)
@@ -142,7 +142,7 @@ def updateFamilyBCNameList3_2(event=None):
 # Pour fillEmptyBC
 def updateFamilyBCNameList4(event=None):
     if CTK.t == []: return
-    varsl = C.getFamilyBCNamesOfType(CTK.t)
+    varsl = Internal.getFamilyBCNamesOfType(CTK.t)
     m = WIDGETS['BCs4'].children['menu']
     m.delete(0, TK.END)
     varsp = Internal.KNOWNBCS[:]
@@ -152,7 +152,7 @@ def updateFamilyBCNameList4(event=None):
 
 def updateFamilyBCNameList4_2(event=None):
     if CTK.t == []: return
-    varsl = C.getFamilyBCNamesOfType(CTK.t)
+    varsl = Internal.getFamilyBCNamesOfType(CTK.t)
     varsp = Internal.KNOWNBCS[:]
     if len(varsl) != 0:
         varsl.sort(key=str.lower)

--- a/Cassiopee/Connector/Connector/DoubleWall.py
+++ b/Cassiopee/Connector/Connector/DoubleWall.py
@@ -30,7 +30,7 @@ def getBCWallRanges__(z, familyNames=[]):
             walls.append([i1,i2,j1,j2,k1,k2])
         elif v == 'FamilySpecified':
             for fname in familyNames:
-                nodes = C.getFamilyBCs(z, fname)
+                nodes = Internal.getFamilyBCs(z, fname)
                 for fambc in nodes:
                     range0 = Internal.getNodeFromName1(fambc, 'PointRange')
                     r = Internal.range2Window(range0[1])
@@ -231,9 +231,9 @@ def extractDoubleWallInfo__(t):
     wallBndIndicesN = [] # indices des parois
     # 1. Extraction des surfaces paroi et indices correspondants
     # liste des familles "paroi"
-    famwalls = C.getFamilyBCNamesOfType(t, 'BCWall')
-    famwalls += C.getFamilyBCNamesOfType(t, 'BCWallViscous')
-    famwalls += C.getFamilyBCNamesOfType(t, 'BCWallInviscid')
+    famwalls = Internal.getFamilyBCNamesOfType(t, 'BCWall')
+    famwalls += Internal.getFamilyBCNamesOfType(t, 'BCWallViscous')
+    famwalls += Internal.getFamilyBCNamesOfType(t, 'BCWallInviscid')
     for base1 in bases:
         firstCentersb = [] # liste des surfaces de la base
         wallsb = []

--- a/Cassiopee/Connector/Connector/OversetDataDtlocal.py
+++ b/Cassiopee/Connector/Connector/OversetDataDtlocal.py
@@ -140,9 +140,9 @@ def setInterpData3(tR, tD, double_wall=0, order=2, penalty=1, nature=0,
 
         # Zones receveuses : on determine les 1ers points paroi (centres ou noeuds)
         # recup des familles de type paroi dans les zones receveuses
-        famwallsR = C.getFamilyBCNamesOfType(ttreeR, 'BCWall')
-        famwallsR += C.getFamilyBCNamesOfType(ttreeR, 'BCWallViscous')
-        famwallsR += C.getFamilyBCNamesOfType(ttreeR, 'BCWallInviscid')
+        famwallsR = Internal.getFamilyBCNamesOfType(ttreeR, 'BCWall')
+        famwallsR += Internal.getFamilyBCNamesOfType(ttreeR, 'BCWallViscous')
+        famwallsR += Internal.getFamilyBCNamesOfType(ttreeR, 'BCWallInviscid')
 
         # interpWallPts : selon la loc, on recupere les premiers centres ou noeuds
         for zr in zonesRcv:

--- a/Cassiopee/Connector/Connector/PyTree.py
+++ b/Cassiopee/Connector/Connector/PyTree.py
@@ -1989,10 +1989,10 @@ def _doubleWall(t, tc, familyBC1, familyBC2, ghostCells=False, check=False, surf
     for b in Internal.getBases(t):
         for z in Internal.getZones(b):
             for f1 in familyBC1:
-                wall1 = C.getFamilyBCs(z, f1)
+                wall1 = Internal.getFamilyBCs(z, f1)
                 for w in wall1: listOfMismatch1.append(b[0]+'/'+z[0]+'/'+w[0])
             for f2 in familyBC2:
-                wall2 = C.getFamilyBCs(z, f2)
+                wall2 = Internal.getFamilyBCs(z, f2)
                 for w in wall2: listOfMismatch2.append(b[0]+'/'+z[0]+'/'+w[0])
 
     # project interpolated points (cellN=2) from listOfMismatch2 onto listOfMismatch1
@@ -2013,7 +2013,7 @@ def initDoubleWall(t, familyBC1, check=False):
     for b in Internal.getBases(t):
         for z in Internal.getZones(b):
             for f1 in familyBC1:
-                wall1 = C.getFamilyBCs(z, f1)
+                wall1 = Internal.getFamilyBCs(z, f1)
                 for w in wall1: listOfMismatch1.append(b[0]+'/'+z[0]+'/'+w[0])
 
     return DoubleWall.getProjSurfaceForDoubleWall(t, listOfMismatch1, '_'.join(familyBC1), check)

--- a/Cassiopee/Converter/Converter/Filter.py
+++ b/Cassiopee/Converter/Converter/Filter.py
@@ -109,12 +109,12 @@ def readZoneHeaders(fileName, format=None, baseNames=None, familyZoneNames=None,
                         if Internal.getValue(f) == fz:
                             znp.append('/'+b[0]+'/'+z[0])
     elif BCType is not None:
-        families = PyTree.getFamilyBCNamesOfType(a, BCType)
+        families = Internal.getFamilyBCNamesOfType(a, BCType)
         s = BCType.split(':',1)
         if len(s) == 2: families.append(s[1])
         if BCType == 'BCWall':
-            families1 = PyTree.getFamilyBCNamesOfType(a, 'BCWallInviscid')
-            families2 = PyTree.getFamilyBCNamesOfType(a, 'BCWallViscous*')
+            families1 = Internal.getFamilyBCNamesOfType(a, 'BCWallInviscid')
+            families2 = Internal.getFamilyBCNamesOfType(a, 'BCWallViscous*')
             families += families1
             families += families2
         znp = []
@@ -125,7 +125,7 @@ def readZoneHeaders(fileName, format=None, baseNames=None, familyZoneNames=None,
                 path = '/'+b[0]+'/'+z[0]
                 _readPyTreeFromPaths(a, fileName, path+'/ZoneBC', format)
                 nodes = Internal.getNodesFromValue(z, BCType)
-                nodes += PyTree.getFamilyBCs(z, families)
+                nodes += Internal.getFamilyBCs(z, families)
                 #_convert2SkeletonTree(z)
                 if nodes != []: znp.append(path)
     else:

--- a/Cassiopee/Converter/Converter/Internal.py
+++ b/Cassiopee/Converter/Converter/Internal.py
@@ -62,7 +62,7 @@ VARNAME2CGNS = {
 
 # Known CGNS BC types
 KNOWNBCS = [
-    'BCWall', 'BCWallInviscid','BCWallViscous', 'BCWallViscousIsothermal',
+    'BCWall', 'BCWallInviscid', 'BCWallViscous', 'BCWallViscousIsothermal',
     'BCFarfield', 'BCExtrapolate',
     'BCInflow', 'BCInflowSubsonic', 'BCInflowSupersonic',
     'BCOutflow', 'BCOutflowSubsonic', 'BCOutflowSupersonic',
@@ -3848,6 +3848,152 @@ def _correctBaseZonesDim(t, splitBases=False):
 #==============================================================================
 # -- BC management --
 #==============================================================================
+
+# -- getFamilyBCs (wildcards possible on familyName)
+def getFamilyBCs(t, familyName):
+  """Return all BC nodes that have this familyName.
+  Usage: getFamilyBCs(t, familyName)"""
+  out = []
+  if isinstance(familyName, str): families = [familyName]
+  else: families = familyName
+  for z in getZones(t):
+    nodes = getNodesFromType2(z, 'BC_t')
+    nodes += getNodesFromType2(z, 'GridConnectivity_t')
+    nodes += getNodesFromType2(z, 'GridConnectivity1to1_t')
+    for n in nodes:
+      res = getNodesFromType1(n, 'FamilyName_t')
+      for i in res:
+        val = getValue(i)
+        val = val.strip()
+        for f in families:
+          if any(c in f for c in ['*', '?', '!', '[']):
+            if fnmatch.fnmatch(val, f): out.append(n)
+          elif val == f: out.append(n)
+  return out
+
+# -- getFamilyBCNamesOfType (wildcards possible on bndType)
+def getFamilyBCNamesOfType(t, bndType=None):
+  """Return the family BC names of a given type.
+  Usage: names = getFamilyBCNamesOfType(t, 'BCWall')"""
+  out = set()
+  nodes = getNodesFromType2(t, 'Family_t')
+  if bndType is None:
+    for n in nodes:
+      p = getNodeFromType1(n, 'FamilyBC_t')
+      if p is not None: out.add(n[0])
+  else:
+    for n in nodes:
+      p = getNodeFromType1(n, 'FamilyBC_t')
+      if p is not None:
+        if isValue(p, bndType): out.add(n[0])
+  return list(out)
+
+# -- getBCNodesFromName
+def getBCNodesFromName(t, bndName=None):
+  """Return all BC nodes matching an input list of BC names. Wildcards are
+  accepted. If bndName is None, return all BC nodes (no filter).
+  """
+  bcs = []
+  zones = getZones(t)
+  if zones == []: zones = [t]  # must be a BC node
+  if bndName is None:
+    for z in zones:
+      bcs.extend(getNodesFromType2(z, 'BC_t'))
+    return bcs
+  if isinstance(bndName, list): bndList = bndName
+  else: bndList = [bndName]
+
+  for z in zones:
+    nodes = getNodesFromType2(z, 'BC_t')
+    for n in nodes:
+      name = getName(n)
+      for bnd in bndList:
+        if any(c in bnd for c in ['*', '?', '!', '[']):
+          if fnmatch.fnmatch(name, bnd): bcs.append(n); break
+        elif name == bnd: bcs.append(n); break
+  return bcs
+
+# -- getBCNodesFromType
+def getBCNodesFromType(t, bndType=None):
+  """Return all BC nodes matching an input list of BC types. Wildcards are
+  accepted. If bndType is None, return all BC nodes (no filter).
+  """
+  bcs = []
+  zones = getZones(t)
+  if zones == []: zones = [t]  # must be a BC node
+  if bndType is None:
+    for z in zones:
+      bcs.extend(getNodesFromType2(z, 'BC_t'))
+    return bcs
+  elif isinstance(bndType, list): bndList = bndType
+  else: bndList = [bndType]
+
+  familyNames = []
+  for bnd in bndList: familyNames.extend(getFamilyBCNamesOfType(t, bnd))
+
+  for z in zones:
+    nodes = getNodesFromType2(z, 'BC_t')
+    for n in nodes:
+      val = getValue(n)
+      if val == 'FamilySpecified':
+        fname = getNodeFromType1(n, 'FamilyName_t')
+        fname = getValue(fname)
+        if fname in familyNames: bcs.append(n)
+      else:
+        for bnd in bndList:
+          if any(c in bnd for c in ['*', '?', '!', '[']):
+            if fnmatch.fnmatch(val, bnd): bcs.append(n); break
+          elif val == bnd: bcs.append(n); break
+  return bcs
+
+# -- getBCNodesFromNameAndType
+def getBCNodesFromNameAndType(t, bndName=None, bndType=None):
+  """Return all BC nodes matching an input list of BC names and BC types.
+  Wildcards are accepted. If bndName and bndType are None, return all BC nodes
+  (no filter).
+  """
+  bcs = []
+  zones = getZones(t)
+  if zones == []: zones = [t]  # must be a BC node
+  if bndName is None and bndType is None:
+    for z in zones:
+      bcs.extend(getNodesFromType2(z, 'BC_t'))
+    return bcs
+  elif bndName is None:
+    return getBCNodesFromType(t, bndType=bndType)
+  elif bndType is None:
+    return getBCNodesFromName(t, bndName=bndName)
+  else:
+    if isinstance(bndName, list): bndNameList = bndName
+    else: bndNameList = [bndName]
+    if isinstance(bndType, list): bndTypeList = bndType
+    else: bndTypeList = [bndType]
+
+    familyNames = []
+    for bnd in bndTypeList: familyNames.extend(getFamilyBCNamesOfType(t, bnd))
+
+    for z in zones:
+      nodes = getNodesFromType2(z, 'BC_t')
+      for n in nodes:
+        name = getName(n)
+        isNameMatching = False
+        for bnd in bndNameList:
+          if any(c in bnd for c in ['*', '?', '!', '[']):
+            if fnmatch.fnmatch(name, bnd): isNameMatching = True; break
+          elif name == bnd: isNameMatching = True; break
+        if not isNameMatching: continue
+
+        val = getValue(n)
+        if val == 'FamilySpecified':
+          fname = getNodeFromType1(n, 'FamilyName_t')
+          fname = getValue(fname)
+          if fname in familyNames: bcs.append(n)
+        else:
+          for bnd in bndTypeList:
+            if any(c in bnd for c in ['*', '?', '!', '[']):
+              if fnmatch.fnmatch(val, bnd): bcs.append(n); break
+            elif val == bnd: bcs.append(n); break
+    return bcs
 
 # -- Add one layer to BCs. dir=1,2,3 (strctured zones)
 def addOneLayer2BC(t, dir, N=1):

--- a/Cassiopee/Converter/Converter/PyTree.py
+++ b/Cassiopee/Converter/Converter/PyTree.py
@@ -2793,30 +2793,27 @@ def _nullifyBCDataSetVectors(t, bndType, loc='FaceCenter',
         locI = 0; FSCont = Internal.__FlowSolutionNodes__
 
     zones = Internal.getZones(t)
-    families = getFamilyBCNamesOfType(t, bndType)
+    families = Internal.getFamilyBCNamesOfType(t, bndType)
     for z in zones:
         dimZ = Internal.getZoneDim(z)
         niZ = dimZ[1]; njZ = dimZ[2]; nkZ = dimZ[3]
         allbcs = Internal.getNodesFromType2(z, 'BC_t')
         bcs = Internal.getNodesFromValue(allbcs, bndType)
-        bcs += getFamilyBCs(z, families)    # CW : plutot allbcs ??
+        bcs += Internal.getFamilyBCs(z, families)    # CW : plutot allbcs ??
         for bc in bcs:
             PR = Internal.getNodeFromName1(bc, 'PointRange')
             PL = Internal.getNodeFromName1(bc, 'PointList')
             np = 0
             if PR is not None:
-                win =  Internal.range2Window(PR[1])
-                imin = win[0]; imax = win[1]
-                jmin = win[2]; jmax = win[3]
-                kmin = win[4]; kmax = win[5]
+                imin, imax, jmin, jmax, kmin, kmax = Internal.range2Window(PR[1])
                 if locI == 0:
-                    di = max(1,imax-imin+1)
-                    dj = max(1,jmax-jmin+1)
-                    dk = max(1,kmax-kmin+1)
+                    di = max(1, imax-imin+1)
+                    dj = max(1, jmax-jmin+1)
+                    dk = max(1, kmax-kmin+1)
                 else:
-                    di = max(1,imax-imin)
-                    dj = max(1,jmax-jmin)
-                    dk = max(1,kmax-kmin)
+                    di = max(1, imax-imin)
+                    dj = max(1, jmax-jmin)
+                    dk = max(1, kmax-kmin)
                 np = di*dj*dk
             elif PL is not None:
                 np = PL[1].size
@@ -2830,14 +2827,17 @@ def _nullifyBCDataSetVectors(t, bndType, loc='FaceCenter',
                 d = Internal.newBCData('BCDirichlet', parent=d)
                 cont, noc = Internal.getParentOfNode(z, d)
                 for vect in vectors:
-                    vxname = vect[0]; fxInt = numpy.zeros((np),numpy.float64)
-                    vyname = vect[1]; fyInt = numpy.zeros((np),numpy.float64)
-                    vzname = vect[2]; fzInt = numpy.zeros((np),numpy.float64)
+                    vxname = vect[0]; fxInt = numpy.zeros((np), numpy.float64)
+                    vyname = vect[1]; fyInt = numpy.zeros((np), numpy.float64)
+                    vzname = vect[2]; fzInt = numpy.zeros((np), numpy.float64)
                     if PR is not None:
-                        Converter.converter.nullifyVectorAtBCFaceStruct(z, fxInt, fyInt, fzInt,
-                                                                        imin, imax, jmin, jmax, kmin, kmax, locI,
-                                                                        vxname, vyname, vzname,
-                                                                        Internal.__GridCoordinates__, Internal.__FlowSolutionNodes__,Internal.__FlowSolutionCenters__)
+                        Converter.converter.nullifyVectorAtBCFaceStruct(
+                            z, fxInt, fyInt, fzInt,
+                            imin, imax, jmin, jmax, kmin, kmax, locI,
+                            vxname, vyname, vzname,
+                            Internal.__GridCoordinates__,
+                            Internal.__FlowSolutionNodes__,Internal.__FlowSolutionCenters__
+                        )
 
                     elif PL is not None:
                         print("Warning: nullifyVectorAtBCDataSet: not implemented for PointList.")
@@ -2848,13 +2848,16 @@ def _nullifyBCDataSetVectors(t, bndType, loc='FaceCenter',
             else: # BCDataSet exists: add missing variables
                 d = Internal.getNodeFromType2(bc,'BCData_t')
                 for vect in vectors:
-                    vxname = vect[0]; fxInt = numpy.zeros((np),numpy.float64)
-                    vyname = vect[1]; fyInt = numpy.zeros((np),numpy.float64)
-                    vzname = vect[2]; fzInt = numpy.zeros((np),numpy.float64)
-                    Converter.converter.nullifyVectorAtBCFaceStruct(z, fxInt, fyInt, fzInt,
-                                                                    imin, imax, jmin, jmax, kmin, kmax, locI,
-                                                                    vxname, vyname, vzname,
-                                                                    Internal.__GridCoordinates__, Internal.__FlowSolutionNodes__,Internal.__FlowSolutionCenters__)
+                    vxname = vect[0]; fxInt = numpy.zeros((np), numpy.float64)
+                    vyname = vect[1]; fyInt = numpy.zeros((np), numpy.float64)
+                    vzname = vect[2]; fzInt = numpy.zeros((np), numpy.float64)
+                    Converter.converter.nullifyVectorAtBCFaceStruct(
+                        z, fxInt, fyInt, fzInt,
+                        imin, imax, jmin, jmax, kmin, kmax, locI,
+                        vxname, vyname, vzname,
+                        Internal.__GridCoordinates__,
+                        Internal.__FlowSolutionNodes__,Internal.__FlowSolutionCenters__
+                    )
                     Internal._createUniqueChild(d, vxname, 'DataArray_t', value=fxInt)
                     Internal._createUniqueChild(d, vyname, 'DataArray_t', value=fyInt)
                     Internal._createUniqueChild(d, vzname, 'DataArray_t', value=fzInt)
@@ -2869,13 +2872,13 @@ def _createBCDataSetOfType(t, bndType, loc='FaceCenter', update=True, vectors=[]
     else: locI = 0; FSCont = Internal.__FlowSolutionNodes__
 
     zones = Internal.getZones(t)
-    families = getFamilyBCNamesOfType(t, bndType)
+    families = Internal.getFamilyBCNamesOfType(t, bndType)
     for z in zones:
         dimZ = Internal.getZoneDim(z)
         niZ = dimZ[1]; njZ = dimZ[2]; nkZ = dimZ[3]
         allbcs = Internal.getNodesFromType2(z, 'BC_t')
         bcs = Internal.getNodesFromValue(allbcs, bndType)
-        bcs += getFamilyBCs(z, families)
+        bcs += Internal.getFamilyBCs(z, families)
         FSNode = Internal.getNodeFromName1(z, FSCont)
         varnames=[]
         for fs in FSNode[2]:
@@ -2886,9 +2889,7 @@ def _createBCDataSetOfType(t, bndType, loc='FaceCenter', update=True, vectors=[]
             np = 0
             if PR is not None:
                 win =  Internal.range2Window(PR[1])
-                imin = win[0]; imax = win[1]
-                jmin = win[2]; jmax = win[3]
-                kmin = win[4]; kmax = win[5]
+                imin, imax, jmin, jmax, kmin, kmax = win
                 if locI == 0:
                     di = max(1,imax-imin+1)
                     dj = max(1,jmax-jmin+1)
@@ -2914,8 +2915,11 @@ def _createBCDataSetOfType(t, bndType, loc='FaceCenter', update=True, vectors=[]
                         varname = fs[0]
                         fInt = numpy.zeros((np),numpy.float64)
                         if PR is not None:
-                            Converter.converter.extrapInterior2BCFaceStruct(z, fInt, imin, imax, jmin, jmax, kmin, kmax, locI, varname,
-                                                                            Internal.__GridCoordinates__, Internal.__FlowSolutionNodes__,Internal.__FlowSolutionCenters__)
+                            Converter.converter.extrapInterior2BCFaceStruct(
+                                z, fInt, imin, imax, jmin, jmax, kmin, kmax, locI, varname,
+                                Internal.__GridCoordinates__,
+                                Internal.__FlowSolutionNodes__, Internal.__FlowSolutionCenters__
+                            )
 
                         elif PL is not None:
                             print("Warning: createBCDataSetOfType: extrapolation from interior cells not implemented for PointList. Fields are initialized by O in BCDataSet.")
@@ -2927,9 +2931,12 @@ def _createBCDataSetOfType(t, bndType, loc='FaceCenter', update=True, vectors=[]
                 for dataSet in d[2]: dataSetNames.append(dataSet[0])
                 for varname in varnames:
                     if varname not in dataSetNames or update is True:
-                        fInt = numpy.zeros((np),numpy.float64)
-                        Converter.converter.extrapInterior2BCFaceStruct(z, fInt, imin, imax, jmin, jmax, kmin, kmax, locI, varname,
-                                                                        Internal.__GridCoordinates__, Internal.__FlowSolutionNodes__,Internal.__FlowSolutionCenters__)
+                        fInt = numpy.zeros((np), numpy.float64)
+                        Converter.converter.extrapInterior2BCFaceStruct(
+                            z, fInt, imin, imax, jmin, jmax, kmin, kmax, locI, varname,
+                            Internal.__GridCoordinates__,
+                            Internal.__FlowSolutionNodes__, Internal.__FlowSolutionCenters__
+                        )
                         Internal._createUniqueChild(d, varname, 'DataArray_t', value=fInt)
     if bndType == 'BCWallInviscid':
         _nullifyBCDataSetVectors(t, bndType, loc=loc, vectors=[['VelocityX','VelocityY','VelocityZ']])
@@ -2940,15 +2947,15 @@ def _createBCDataSetOfType(t, bndType, loc='FaceCenter', update=True, vectors=[]
             _nullifyBCDataSetVectors(t, bndType, loc=loc, vectors=[['VelocityX','VelocityY','VelocityZ']]+vectors)
     return None
 
-# Apply init to all BCDataSets
-def _initBCDataSet(t, varNameString, val1=None, val2=None):
+# Initialize BCDataSets of BC nodes given by their names and/or types
+def _initBCDataSet(t, varNameString, v1=None, v2=None,
+                   bndName=None, bndType=None, isVectorized=False):
     zones = Internal.getZones(t)
     if zones == []: zones = [t] # must be a BC node
     for z in zones:
-        bcs = Internal.getNodesFromType2(z, 'BC_t')
+        bcs = Internal.getBCNodesFromNameAndType(z, bndName, bndType)
         for b in bcs:
             datas = Internal.getBCDataSet(z, b)
-
             fields = []; connects = []
             for d in datas: # build array
                 np = d[1].size; ne = np-1
@@ -2966,26 +2973,22 @@ def _initBCDataSet(t, varNameString, val1=None, val2=None):
                 elif np2 is not None:
                     if np2[1].size == 6: # structured range
                         win = Internal.range2Window(np2[1])
-                        imin = win[0]; imax = win[1]
-                        jmin = win[2]; jmax = win[3]
-                        kmin = win[4]; kmax = win[5]
-                        np = max(imax-imin,1)*max(jmax-jmin,1)*max(kmax-kmin,1)
+                        imin, imax, jmin, jmax, kmin, kmax = win
+                        np = max(imax-imin, 1)*max(jmax-jmin, 1)*max(kmax-kmin, 1)
                     elif np2[1].size == 2: # element range
                         npr = np2[1].ravel("k")
                         np = npr[1] - npr[0]
                 elif np3 is not None:
                     if np3[1].size == 6: # structured range
                         win = Internal.range2Window(np3[1])
-                        imin = win[0]; imax = win[1]
-                        jmin = win[2]; jmax = win[3]
-                        kmin = win[4]; kmax = win[5]
-                        np = max(imax-imin,1)*max(jmax-jmin,1)*max(kmax-kmin,1)
+                        imin, imax, jmin, jmax, kmin, kmax = win
+                        np = max(imax-imin, 1)*max(jmax-jmin, 1)*max(kmax-kmin, 1)
                     elif np3[1].size == 2: # element range
                         npr = np3[1].ravel("k")
                         np = npr[1] - npr[0]
                 else: raise ValueError('initBCDataSet: no PointRange or PointList in BC.')
-                fields = Converter.array('empty',np,1,1)
-            fn = Converter.initVars(fields, varNameString, val1, val2)
+                fields = Converter.array('empty', np, 1, 1)
+            fn = Converter.initVars(fields, varNameString, v1, v2, isVectorized=isVectorized)
             varName = varNameString.split('=')[0]
             varName = varName.replace('{', '')
             varName = varName.replace('}', '')
@@ -2994,7 +2997,7 @@ def _initBCDataSet(t, varNameString, val1=None, val2=None):
             f = Converter.extractVars(fn, [varName])
             fieldFaceNode = Internal.createDataNode(varName, f, 0, cellDim=1)
             if datas != []:
-                cont, c = Internal.getParentOfNode(z, datas[0])
+                cont, _ = Internal.getParentOfNode(z, datas[0])
                 Internal._createUniqueChild(cont, varName, 'DataArray_t', value=fieldFaceNode[1])
             else:
                 d = Internal.newBCDataSet(name='BCDataSet', value='UserDefined',
@@ -4310,8 +4313,8 @@ def convertStringRange2Range__(wrange, z):
 
 # -- converti un BCRange en tableau de BCFaces
 def convertBCRange2BCFace__(ni, nj, nk, range0):
-    win = Internal.range2Window(range0)
-    imin, imax, jmin, jmax, kmin, kmax = win
+    imin, imax, jmin, jmax, kmin, kmax = Internal.range2Window(range0)
+
     dir = 0
     di = imax-imin; dj = jmax-jmin; dk = kmax-kmin
     if di == 0:
@@ -4511,7 +4514,7 @@ def _recoverBCs(t, BCInfo, tol=1.e-11, removeBC=True, indices=None):
                                 Internal._createUniqueChild(d, node[0], 'DataArray_t', value=val1)
                 else:  # topologic
                     #print("*"*30+BCNames[c]+"*"*30)
-                    print("b", b)
+                    #print("b", b)
                     if isinstance(b, tuple) and len(b) == 2:  # input formatted by getBC__
                         if b[0] == 'Window':
                             pointList = Converter.converter.range2PointList(*b[1], ni, nj, nk)
@@ -4570,7 +4573,8 @@ def pushBC(t1, t2, type='F', tol=1.e-12, overwriteBC=True):
                 BCType = Internal.getValue(b)
                 if BCType == 'FamilySpecified':
                     familyName = Internal.getNodeFromType1(b, 'FamilyName_t')
-                    if familyName is not None: BCType = 'FamilySpecified:%s'%Internal.getValue(familyName)
+                    if familyName is not None:
+                        BCType = 'FamilySpecified:%s'%Internal.getValue(familyName)
                 ext = extractBCOfName(z1, name)
                 if outBCC == 0:
                     n = identifyElements(KDT, ext, tol)
@@ -4628,7 +4632,7 @@ def identifyBC(t, infos, tol=1.e-12):
                                 niw = dimW[1]; njw = dimW[2]
                                 idHook = identifyNodes(globalHook, face, tol)
                                 if max(idHook) > -1:
-                                    ranges,nowins = Internal.gatherInStructPatch2D__(idHook,indirWins,niw,njw,dirf,niZ,njZ,nkZ)
+                                    ranges, nowins = Internal.gatherInStructPatch2D__(idHook, indirWins, niw, njw, dirf, niZ, njZ, nkZ)
                                     if ranges != []:
                                         nor = 0
                                         for r in ranges:
@@ -4640,24 +4644,27 @@ def identifyBC(t, infos, tol=1.e-12):
                                             if bcdata is not None: bcdata = bcdata[1]
                                             win = info[3]
                                             famName = ''
-                                            if bctype.split(':')[0] == 'FamilySpecified': famName=bctype.split(':')[1]
+                                            if bctype.split(':')[0] == 'FamilySpecified':
+                                                famName = bctype.split(':')[1]
 
                                             # Passage en noeuds des indices
-                                            istart=r[0]; iend=r[1]
-                                            jstart=r[2]; jend=r[3]
-                                            kstart=r[4]; kend=r[5]
+                                            istart, iend, jstart, jend, kstart, kend = r
                                             if istart != iend:
-                                                if iend>1: iend=min(niZ,iend+1)
+                                                if iend > 1: iend = min(niZ, iend+1)
                                             if jstart != jend:
-                                                if jend>1: jend=min(njZ,jend+1)
+                                                if jend > 1: jend = min(njZ, jend+1)
                                             if kstart != kend:
-                                                if kend>1: kend=min(nkZ,kend+1)
+                                                if kend > 1: kend = min(nkZ, kend+1)
                                             else: # cas 2D
                                                 if nkZ == 2 and kend == 1: kend = 2
                                             nor += 1
 
                                             # addBC
-                                            _addBC2Zone(z,bcname,bctype,[istart,iend,jstart,jend,kstart,kend],data=bcdata)
+                                            _addBC2Zone(
+                                                z, bcname, bctype,
+                                                [istart, iend, jstart, jend, kstart, kend],
+                                                data=bcdata
+                                            )
                                             tpp[2][nob][2][noz] = z
     Converter.freeHook(globalHook)
     tp = Internal.pyTree2Node(tpp, typen)
@@ -4885,20 +4892,20 @@ def _rmBCOfType(t, bndType):
                         (parent, d) = Internal.getParentOfNode(z, i)
                         del parent[2][d]
     else: # physical BC
-        families = getFamilyBCNamesOfType(t, bndType)
+        families = Internal.getFamilyBCNamesOfType(t, bndType)
         if bndType == 'BCWall':
-            familiesI = getFamilyBCNamesOfType(t, 'BCWallInviscid')
-            familiesV = getFamilyBCNamesOfType(t, 'BCWallViscous*')
+            familiesI = Internal.getFamilyBCNamesOfType(t, 'BCWallInviscid')
+            familiesV = Internal.getFamilyBCNamesOfType(t, 'BCWallViscous*')
         for z in zones:
             BCnodes = Internal.getNodesFromType1(z, 'ZoneBC_t')
             for n in BCnodes:
                 nodes = Internal.getNodesFromValue(n, bndType)
-                nodes += getFamilyBCs(z, families)
+                nodes += Internal.getFamilyBCs(z, families)
                 if bndType == 'BCWall':
                     nodes += Internal.getNodesFromValue(n, 'BCWallInviscid')
                     nodes += Internal.getNodesFromValue(n, 'BCWallViscous*')
-                    nodes += getFamilyBCs(z, familiesI)
-                    nodes += getFamilyBCs(z, familiesV)
+                    nodes += Internal.getFamilyBCs(z, familiesI)
+                    nodes += Internal.getFamilyBCs(z, familiesV)
                 for i in nodes:
                     (parent, d) = Internal.getParentOfNode(z, i)
                     del parent[2][d]
@@ -4925,7 +4932,7 @@ def _rmBCOfName(t, bndName):
     else: # family specified BC
         zones = Internal.getZones(t)
         for z in zones:
-            nodes = getFamilyBCs(z, names[1])
+            nodes = Internal.getFamilyBCs(z, names[1])
             for i in nodes:
                 (parent, d) = Internal.getParentOfNode(z, i)
                 del parent[2][d]
@@ -5105,7 +5112,9 @@ def getEmptyBCForNGonZone__(z, dims, pbDim, splitFactor):
         nfacesExt = indicesF.size
         nfacesDef = indicesBC.size
         if nfacesExt < nfacesDef:
-            print('Warning: zone %s: number of faces defined by BCs is greater than the number of external faces. Try to reduce the matching tolerance.'%(z[0]))
+            print('Warning: zone %s: number of faces defined by BCs is greater '
+                  'than the number of external faces. Try to reduce the '
+                  'matching tolerance.'%(z[0]))
         elif nfacesExt > nfacesDef:
             indicesBC = indicesBC.reshape( (indicesBC.size) )
             indicesE = Converter.converter.diffIndex(indicesF, indicesBC)
@@ -5325,10 +5334,10 @@ def extractBCOfType(t, bndType, topTree=None, reorder=True, extrapFlow=True,
                             extrapFlow=extrapFlow, shift=shift, method=method)
     else: # BC physiques
         if topTree is None: topTree = t
-        families = getFamilyBCNamesOfType(topTree, bndType)
+        families = Internal.getFamilyBCNamesOfType(topTree, bndType)
         if bndType == 'BCWall':
-            families1 = getFamilyBCNamesOfType(topTree, 'BCWallInviscid')
-            families2 = getFamilyBCNamesOfType(topTree, 'BCWallViscous*')
+            families1 = Internal.getFamilyBCNamesOfType(topTree, 'BCWallInviscid')
+            families2 = Internal.getFamilyBCNamesOfType(topTree, 'BCWallViscous*')
 
         for z in zones:
             nodes = []
@@ -5336,14 +5345,14 @@ def extractBCOfType(t, bndType, topTree=None, reorder=True, extrapFlow=True,
             for zbc in zbcs:
                 for i in zbc[2]:
                     if Internal.isValue(i, bndType) and i[3] == 'BC_t': nodes.append(i)
-            nodes += getFamilyBCs(z, families)
+            nodes += Internal.getFamilyBCs(z, families)
             if bndType == 'BCWall':
                 for zbc in zbcs:
                     for i in zbc[2]:
                         if (Internal.isValue(i, 'BCWallInviscid') or Internal.isValue(i, 'BCWallViscous*')) and i[3] == 'BC_t':
                             nodes.append(i)
-                nodes += getFamilyBCs(z, families1)
-                nodes += getFamilyBCs(z, families2)
+                nodes += Internal.getFamilyBCs(z, families1)
+                nodes += Internal.getFamilyBCs(z, families2)
             for i in nodes:
                 getBC__(i, z, T, res, reorder=reorder, extrapFlow=extrapFlow,
                         shift=shift, method=method)
@@ -5369,7 +5378,7 @@ def extractBCOfName(t, bndName, reorder=True, extrapFlow=True, shift=0, method="
                             extrapFlow=extrapFlow, shift=shift, method=method)
     else: # family specified BC
         for z in Internal.getZones(t):
-            nodes = getFamilyBCs(z, names[1])
+            nodes = Internal.getFamilyBCs(z, names[1])
             for i in nodes: getBC__(i, z, T, res, reorder=reorder,
                                     extrapFlow=extrapFlow, shift=shift, method=method)
     return res
@@ -5400,7 +5409,8 @@ def extractBCOfSubRegionName__(t, zsrName, reorder=True, extrapFlow=True, shift=
 # Retourne la geometrie ou la topologie de toutes les BCs
 # IN: t: une zone, une liste de zones, une base ou un arbre
 # IN: extrapFlow: extrapolate flow solution if True
-# IN: reorder: if True, extracted zones are reordered such that normals are oriented towards the interior of a
+# IN: reorder: if True, extracted zones are reordered such that normals are
+# #            oriented towards the interior of a
 # IN: method: geometric or topologic
 # OUT: BCs: liste des geometries ou topologies de bcs (a plat)
 # OUT: BCNames: liste des noms des BCs (a plat)
@@ -5489,7 +5499,7 @@ def _mergeBCs(z):
         BCNames.append(i)
         BCTypes.append(i)
 
-    _recoverBCs(z, (BCs,BCNames,BCTypes))
+    _recoverBCs(z, (BCs, BCNames, BCTypes))
     return None
 
 def isXZone(zone):
@@ -6014,9 +6024,7 @@ def extractBCFields(z, varList=None):
         else:
             PR = Internal.getNodeFromName1(bc,'PointRange')
             win = Internal.range2Window(PR[1])
-            imin = win[0]; imax = win[1]
-            jmin = win[2]; jmax = win[3]
-            kmin = win[4]; kmax = win[5]
+            imin, imax, jmin, jmax, kmin, kmax = win
             ni = dimZone[1]; nj = dimZone[2]; nk = dimZone[3]
             indicesL = Converter.converter.range2PointList(imin, imax, jmin, jmax, kmin, kmax, ni, nj, nk)
 
@@ -6239,41 +6247,13 @@ def getFamilyBCZones(t, familyBCName):
 def getFamilyBCs(t, familyName):
     """Return all BC nodes that have this familyName.
     Usage: getFamilyBCs(t, familyName)"""
-    out = []
-    if isinstance(familyName, str): families = [familyName]
-    else: families = familyName
-    for z in Internal.getZones(t):
-        nodes = Internal.getNodesFromType2(z, 'BC_t')
-        nodes += Internal.getNodesFromType2(z, 'GridConnectivity_t')
-        nodes += Internal.getNodesFromType2(z, 'GridConnectivity1to1_t')
-        for n in nodes:
-            res = Internal.getNodesFromType1(n, 'FamilyName_t')
-            for i in res:
-                val = Internal.getValue(i)
-                val = val.strip()
-                for f in families:
-                    if ('*' in f)|('?' in f)|('[' in f):
-                        if fnmatch.fnmatch(val, f): out.append(n)
-                    else:
-                        if val == f: out.append(n)
-    return out
+    return Internal.getFamilyBCs(t, familyName)
 
 # -- getFamilyBCNamesOfType (wildcards possible on bndType)
 def getFamilyBCNamesOfType(t, bndType=None):
     """Return the family BC names of a given type.
     Usage: names = getFamilyBCNamesOfType(t, 'BCWall')"""
-    out = set()
-    nodes = Internal.getNodesFromType2(t, 'Family_t')
-    if bndType is None:
-        for n in nodes:
-            p = Internal.getNodeFromType1(n, 'FamilyBC_t')
-            if p is not None: out.add(n[0])
-    else:
-        for n in nodes:
-            p = Internal.getNodeFromType1(n, 'FamilyBC_t')
-            if p is not None:
-                if Internal.isValue(p, bndType): out.add(n[0])
-    return list(out)
+    return Internal.getFamilyBCNamesOfType(t, bndType)
 
 # -- getFamilyBCNamesDict
 def getFamilyBCNamesDict(t):
@@ -8189,8 +8169,8 @@ def convertMIXED2NGon(a, recoverBC=True, merged=False):
 
                 for zbc in Internal.getZones(myZone):
                     zbc[0] = getZoneName(znamebc)
-                    Internal.createNode("BCName","UserDefinedData_t",value=b[0], parent=zbc)
-                    Internal.createNode("BCType","UserDefinedData_t",value=bctype, parent=zbc)
+                    Internal.createNode("BCName", "UserDefinedData_t", value=b[0], parent=zbc)
+                    Internal.createNode("BCType", "UserDefinedData_t", value=bctype, parent=zbc)
                     AllBCs.append(zbc)
 
     Internal._rmNodesFromType(a, 'ZoneBC_t')

--- a/Cassiopee/Converter/doc/source/Converter.rst
+++ b/Cassiopee/Converter/doc/source/Converter.rst
@@ -169,9 +169,7 @@ List of functions
     Converter.PyTree.addFamily2Base
     Converter.PyTree.tagWithFamily
     Converter.PyTree.getFamilyZones
-    Converter.PyTree.getFamilyBCs
     Converter.PyTree.getFamilyZoneNames
-    Converter.PyTree.getFamilyBCNamesOfType
     Converter.PyTree.getFamilyBCNamesDict
     Converter.PyTree.getValue
     Converter.PyTree.setValue
@@ -191,6 +189,7 @@ List of functions
     Converter.getNPts
     Converter.getNCells
     Converter.initVars
+    Converter._initBCDataSet
     Converter.extractVars
     Converter.rmVars
     Converter.convertArray2Tetra
@@ -991,7 +990,7 @@ pyTree creation and manipulation
 
 ---------------------------------------------------------------------------
 
-.. py:function:: Converter.PyTree.extractBCFields(a,varList=None)
+.. py:function:: Converter.PyTree.extractBCFields(a, varList=None)
 
     Extract fields defined at BCs of a zone *z*. If no BCDataSet is defined then a 0th-order extrapolation from interior cells is done. If a BCDataSet is defined, it has priority on the extrapolation. List of variables can be specified by the user. If not, the variables that are extracted are those defined in the FlowSolution node located at cell centers. Currently, this function works for structured and NGON zones. It returns the list of variables that could have been extracted and the indices of the face centers of the corresponding BCs.
 
@@ -1097,22 +1096,6 @@ pyTree creation and manipulation
 
 ---------------------------------------------------------------------------
 
-.. py:function:: Converter.PyTree.getFamilyBCs(a, familyName)
-
-    Get all BC nodes corresponding to a given familyName (family of BCs).
-
-    :param a: input data 
-    :type a: [pyTree, base, zone, list of zones]
-    :rtype: list of BC nodes (shared with a)
-
-    *Example of use:*
-
-    * `Get family BC nodes (pyTree) <Examples/Converter/getFamilyBCsPT.py>`_:
-
-    .. literalinclude:: ../build/Examples/Converter/getFamilyBCsPT.py
-
----------------------------------------------------------------------------
-
 .. py:function:: Converter.PyTree.getFamilyZoneNames(a)
 
     Return all family zone names defined in a. 
@@ -1126,23 +1109,6 @@ pyTree creation and manipulation
     * `Get familyZone names (pyTree) <Examples/Converter/getFamilyZoneNamesPT.py>`_:
 
     .. literalinclude:: ../build/Examples/Converter/getFamilyZoneNamesPT.py
-
----------------------------------------------------------------------------
-
-.. py:function:: Converter.PyTree.getFamilyBCNamesOfType(a, bndType=None)
-
-    Return all family BC names of a given type. If type is None, 
-    return all family BC names.
-    
-    :param a: input data 
-    :type a: [pyTree, base]
-    :rtype: list of familyBC names
-
-    *Example of use:*
-
-    * `Get familyBC names of given type (pyTree) <Examples/Converter/getFamilyBCNamesOfTypePT.py>`_:
-
-    .. literalinclude:: ../build/Examples/Converter/getFamilyBCNamesOfTypePT.py
 
 ---------------------------------------------------------------------------
 
@@ -1424,7 +1390,7 @@ Array / PyTree common manipulations
 
 -----------------------------------------------------------------------------------
 
-.. py:function:: Converter.initVars(a, varNameString, value, isVectorized=False)
+.. py:function:: Converter.initVars(a, varNameString, v1=None, v2=None, isVectorized=False)
 
     Initialize one or several variables as given by varNameString.
 
@@ -1435,12 +1401,16 @@ Array / PyTree common manipulations
 
     If the function is vectorized (can be interpreted as a numpy formula), set isVectorized to True.
 
+    Exists also as in place version (_initVars) that modifies a and returns None.
+
     :param a: input data
     :type a: [array, list of arrays] or [pyTree, base, zone, list of zones]
     :param varNameString: string describing variable or formula
     :type varNameString: string or list of strings
-    :param value: value in case of constant init or function.
-    :type value: float or function and parameters
+    :param v1: value in case of constant init or function.
+    :type v1: float or function
+    :param v2: function's arguments if v1 is a function, None otherwise
+    :type v2: list of strings
     :param isVectorized: when using functions, indicates that function is in vectorized form.
     :type isVectorized: boolean
     :rtype: identical to input
@@ -1472,6 +1442,43 @@ Array / PyTree common manipulations
     * `Init a variable with a formula (pyTree) <Examples/Converter/initVarsByEqPT.py>`_:
 
     .. literalinclude:: ../build/Examples/Converter/initVarsByEqPT.py
+
+-----------------------------------------------------------------------------------
+
+.. py:function:: Converter._initBCDataSet(t, varNameString, v1=None, v2=None, bndName=None, bndType=None, isVectorized=False)
+
+    Initialize one or several variables, as listed in varNameString, in the
+    BCDataSets of BC nodes. BC nodes can be filtered by their names and/or types
+    and wildcards are accepted.
+
+    For an initialisation by a formula string, only one variable can be set at a time.
+
+    For an initialisation by a function or a constant, varNameString can be a string
+    or a list of strings.
+
+    If the function is vectorized (can be interpreted as a numpy formula), set isVectorized to True.
+
+    :param a: input data
+    :type a: [array, list of arrays] or [pyTree, base, zone, list of zones]
+    :param varNameString: string describing variable or formula
+    :type varNameString: string or list of strings
+    :param v1: value in case of constant init or function.
+    :type v1: float or function
+    :param v2: function's arguments if v1 is a function, None otherwise
+    :type v2: list of strings
+    :param bndName: name(s) of the BC node(s) to get
+    :type bndName: string or list of strings
+    :param bndType: name(s) of the BC type(s) to get
+    :type bndType: string or list of strings
+    :param isVectorized: when using functions, indicates that function is in vectorized form.
+    :type isVectorized: boolean
+    :rtype: None
+
+    *Example of use:*
+
+    * `Init a variable to a constant value (pyTree) <Examples/Converter/initBCDataSetPT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Converter/initBCDataSetPT.py
 
 -----------------------------------------------------------------------------------
 

--- a/Cassiopee/Converter/doc/source/Internal.rst
+++ b/Cassiopee/Converter/doc/source/Internal.rst
@@ -121,6 +121,11 @@ List of functions
     Converter.Internal.getPathAncestor
     Converter.Internal.getZonePaths
 
+    Converter.Internal.getFamilyBCs
+    Converter.Internal.getFamilyBCNamesOfType
+    Converter.Internal.getBCNodesFromName
+    Converter.Internal.getBCNodesFromType
+
     Converter.Internal.getZones
     Converter.Internal.getZonesPerIteration
     Converter.Internal.getBases
@@ -1192,6 +1197,98 @@ Acess nodes
 
     .. note:: New in version 2.5
 
+---------------------------------------------------------------------------
+
+.. py:function:: Converter.Internal.getFamilyBCs(a, familyName)
+
+    Get all BC nodes corresponding to a given familyName (family of BCs).
+
+    :param a: input data 
+    :type a: [pyTree, base, zone, list of zones]
+    :rtype: list of BC nodes (shared with a)
+
+    *Example of use:*
+
+    * `Get family BC nodes (pyTree) <Examples/Converter/getFamilyBCsPT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Converter/getFamilyBCsPT.py
+
+---------------------------------------------------------------------------
+
+.. py:function:: Converter.Internal.getFamilyBCNamesOfType(a, bndType=None)
+
+    Return all family BC names of a given type. If type is None, 
+    return all family BC names.
+    
+    :param a: input data 
+    :type a: [pyTree, base]
+    :rtype: list of familyBC names
+
+    *Example of use:*
+
+    * `Get familyBC names of given type (pyTree) <Examples/Converter/getFamilyBCNamesOfTypePT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Converter/getFamilyBCNamesOfTypePT.py
+
+---------------------------------------------------------------------------
+
+.. py:function:: Converter.Internal.getBCNodesFromName(a, bndName=None)
+
+    Return all BC nodes of a given name. If name is None, return all BC nodes.
+    Wildcards are accepted.
+    
+    :param a: input data 
+    :type a: [pyTree, base, zone, list of zones, BC_t node]
+    :param bndName: name(s) of the BC node(s) to get
+    :type bndName: string or list of strings
+    :rtype: list of BC nodes (shared with a)
+
+    *Example of use:*
+
+    * `Get BC nodes of given name (pyTree) <Examples/Converter/getBCNodesFromNamePT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Converter/getBCNodesFromNamePT.py
+
+---------------------------------------------------------------------------
+
+.. py:function:: Converter.Internal.getBCNodesFromType(a, bndType=None)
+
+    Return all BC nodes of a given type. If type is None, return all BC nodes.
+    Wildcards are accepted.
+    
+    :param a: input data 
+    :type a: [pyTree, base, zone, list of zones, BC_t node]
+    :param bndType: name(s) of the BC type(s) to get
+    :type bndType: string or list of strings
+    :rtype: list of BC nodes (shared with a)
+
+    *Example of use:*
+
+    * `Get BC nodes of given type (pyTree) <Examples/Converter/getBCNodesFromTypePT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Converter/getBCNodesFromTypePT.py
+
+---------------------------------------------------------------------------
+
+.. py:function:: Converter.Internal.getBCNodesFromNameAndType(a, bndType=None, bndType=None)
+
+    Return all BC nodes of a given name and type. If name and type are noth None,
+    return all BC nodes. Wildcards are accepted.
+    
+    :param a: input data 
+    :type a: [pyTree, base, zone, list of zones, BC_t node]
+    :param bndName: name(s) of the BC node(s) to get
+    :type bndName: string or list of strings
+    :param bndType: name(s) of the BC type(s) to get
+    :type bndType: string or list of strings
+    :rtype: list of BC nodes (shared with a)
+
+    *Example of use:*
+
+    * `Get BC nodes of given type (pyTree) <Examples/Converter/getBCNodesFromNameAndTypePT.py>`_:
+
+    .. literalinclude:: ../build/Examples/Converter/getBCNodesFromNameAndTypePT.py
+        
 -----------------------------------------------------------------------------------------------
 
 .. py:function:: Converter.Internal.getZones(t)

--- a/Cassiopee/Converter/test/getBCNodesFromNameAndTypePT.py
+++ b/Cassiopee/Converter/test/getBCNodesFromNameAndTypePT.py
@@ -21,4 +21,3 @@ print([n[0] for n in nodes])
 nodes = Internal.getBCNodesFromNameAndType(t, bndName='wall*', bndType='BCWallViscous')
 print([n[0] for n in nodes])
 #>> ['wall1', 'wall2']
-

--- a/Cassiopee/Converter/test/getBCNodesFromNameAndTypePT.py
+++ b/Cassiopee/Converter/test/getBCNodesFromNameAndTypePT.py
@@ -1,0 +1,24 @@
+# - getBCNodesFromNameAndType (pyTree) -
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+
+a = G.cart((-0.1,0.9,0), (0.01,0.01,1.), (10,10,2))
+C._addBC2Zone(a, 'inlet', 'BCInflow', 'kmin')
+C._addBC2Zone(a, 'outlet', 'BCOutflow', 'kmax')
+C._addBC2Zone(a, 'match1', 'BCMatch', 'imin', a, 'imax', [1,2,3])
+C._addBC2Zone(a, 'wall1', 'FamilySpecified:CYLINDER', 'jmin')
+C._addBC2Zone(a, 'wall2', 'FamilySpecified:CYLINDER', 'jmax')
+t = C.newPyTree(['Base', a])
+C._addFamily2Base(t[2][1], 'CYLINDER', bndType='BCWallViscous')
+bc = Internal.getNodeFromType2(a, 'BC_t')
+
+# On a PyTree
+nodes = Internal.getBCNodesFromNameAndType(t, bndName='wall2', bndType='BCWallViscous')
+print([n[0] for n in nodes])
+#>> ['wall2']
+
+nodes = Internal.getBCNodesFromNameAndType(t, bndName='wall*', bndType='BCWallViscous')
+print([n[0] for n in nodes])
+#>> ['wall1', 'wall2']
+

--- a/Cassiopee/Converter/test/getBCNodesFromNameAndTypePT_t1.py
+++ b/Cassiopee/Converter/test/getBCNodesFromNameAndTypePT_t1.py
@@ -1,0 +1,77 @@
+# - getBCNodesFromNameAndType (pyTree) -
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+import KCore.test as test
+
+a = G.cart((-0.1,0.9,0), (0.01,0.01,1.), (10,10,2))
+C._addBC2Zone(a, 'wall1', 'BCWallInviscid', 'jmin')
+C._addBC2Zone(a, 'wall2', 'BCWallViscous', 'jmax')
+C._addBC2Zone(a, 'farfield', 'BCFarfield', 'kmin')
+C._addBC2Zone(a, 'wall3', 'BCWallViscousIsothermal', 'kmax')
+C._addBC2Zone(a, 'wall4', 'FamilySpecified:CYLINDER', 'imin')
+C._addBC2Zone(a, 'wall5', 'FamilySpecified:CYLINDER', 'imax')
+t = C.newPyTree(['Base', a])
+C._addFamily2Base(t[2][1], 'CYLINDER', bndType='BCWallViscous')
+bc = Internal.getNodeFromType2(a, 'BC_t')
+
+# On a PyTree
+n = Internal.getBCNodesFromNameAndType(t)  # all BCs
+test.testO(n, 1)
+
+n = Internal.getBCNodesFromNameAndType(t, bndType='BCSymmetryPlane')  # not found, empty list
+test.testO(n, 2)
+
+n = Internal.getBCNodesFromNameAndType(t, bndType='BCWallInviscid')  # one BC
+test.testO(n, 3)
+
+n = Internal.getBCNodesFromNameAndType(t, bndName=['wall1', 'wall3'])  # from a list of BC names
+test.testO(n, 4)
+
+n = Internal.getBCNodesFromNameAndType(t, bndType=['BCFarfield', 'BCWallViscousIsothermal'])  # from a list of BC types
+test.testO(n, 5)
+
+n = Internal.getBCNodesFromNameAndType(t, bndName='wall*')  # wildcard on BC names
+test.testO(n, 6)
+
+n = Internal.getBCNodesFromNameAndType(t, bndType='BCWall*')  # wildcard on BC types
+test.testO(n, 7)
+
+n = Internal.getBCNodesFromNameAndType(t, bndName='wall*', bndType='BCWallViscous')  # combination
+test.testO(n, 8)
+
+n = Internal.getBCNodesFromNameAndType(t, bndName='wall*', bndType='BCWallViscous*')  # combination
+test.testO(n, 9)
+
+# On a BC_t node that is not FamilySpecified
+n = Internal.getBCNodesFromNameAndType(bc)  # all BCs
+test.testO(n, 10)
+
+n = Internal.getBCNodesFromNameAndType(bc, bndType='BCWallInviscid')  # one BC
+test.testO(n, 11)
+
+n = Internal.getBCNodesFromNameAndType(bc, bndType='BCWall*')  # wildcard
+test.testO(n, 12)
+
+# On a list of zones
+a = G.cart((-0.1,0.9,0), (0.01,0.01,1.), (20,20,2))
+b = G.cart((5,0.9,0), (0.01,0.01,1.), (20,20,2)); b[0] = 'cart2'
+zones = [a, b]
+C._addBC2Zone(zones, 'wall1', 'BCWallInviscid', 'imin')
+C._addBC2Zone(zones, 'wall2', 'BCWallViscous', 'jmin')
+C._addBC2Zone(zones, 'wall3', 'BCWallViscousIsothermal', 'jmax')
+C._addBC2Zone(zones, 'inlet', 'BCInflow', 'kmin')
+C._addBC2Zone(zones, 'farfield', 'BCFarfield', 'kmax')
+
+n = Internal.getBCNodesFromNameAndType(zones)  # all BCs
+test.testO(n, 13)
+
+n = Internal.getBCNodesFromNameAndType(zones, bndType='BCSymmetryPlane')  # not found, empty list
+test.testO(n, 14)
+
+n = Internal.getBCNodesFromNameAndType(zones, bndName='wall*', bndType='BCWallViscousIsothermal')  # one BC
+test.testO(n, 15)
+
+n = Internal.getBCNodesFromNameAndType(zones, bndName='wall*', bndType='BCWallViscous*')  # combination
+test.testO(n, 16)
+

--- a/Cassiopee/Converter/test/getBCNodesFromNameAndTypePT_t1.py
+++ b/Cassiopee/Converter/test/getBCNodesFromNameAndTypePT_t1.py
@@ -74,4 +74,3 @@ test.testO(n, 15)
 
 n = Internal.getBCNodesFromNameAndType(zones, bndName='wall*', bndType='BCWallViscous*')  # combination
 test.testO(n, 16)
-

--- a/Cassiopee/Converter/test/getBCNodesFromNamePT.py
+++ b/Cassiopee/Converter/test/getBCNodesFromNamePT.py
@@ -1,0 +1,32 @@
+# - getBCNodesFromName (pyTree) -
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+
+a = G.cart((-0.1,0.9,0), (0.01,0.01,1.), (10,10,2))
+C._addBC2Zone(a, 'wall1', 'BCWall', 'jmin')
+C._addBC2Zone(a, 'match1', 'BCMatch', 'imin', a, 'imax', [1,2,3])
+C._addBC2Zone(a, 'wall2', 'BCWall', 'jmax')
+C._addBC2Zone(a, 'inlet', 'BCInflow', 'kmin')
+C._addBC2Zone(a, 'outlet', 'BCOutflow', 'kmax')
+t = C.newPyTree(['Base', a])
+bc = Internal.getNodeFromType2(a, 'BC_t')
+
+# On a PyTree
+nodes = Internal.getBCNodesFromName(t, 'wall1')
+print([n[0] for n in nodes])
+#>> ['wall1']
+
+nodes = Internal.getBCNodesFromName(t, ['wall1', 'outlet'])
+print([n[0] for n in nodes])
+#>> ['wall1', 'outlet']
+
+nodes = Internal.getBCNodesFromName(t, 'wall*')
+print([n[0] for n in nodes])
+#>> ['wall1', 'wall2']
+
+# On a BC_t
+nodes = Internal.getBCNodesFromName(bc, 'wall1')
+print([n[0] for n in nodes])
+#>> ['wall1']
+

--- a/Cassiopee/Converter/test/getBCNodesFromNamePT.py
+++ b/Cassiopee/Converter/test/getBCNodesFromNamePT.py
@@ -29,4 +29,3 @@ print([n[0] for n in nodes])
 nodes = Internal.getBCNodesFromName(bc, 'wall1')
 print([n[0] for n in nodes])
 #>> ['wall1']
-

--- a/Cassiopee/Converter/test/getBCNodesFromNamePT_t1.py
+++ b/Cassiopee/Converter/test/getBCNodesFromNamePT_t1.py
@@ -76,4 +76,3 @@ test.testO(n, 16)
 
 n = Internal.getBCNodesFromName(zones, 'wall*')  # wildcard
 test.testO(n, 17)
-

--- a/Cassiopee/Converter/test/getBCNodesFromNamePT_t1.py
+++ b/Cassiopee/Converter/test/getBCNodesFromNamePT_t1.py
@@ -1,0 +1,79 @@
+# - getBCNodesFromName (pyTree) -
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+import KCore.test as test
+
+a = G.cart((-0.1,0.9,0), (0.01,0.01,1.), (10,10,2))
+C._addBC2Zone(a, 'wall1', 'BCWall', 'jmin')
+C._addBC2Zone(a, 'match1', 'BCMatch', 'imin', a, 'imax', [1,2,3])
+C._addBC2Zone(a, 'wall2', 'BCWall', 'jmax')
+C._addBC2Zone(a, 'inlet', 'BCInflow', 'kmin')
+C._addBC2Zone(a, 'outlet', 'BCOutflow', 'kmax')
+t = C.newPyTree(['Base', a])
+bc = Internal.getNodeFromType2(a, 'BC_t')
+
+# On a zone
+n = Internal.getBCNodesFromName(a)  # all BCs
+test.testO(n, 1)
+
+n = Internal.getBCNodesFromName(a, 'cylinder')  # not found, empty list
+test.testO(n, 2)
+
+n = Internal.getBCNodesFromName(a, 'wall1')  # one BC
+test.testO(n, 3)
+
+n = Internal.getBCNodesFromName(a, ['wall1', 'wall2'])  # from a list of BC names
+test.testO(n, 4)
+
+n = Internal.getBCNodesFromName(a, 'wall*')  # wildcard
+test.testO(n, 5)
+
+# On a PyTree
+n = Internal.getBCNodesFromName(t)  # all BCs
+test.testO(n, 6)
+
+n = Internal.getBCNodesFromName(t, 'cylinder')  # not found, empty list
+test.testO(n, 7)
+
+n = Internal.getBCNodesFromName(t, 'wall1')  # one BC
+test.testO(n, 8)
+
+n = Internal.getBCNodesFromName(t, 'wall*')  # wildcard
+test.testO(n, 9)
+
+# On a BC_t node
+n = Internal.getBCNodesFromName(bc)  # all BCs
+test.testO(n, 10)
+
+n = Internal.getBCNodesFromName(bc, 'cylinder')  # not found, empty list
+test.testO(n, 11)
+
+n = Internal.getBCNodesFromName(bc, 'wall1')  # one BC
+test.testO(n, 12)
+
+n = Internal.getBCNodesFromName(bc, 'wall*')  # wildcard
+test.testO(n, 13)
+
+# On a list of zones
+a = G.cart((-0.1,0.9,0), (0.01,0.01,1.), (20,20,2))
+b = G.cart((5,0.9,0), (0.01,0.01,1.), (20,20,2)); b[0] = 'cart2'
+zones = [a, b]
+C._addBC2Zone(zones, 'wall1', 'BCWall', 'imin')
+C._addBC2Zone(zones, 'wall2', 'BCWall', 'jmin')
+C._addBC2Zone(zones, 'wall3', 'BCWall', 'jmax')
+C._addBC2Zone(zones, 'inlet', 'BCInflow', 'kmin')
+C._addBC2Zone(zones, 'farfield', 'BCFarfield', 'kmax')
+
+n = Internal.getBCNodesFromName(zones)  # all BCs
+test.testO(n, 14)
+
+n = Internal.getBCNodesFromName(zones, 'cylinder')  # not found, empty list
+test.testO(n, 15)
+
+n = Internal.getBCNodesFromName(zones, 'wall3')  # one BC
+test.testO(n, 16)
+
+n = Internal.getBCNodesFromName(zones, 'wall*')  # wildcard
+test.testO(n, 17)
+

--- a/Cassiopee/Converter/test/getBCNodesFromTypePT.py
+++ b/Cassiopee/Converter/test/getBCNodesFromTypePT.py
@@ -1,0 +1,33 @@
+# - getBCNodesFromType (pyTree) -
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+
+a = G.cart((-0.1,0.9,0), (0.01,0.01,1.), (10,10,2))
+C._addBC2Zone(a, 'inlet', 'BCInflow', 'kmin')
+C._addBC2Zone(a, 'outlet', 'BCOutflow', 'kmax')
+C._addBC2Zone(a, 'match1', 'BCMatch', 'imin', a, 'imax', [1,2,3])
+C._addBC2Zone(a, 'wall1', 'FamilySpecified:CYLINDER', 'jmin')
+C._addBC2Zone(a, 'wall2', 'FamilySpecified:CYLINDER', 'jmax')
+t = C.newPyTree(['Base', a])
+C._addFamily2Base(t[2][1], 'CYLINDER', bndType='BCWallViscous')
+bc = Internal.getNodeFromType2(a, 'BC_t')
+
+# On a PyTree
+nodes = Internal.getBCNodesFromType(t, 'BCOutflow')
+print([n[0] for n in nodes])
+#>> ['outlet']
+
+nodes = Internal.getBCNodesFromType(t, ['BCInflow', 'BCOutflow'])
+print([n[0] for n in nodes])
+#>> ['inlet', 'outlet']
+
+nodes = Internal.getBCNodesFromType(t, 'BCWall*')
+print([n[0] for n in nodes])
+#>> ['wall1', 'wall2']
+
+# On a BC_t that is not FamilySpecified
+nodes = Internal.getBCNodesFromType(bc, 'BCInflow')
+print([n[0] for n in nodes])
+#>> ['inlet']
+

--- a/Cassiopee/Converter/test/getBCNodesFromTypePT.py
+++ b/Cassiopee/Converter/test/getBCNodesFromTypePT.py
@@ -30,4 +30,3 @@ print([n[0] for n in nodes])
 nodes = Internal.getBCNodesFromType(bc, 'BCInflow')
 print([n[0] for n in nodes])
 #>> ['inlet']
-

--- a/Cassiopee/Converter/test/getBCNodesFromTypePT_t1.py
+++ b/Cassiopee/Converter/test/getBCNodesFromTypePT_t1.py
@@ -76,4 +76,3 @@ test.testO(n, 16)
 
 n = Internal.getBCNodesFromType(zones, 'BCWallViscous*')  # wildcard
 test.testO(n, 17)
-

--- a/Cassiopee/Converter/test/getBCNodesFromTypePT_t1.py
+++ b/Cassiopee/Converter/test/getBCNodesFromTypePT_t1.py
@@ -1,0 +1,79 @@
+# - getBCNodesFromType (pyTree) -
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+import KCore.test as test
+
+a = G.cart((-0.1,0.9,0), (0.01,0.01,1.), (10,10,2))
+C._addBC2Zone(a, 'wall1', 'BCWallInviscid', 'jmin')
+C._addBC2Zone(a, 'match1', 'BCMatch', 'imin', a, 'imax', [1,2,3])
+C._addBC2Zone(a, 'wall2', 'BCWallViscous', 'jmax')
+C._addBC2Zone(a, 'inlet', 'BCInflow', 'kmin')
+C._addBC2Zone(a, 'outlet', 'BCOutflow', 'kmax')
+t = C.newPyTree(['Base', a])
+bc = Internal.getNodeFromType2(a, 'BC_t')
+
+# On a zone
+n = Internal.getBCNodesFromType(a)  # all BCs
+test.testO(n, 1)
+
+n = Internal.getBCNodesFromType(a, 'BCSymmetryPlane')  # not found, empty list
+test.testO(n, 2)
+
+n = Internal.getBCNodesFromType(a, 'BCWallInviscid')  # one BC
+test.testO(n, 3)
+
+n = Internal.getBCNodesFromType(a, ['BCInflow', 'BCOutflow'])  # from a list of BC types
+test.testO(n, 4)
+
+n = Internal.getBCNodesFromType(a, 'BCWall*')  # wildcard
+test.testO(n, 5)
+
+# On a PyTree
+n = Internal.getBCNodesFromType(t)  # all BCs
+test.testO(n, 6)
+
+n = Internal.getBCNodesFromType(t, 'BCSymmetryPlane')  # not found, empty list
+test.testO(n, 7)
+
+n = Internal.getBCNodesFromType(t, 'BCWallInviscid')  # one BC
+test.testO(n, 8)
+
+n = Internal.getBCNodesFromType(t, 'BCWall*')  # wildcard
+test.testO(n, 9)
+
+# On a BC_t node
+n = Internal.getBCNodesFromType(bc)  # all BCs
+test.testO(n, 10)
+
+n = Internal.getBCNodesFromType(bc, 'BCSymmetryPlane')  # not found, empty list
+test.testO(n, 11)
+
+n = Internal.getBCNodesFromType(bc, 'BCWallInviscid')  # one BC
+test.testO(n, 12)
+
+n = Internal.getBCNodesFromType(bc, 'BCWall*')  # wildcard
+test.testO(n, 13)
+
+# On a list of zones
+a = G.cart((-0.1,0.9,0), (0.01,0.01,1.), (20,20,2))
+b = G.cart((5,0.9,0), (0.01,0.01,1.), (20,20,2)); b[0] = 'cart2'
+zones = [a, b]
+C._addBC2Zone(zones, 'wall1', 'BCWallInviscid', 'imin')
+C._addBC2Zone(zones, 'wall2', 'BCWallViscous', 'jmin')
+C._addBC2Zone(zones, 'wall3', 'BCWallViscousIsothermal', 'jmax')
+C._addBC2Zone(zones, 'inlet', 'BCInflow', 'kmin')
+C._addBC2Zone(zones, 'farfield', 'BCFarfield', 'kmax')
+
+n = Internal.getBCNodesFromType(zones)  # all BCs
+test.testO(n, 14)
+
+n = Internal.getBCNodesFromType(zones, 'BCSymmetryPlane')  # not found, empty list
+test.testO(n, 15)
+
+n = Internal.getBCNodesFromType(zones, 'BCWallViscous')  # one BC
+test.testO(n, 16)
+
+n = Internal.getBCNodesFromType(zones, 'BCWallViscous*')  # wildcard
+test.testO(n, 17)
+

--- a/Cassiopee/Converter/test/getBCNodesFromTypePT_t2.py
+++ b/Cassiopee/Converter/test/getBCNodesFromTypePT_t2.py
@@ -1,0 +1,25 @@
+# - getBCNodesFromType (pyTree) -
+import Converter.PyTree as C
+import Converter.Internal as Internal
+import Generator.PyTree as G
+import KCore.test as test
+
+a = G.cart((-0.1,0.9,0), (0.01,0.01,1.), (10,10,2))
+C._addBC2Zone(a, 'wall1', 'FamilySpecified:CYLINDER', 'jmin')
+C._addBC2Zone(a, 'match1', 'BCMatch', 'imin', a, 'imax', [1,2,3])
+C._addBC2Zone(a, 'wall2', 'FamilySpecified:CYLINDER', 'jmax')
+C._addBC2Zone(a, 'inlet', 'BCInflow', 'kmin')
+C._addBC2Zone(a, 'outlet', 'BCOutflow', 'kmax')
+t = C.newPyTree(['Base', a])
+C._addFamily2Base(t[2][1], 'CYLINDER', bndType='BCWallViscous')
+
+n = Internal.getBCNodesFromType(t)  # all BCs
+test.testO(n, 1)
+
+n = Internal.getBCNodesFromType(t, 'BCWall*')  # wildcard
+test.testO(n, 2)
+
+n = Internal.getBCNodesFromType(t, 'BCWallViscous')  # by BC type
+test.testO(n, 3)
+
+

--- a/Cassiopee/Converter/test/getBCNodesFromTypePT_t2.py
+++ b/Cassiopee/Converter/test/getBCNodesFromTypePT_t2.py
@@ -21,5 +21,3 @@ test.testO(n, 2)
 
 n = Internal.getBCNodesFromType(t, 'BCWallViscous')  # by BC type
 test.testO(n, 3)
-
-

--- a/Cassiopee/Converter/test/getFamilyBCNamesOfTypePT.py
+++ b/Cassiopee/Converter/test/getFamilyBCNamesOfTypePT.py
@@ -1,5 +1,6 @@
 # - getFamilyBCNamesOfType (pyTree) -
 import Converter.PyTree as C
+import Converter.Internal as Internal
 import Generator.PyTree as G
 
 a = G.cart((0.,0.,0), (0.01,0.01,1.), (20,20,2))
@@ -13,8 +14,8 @@ t = C.newPyTree(['Base',a,b])
 C._addFamily2Base(t[2][1], 'CARTER', bndType='BCWall')
 
 # Toutes les familyBCs de type BCwall
-names = C.getFamilyBCNamesOfType(t, 'BCWall'); print(names)
+names = Internal.getFamilyBCNamesOfType(t, 'BCWall'); print(names)
 #>> ['CARTER']
 # Toutes les familyBCs de l'arbre
-names = C.getFamilyBCNamesOfType(t); print(names)
+names = Internal.getFamilyBCNamesOfType(t); print(names)
 #>> ['CARTER']

--- a/Cassiopee/Converter/test/getFamilyBCNamesOfTypePT_t1.py
+++ b/Cassiopee/Converter/test/getFamilyBCNamesOfTypePT_t1.py
@@ -1,5 +1,6 @@
 # - getFamilyBCNamesOfType (pyTree) -
 import Converter.PyTree as C
+import Converter.Internal as Internal
 import Generator.PyTree as G
 import KCore.test as test
 
@@ -16,8 +17,8 @@ t[2][1] = C.addFamily2Base(t[2][1], 'CARTER', bndType='BCWall')
 t[2][1] = C.addFamily2Base(t[2][1], 'LOIN', bndType='BCFarfield')
 
 # Toutes les familyBCs de type BCwall
-names1 = C.getFamilyBCNamesOfType(t, 'BCWall')
+names1 = Internal.getFamilyBCNamesOfType(t, 'BCWall')
 # Toutes les familyBCs de l'arbre
-names2 = C.getFamilyBCNamesOfType(t)
+names2 = Internal.getFamilyBCNamesOfType(t)
 names1.sort(); names2.sort()
 test.testO([names1, names2], 1)

--- a/Cassiopee/Converter/test/getFamilyBCsPT.py
+++ b/Cassiopee/Converter/test/getFamilyBCsPT.py
@@ -11,7 +11,7 @@ b = C.addBC2Zone(b, 'wallb', 'FamilySpecified:CARTER', 'jmin')
 
 t = C.newPyTree(['Base',a,b])
 C._addFamily2Base(t[2][1], 'CARTER', bndType='BCWall')
-B1 = C.getFamilyBCs(t, 'CARTER'); Internal.printTree(B1)
+B1 = Internal.getFamilyBCs(t, 'CARTER'); Internal.printTree(B1)
 #>> ['walla',array('FamilySpecified',dtype='|S1'),[2 sons],'BC_t']
 #>>   |_['PointRange',array(shape=(3, 2),dtype='int32',order='F'),[0 son],'IndexRange_t']
 #>>   |_['FamilyName',array('CARTER',dtype='|S1'),[0 son],'FamilyName_t']

--- a/Cassiopee/Converter/test/getFamilyBCsPT_t1.py
+++ b/Cassiopee/Converter/test/getFamilyBCsPT_t1.py
@@ -1,5 +1,6 @@
 # - getFamilyBCs (pyTree) -
 import Converter.PyTree as C
+import Converter.Internal as Internal
 import Generator.PyTree as G
 import KCore.test as test
 
@@ -13,5 +14,5 @@ t = C.newPyTree(['Base']); t[2][1][2] += [a,b]
 
 t[2][1] = C.addFamily2Base(t[2][1], 'CARTER', bndType='BCWall')
 
-B1 = C.getFamilyBCs(t, 'CARTER')
+B1 = Internal.getFamilyBCs(t, 'CARTER')
 test.testO(B1, 1)

--- a/Cassiopee/Converter/test/initBCDataSetPT.py
+++ b/Cassiopee/Converter/test/initBCDataSetPT.py
@@ -2,14 +2,16 @@
 import Converter.Internal as Internal
 import Converter.PyTree as C
 import Generator.PyTree as G
-N = 10; NFACES = (N-1)*(N-1)
+
+N = 10; nfaces = (N-1)*(N-1)
+
 a = G.cart((0,0,0), (1,1,1), (N,N,N))
 a = C.addBC2Zone(a, 'wall', 'BCWall', 'imin')
 b = Internal.getNodeFromName2(a, 'wall')
 d = Internal.newBCDataSet(name='BCDataSet', value='UserDefined',
                           gridLocation='FaceCenter', parent=b)
 d = Internal.newBCData('BCNeumann', parent=d)
-d = Internal.newDataArray('Density', value=NFACES*[1.], parent=d)
+d = Internal.newDataArray('Density', value=nfaces*[1.], parent=d)
 
 # Init all BCs
 C._initBCDataSet(a, 'MomentumX=2.*numpy.min({Density},0)')

--- a/Cassiopee/Converter/test/initBCDataSetPT_t1.py
+++ b/Cassiopee/Converter/test/initBCDataSetPT_t1.py
@@ -3,18 +3,20 @@ import Converter.Internal as Internal
 import Converter.PyTree as C
 import Generator.PyTree as G
 import KCore.test as test
-N = 10; NFACES = (N-1)*(N-1)
+
+N = 10; nfaces = (N-1)*(N-1)
+
 a = G.cart((0,0,0), (1,1,1), (N,N,N))
 a = C.addBC2Zone(a, 'wall', 'BCWall', 'imin')
 b = Internal.getNodeFromName2(a, 'wall')
 d = Internal.newBCDataSet(name='BCDataSet', value='UserDefined',
                           gridLocation='FaceCenter', parent=b)
 d = Internal.newBCData('BCNeumann', parent=d)
-d = Internal.newDataArray('Density', value=NFACES*[1.], parent=d)
+d = Internal.newDataArray('Density', value=nfaces*[1.], parent=d)
 
 # Init all BCs
 C._initBCDataSet(a, '{MomentumX}=2.*minimum({Density},0)')
 # Init only BC node
 bc = Internal.getNodeFromName(a, 'wall')
 C._initBCDataSet(bc, 'MomentumY', 3.)
-test.testT(a)
+test.testT(a, 1)

--- a/Cassiopee/Intersector/Intersector/PyTree.py
+++ b/Cassiopee/Intersector/Intersector/PyTree.py
@@ -565,7 +565,7 @@ def getBCPtListOfType(z, typesList, families=[]):
     nodes = []
     for btyp in typesList:
         nodes += Internal.getNodesFromValue(z, btyp)
-        if families != []:nodes += C.getFamilyBCs(z, families)
+        if families != []:nodes += Internal.getFamilyBCs(z, families)
 
     #print(nodes)
     ptList = []
@@ -1286,7 +1286,7 @@ def _XcellN_(t, priorities, output_type=0, rtol=0.05):
 
     for z in Internal.getZones(tNG):
         for btyp in WALLBCS:
-            wallfamilies += C.getFamilyBCNamesOfType(t, btyp)
+            wallfamilies += Internal.getFamilyBCNamesOfType(t, btyp)
 
     wallfamilies = list(set(wallfamilies)) # make unique occurences
     #print(wallfamilies)


### PR DESCRIPTION
No regressions

- Move C.getFamilyBCs and C.getFamilyBCNamesOfType to Internal, create aliases in Converter.PyTree
- Add functions to get BC nodes: `Internal.getBCNodesFrom Name/Type/NameAndType`
- Add tests
- Add doc
- Improve C._initBCDataSet (add filtering by BC names and types) using the functions listed above

@benoit128: please feel free to propose any edits/rework