### PR TITLE
Offset: add security and update test cases

### DIFF
--- a/Cassiopee/Geom/Geom/Offset.py
+++ b/Cassiopee/Geom/Geom/Offset.py
@@ -59,6 +59,19 @@ def withCart__(a, offset, pointsPerUnitLength, dim=3):
     BB = G.bbox(a)
     xmin = BB[0]; ymin = BB[1]; zmin = BB[2]
     xmax = BB[3]; ymax = BB[4]; zmax = BB[5]
+
+    xc = (xmax+xmin)*0.5
+    yc = (ymax+ymin)*0.5
+    zc = (zmax+zmin)*0.5
+
+    if dim == 3: # security for quasi-2D tridimensional cases
+        dmax = max((xmax-xmin), (ymax-ymin), (zmax-zmin))
+
+        # each direction is scaled to at least 10% of dmax
+        if xmax-xmin < 0.1*dmax: xmin = xc - 0.05*dmax; xmax = xc + 0.05*dmax
+        if ymax-ymin < 0.1*dmax: ymin = yc - 0.05*dmax; ymax = yc + 0.05*dmax
+        if zmax-zmin < 0.1*dmax: zmin = zc - 0.05*dmax; zmax = zc + 0.05*dmax
+
     ni = pointsPerUnitLength*(xmax-xmin);
     nj = pointsPerUnitLength*(ymax-ymin)
     nk = pointsPerUnitLength*(zmax-zmin)
@@ -73,9 +86,9 @@ def withCart__(a, offset, pointsPerUnitLength, dim=3):
     ni = int((xmax-xmin)/h)+7; nj = int((ymax-ymin)/h)+7
     nk = int((zmax-zmin)/h)+7
     ni += int(2*abs(offset)/h); nj += int(2*abs(offset)/h); nk += int(2*abs(offset)/h)
-    xc = (xmax+xmin)*0.5; Lx = ni*h*0.5
-    yc = (ymax+ymin)*0.5; Ly = nj*h*0.5
-    zc = (zmax+zmin)*0.5; Lz = nk*h*0.5
+    Lx = ni*h*0.5
+    Ly = nj*h*0.5
+    Lz = nk*h*0.5
 
     if dim == 2:
         nk = 1

--- a/Cassiopee/Geom/test/offsetSurfacePT.py
+++ b/Cassiopee/Geom/test/offsetSurfacePT.py
@@ -5,4 +5,4 @@ import Converter.PyTree as C
 
 a = D.circle((0,0,0), 1.)
 b = Geom.Offset.offsetSurface(a, offset=1., pointsPerUnitLength=10., algo=0, dim=2)
-C.convertPyTree2File(a, 'out.cgns')
+C.convertPyTree2File(b, 'out.cgns')

--- a/Cassiopee/Geom/test/offsetSurfacePT_t1.py
+++ b/Cassiopee/Geom/test/offsetSurfacePT_t1.py
@@ -16,3 +16,7 @@ b = Geom.Offset.offsetSurface(a, offset=1., pointsPerUnitLength=10., algo=0, dim
 test.testT(b,3)
 b = Geom.Offset.offsetSurface(a, offset=1., pointsPerUnitLength=10., algo=1, dim=2)
 test.testT(b,4)
+b = Geom.Offset.offsetSurface(a, offset=1., pointsPerUnitLength=10., algo=0, dim=3)
+test.testT(b,5)
+b = Geom.Offset.offsetSurface(a, offset=1., pointsPerUnitLength=10., algo=1, dim=3)
+test.testT(b,6)


### PR DESCRIPTION
No regression.

Add a security for quasi-2D 3D cases that would create very fine Cartesian grids due to the input ppul and small distance in one of the three directions of space. The bug fix proposes an automatic expansion of the bounding box based on the maximum length found in the original geometry.

Update the associated test-case (offsetsurfacePT_t1.py) with dim=3. The 3rd and 4th tests, though wrong (3D sphere case but offsetSurface with dim=2), are kept to avoid regression.