### PR TITLE
KCore: test: declutter checkTree when parent node is missing

### DIFF
--- a/Cassiopee/KCore/KCore/test.py
+++ b/Cassiopee/KCore/KCore/test.py
@@ -336,7 +336,7 @@ def testO(objet, number=1):
 # Retourne 0 si differents
 #=============================================================================
 def checkTree(t1, t2):
-    """Check that pyTree t1 and t2 are identical."""
+    """Check that pyTrees t1 and t2 are identical."""
     dict1 = {}
     buildDict__('.', dict1, t1)
     dict1.pop('./CGNSTree/CGNSLibraryVersion', None) # avoid comparison when version change
@@ -344,14 +344,25 @@ def checkTree(t1, t2):
     buildDict__('.', dict2, t2)
     dict2.pop('./CGNSTree/CGNSLibraryVersion', None)
 
-    for k in dict2.keys():
-        node2 = dict2[k]
+    missing = []
+    for k in dict2:
         # cherche le noeud equivalent dans t1
-        if k not in dict1:
-            print('DIFF: node %s existe dans reference mais pas dans courant.'%k)
-        else:
-            node1 = dict1[k]
-            checkTree__(node1, node2)
+        if k in dict1:
+            checkTree__(dict1[k], dict2[k])
+        elif not any(k.startswith(p + "/") or k == p for p in missing):
+            # parent node of k was found but k isn't: report as missing in current
+            missing.append(k)
+            print(f'DIFF: node {k} exists in reference but not in current.')
+
+    missing = []
+    for k in dict1:
+        # cherche le noeud equivalent dans t2
+        if k in dict2:
+            pass  # test already done above
+        elif not any(k.startswith(p + "/") or k == p for p in missing):
+            # parent node of k was found but k isn't: report as missing in reference
+            missing.append(k)
+            print(f'DIFF: node {k} exists in current but not in reference.')
 
 def buildDict__(curr, mdict, node):
     d = f"{curr}/{node[0]}"


### PR DESCRIPTION
No regressions

- Do not report node as missing in test.checkTree if parent node is missing too
- Report nodes present in current but not in reference

Example:

Before fix
```py
Reading Data_ubuntu/convertArray2NGonPT_t1.ref2 (bin_pickle)...done.
DIFF: node ./CGNSTree/Base/cart.1 existe dans reference mais pas dans courant.
DIFF: node ./CGNSTree/Base/cart.1/ZoneType existe dans reference mais pas dans courant.
DIFF: node ./CGNSTree/Base/cart.1/GridCoordinates existe dans reference mais pas dans courant.
DIFF: node ./CGNSTree/Base/cart.1/GridCoordinates/CoordinateX existe dans reference mais pas dans courant.
DIFF: node ./CGNSTree/Base/cart.1/GridCoordinates/CoordinateY existe dans reference mais pas dans courant.
DIFF: node ./CGNSTree/Base/cart.1/GridCoordinates/CoordinateZ existe dans reference mais pas dans courant.
DIFF: node ./CGNSTree/Base/cart.1/NGonElements existe dans reference mais pas dans courant.
DIFF: node ./CGNSTree/Base/cart.1/NGonElements/ElementRange existe dans reference mais pas dans courant.
DIFF: node ./CGNSTree/Base/cart.1/NGonElements/ElementConnectivity existe dans reference mais pas dans courant.
DIFF: node ./CGNSTree/Base/cart.1/NFaceElements existe dans reference mais pas dans courant.
DIFF: node ./CGNSTree/Base/cart.1/NFaceElements/ElementRange existe dans reference mais pas dans courant.
DIFF: node ./CGNSTree/Base/cart.1/NFaceElements/ElementConnectivity existe dans reference mais pas dans courant.
```

After fix
```py
Reading Data_ubuntu/convertArray2NGonPT_t1.ref2 (bin_pickle)...done.
DIFF: node ./CGNSTree/Base/cart.1 existe dans reference mais pas dans courant.
DIFF: node ./CGNSTree/Base/cart.0 existe dans courant mais pas dans reference.
```