### PR TITLE
Generator: bug fix for cartTetra (TRI) and cartHexa (QUAD)

### DIFF
--- a/Cassiopee/Generator/Generator/cartHexa.cpp
+++ b/Cassiopee/Generator/Generator/cartHexa.cpp
@@ -54,21 +54,27 @@ PyObject* K_GENERATOR::cartHexa(PyObject* self,  PyObject* args)
   
   // 1D, 2D or 3D ?
   E_Int dim0 = 3;
+  E_Int im = 1, jm = 1; // local ni/nj for dim0 < 3
   if (ni == 1)
   {
-    if (nj == 1 || nk == 1) dim0 = 1;
-    else dim0 = 2;
+    if (nj == 1) {dim0 = 1; im = nk;}
+    else if (nk == 1) {dim0 = 1; im = nj;}
+    else {dim0 = 2; im = nj; jm = nk;}
   }
   else if (nj == 1)
   {
-    if (ni == 1 || nk == 1) dim0 = 1;
-    else dim0 = 2;
+    if (ni == 1) {dim0 = 1; im = nk;}
+    else if (nk == 1) {dim0 = 1; im = ni;}
+    else {dim0 = 2; im = ni; jm = nk;}
   }
   else if (nk == 1)
   {
-    if (ni == 1 || nj == 1) dim0 = 1;
-    else dim0 = 2;
+    if (ni == 1) {dim0 = 1; im = nj;}
+    else if (nj == 1) {dim0 = 1; im = ni;}
+    else {dim0 = 2; im = ni; jm = nj;}
   }
+  E_Int im1 = E_max(1, E_Int(im)-1);
+  E_Int jm1 = E_max(1, E_Int(jm)-1);
 
   // Create cartesian mesh
   E_Int ninj = ni*nj; E_Int npts = ninj*nk;
@@ -92,11 +98,11 @@ PyObject* K_GENERATOR::cartHexa(PyObject* self,  PyObject* args)
   E_Float* zt = f->begin(3);
 
   // Build the unstructured mesh (BE connectivity and fields)
-#pragma omp parallel if (ncells > __MIN_SIZE_MEAN__)
+  #pragma omp parallel if (ncells > __MIN_SIZE_MEAN__)
   {
     E_Int i, j, k, c;
     E_Int ind1, ind2, ind3, ind4;
-#pragma omp for
+    #pragma omp for
     for (E_Int ind = 0; ind < npts; ind++)
     {
       k = ind/ninj;
@@ -109,114 +115,57 @@ PyObject* K_GENERATOR::cartHexa(PyObject* self,  PyObject* args)
   
     if (dim0 == 1)
     {
-      if (nk1 == 1 && nj1 == 1)
+      #pragma omp for
+      for (E_Int i = 0; i < im1; i++)
       {
-#pragma omp for
-        for (E_Int i = 0; i < ni1; i++)
-        {
-          cm(i,1) = i+1;
-          cm(i,2) = i+2;
-        }
-      }
-      else if (ni1 == 1 && nj1 == 1)
-      {
-#pragma omp for
-        for (E_Int k = 0; k < nk1; k++)
-        {
-          ind1 = k*ni*nj + 1;
-          ind2 = ind1 + ni*nj;
-          cm(k,1) = ind1;
-          cm(k,2) = ind2;
-        }
-      }
-      else if (ni1 == 1 && nk1 == 1)
-      {
-#pragma omp for
-        for (E_Int j = 0; j < nj1; j++)
-        {
-          ind1 = j*ni + 1;
-          ind2 = ind1 + ni;
-          cm(j,1) = ind1;
-          cm(j,2) = ind2;
-        }
+        //starts from 1
+        ind1 = 1 + i;    //(i,1,1)
+        ind2 = ind1 + 1; //(i+1,1,1)
+
+        cm(i,1) = ind1;
+        cm(i,2) = ind2;
       }
     }
     else if (dim0 == 2)
     {
-      if (nk1 == 1)
+      #pragma omp for collapse(2)
+      for (E_Int j = 0; j < jm1; j++)
+      for (E_Int i = 0; i < im1; i++)
       {
-#pragma omp for
-        for (E_Int j = 0; j < nj1; j++)
-          for (E_Int i = 0; i < ni1; i++)
-          {
-            //starts from 1
-            ind1 = i + j*ni + 1; //(i,j,1)
-            ind2 = ind1 + 1;     //(i+1,j,1)
-            ind3 = ind2 + ni;    //(i+1,j+1,1)
-            ind4 = ind3 - 1;     //(i,j+1,1)
-            c = j*ni1 + i;
-            cm(c,1) = ind1;
-            cm(c,2) = ind2;
-            cm(c,3) = ind3;
-            cm(c,4) = ind4;
-          }
+        //starts from 1
+        ind1 = 1 + i + j*im; //(i,j,1)
+        ind2 = ind1 + 1;     //(i+1,j,1)
+        ind3 = ind2 + im;    //(i+1,j+1,1)
+        ind4 = ind3 - 1;     //(i,j+1,1)
+        c = j*im1 + i;
+        cm(c,1) = ind1;
+        cm(c,2) = ind2;
+        cm(c,3) = ind3;
+        cm(c,4) = ind4;
       }
-      else if (nj1 == 1)
-      {
-#pragma omp for
-        for (E_Int k = 0; k < nk1; k++)
-          for (E_Int i = 0; i < ni1; i++)
-          {
-            ind1 = i + k*ninj + 1;  //(i,1,k)
-            ind2 = ind1 + ninj;     //(i,1,k+1)
-            ind3 = ind2 + 1;        //(i+1,1,k+1)
-            ind4 = ind3 - 1;        //(i,1,k+1)
-            c = k*ni1 + i;
-            cm(c,1) = ind1;
-            cm(c,2) = ind2;
-            cm(c,3) = ind3;
-            cm(c,4) = ind4;
-          }
-      }
-      else // ni1 = 1 
-      {
-#pragma omp for
-        for (E_Int j = 0; j < nj1; j++)
-          for (E_Int k = 0; k < nk1; k++)
-          {
-            ind1 = 1 + j*ni + k*ninj; //(1,j,k)
-            ind2 = ind1 + ni;         //(1,j+1,k)
-            ind3 = ind2 + ninj;       //(1,j+1,k+1)
-            ind4 = ind3 - ni;         //(1,j,k+1)
-            c = j*nk1 + k;
-            cm(c,1) = ind1;
-            cm(c,2) = ind2;
-            cm(c,3) = ind3;
-            cm(c,4) = ind4;
-          }
-      }// ni1 = 1
     }
     else
     {
-#pragma omp for
-      for(E_Int k = 0; k < nk1; k++)
-        for (E_Int j = 0; j < nj1; j++)
-          for (E_Int i = 0; i < ni1; i++)
-          {
-            ind1 = 1 + i + j*ni + k*ninj; //(i,j,k)
-            ind2 = ind1 + 1;              // (i+1,j,k)
-            ind3 = ind2 + ni;             // (i+1,j+1,k)
-            ind4 = ind3 -1;               // (i,j+1,k)
-            c = (k*nj1 + j)*ni1 + i;
-            cm(c,1) = ind1;
-            cm(c,2) = ind2;
-            cm(c,3) = ind3;
-            cm(c,4) = ind4;
-            cm(c,5) = ind1 + ninj;
-            cm(c,6) = ind2 + ninj;
-            cm(c,7) = ind3 + ninj;
-            cm(c,8) = ind4 + ninj;
-          }
+      #pragma omp for collapse(3)
+      for (E_Int k = 0; k < nk1; k++)
+      for (E_Int j = 0; j < nj1; j++)
+      for (E_Int i = 0; i < ni1; i++)
+      {
+        //starts from 1
+        ind1 = 1 + i + j*ni + k*ninj; // (i,j,k)
+        ind2 = ind1 + 1;              // (i+1,j,k)
+        ind3 = ind2 + ni;             // (i+1,j+1,k)
+        ind4 = ind3 -1;               // (i,j+1,k)
+        c = (k*nj1 + j)*ni1 + i;
+        cm(c,1) = ind1;
+        cm(c,2) = ind2;
+        cm(c,3) = ind3;
+        cm(c,4) = ind4;
+        cm(c,5) = ind1 + ninj;
+        cm(c,6) = ind2 + ninj;
+        cm(c,7) = ind3 + ninj;
+        cm(c,8) = ind4 + ninj;
+      }
     }
   }
 

--- a/Cassiopee/Generator/Generator/cartTetra.cpp
+++ b/Cassiopee/Generator/Generator/cartTetra.cpp
@@ -61,21 +61,27 @@ PyObject* K_GENERATOR::cartTetra(PyObject* self, PyObject* args)
 
   // 1D, 2D or 3D ?
   E_Int dim0 = 3;
+  E_Int im = 1, jm = 1; // local im, jm for dim0 < 3
   if (ni == 1)
   {
-    if (nj == 1 || nk == 1 ) dim0 = 1;
-    else dim0 = 2;
+    if (nj == 1) {dim0 = 1; im = nk;}
+    else if (nk == 1) {dim0 = 1; im = nj;}
+    else {dim0 = 2; im = nj; jm = nk;}
   }
   else if (nj == 1)
   {
-    if (ni == 1 || nk == 1 ) dim0 = 1;
-    else dim0 = 2;
+    if (ni == 1) {dim0 = 1; im = nk;}
+    else if (nk == 1) {dim0 = 1; im = ni;}
+    else {dim0 = 2; im = ni; jm = nk;}
   }
   else if (nk == 1)
   {
-    if (ni == 1 || nj == 1) dim0 = 1;
-    else dim0 = 2;
+    if (ni == 1) {dim0 = 1; im = nj;}
+    else if (nj == 1) {dim0 = 1; im = ni;}
+    else {dim0 = 2; im = ni; jm = nj;}
   }
+  E_Int im1 = E_max(1, E_Int(im)-1);
+  E_Int jm1 = E_max(1, E_Int(jm)-1);
 
   // Create cartesian mesh
   E_Int ninj = ni*nj; E_Int npts = ninj*nk;
@@ -99,11 +105,11 @@ PyObject* K_GENERATOR::cartTetra(PyObject* self, PyObject* args)
   E_Float* zt = f->begin(3);
 
   // Build the unstructured mesh (BE connectivity and fields)
-#pragma omp parallel if (nelts > __MIN_SIZE_MEAN__)
+  #pragma omp parallel if (nelts > __MIN_SIZE_MEAN__)
   {
     E_Int i, j, k, c;
 
-#pragma omp for 
+    #pragma omp for 
     for (E_Int ind = 0; ind < npts; ind++)
     {
       k = ind/ninj;
@@ -117,193 +123,126 @@ PyObject* K_GENERATOR::cartTetra(PyObject* self, PyObject* args)
     if (dim0 == 1)
     {
       E_Int ind1, ind2;
-      if (nk1 == 1 && nj1 == 1)
+
+      #pragma omp for
+      for (E_Int i = 0; i < im1; i++)
       {
-#pragma omp for
-        for (E_Int i = 0; i < ni1; i++)
-        {
-          ind1 = i + 1;
-          ind2 = ind1 + 1;
-          cm(i,1) = ind1;
-          cm(i,2) = ind2;
-        }
+        //starts from 1
+        ind1 = 1 + i;    //(i,1,1)
+        ind2 = ind1 + 1; //(i+1,1,1)
+
+        cm(i,1) = ind1;
+        cm(i,2) = ind2;
       }
-      else if (ni1 == 1 && nj1 == 1)
-      {
-#pragma omp for
-        for (E_Int k = 0; k < nk1; k++)
-        {
-          ind1 = k*ni*nj + 1;
-          ind2 = ind1 + ni*nj;
-          cm(k,1) = ind1;
-          cm(k,2) = ind2;
-        }
-      }
-      else if (ni1 == 1 && nk1 == 1)
-      {
-#pragma omp for
-        for (E_Int j = 0; j < nj1; j++)
-        {
-          ind1 = j*ni + 1;
-          ind2 = ind1 + ni;
-          cm(j,1) = ind1;
-          cm(j,2) = ind2;
-        }
-      }
-      // type BAR 
     }
     else if (dim0 == 2)
     {
       E_Int ind1, ind2, ind3, ind4;
-      if (nk1 == 1)
-      {
-#pragma omp for
-        for (E_Int j = 0; j < nj1; j++)
-          for (E_Int i = 0; i < ni1; i++)
-          {
-            // starts from 1
-            ind1 = i + j*ni + 1; //(i,j,1)
-            ind2 = ind1 + 1;     //(i+1,j,1)
-            ind3 = ind2 + ni;    //(i+1,j+1,1)
-            ind4 = ind3 - 1;     //(i,j+1,1)
-            c = 2*(j*ni1 + i);
 
-            cm(c,1) = ind1;
-            cm(c,2) = ind2;
-            cm(c,3) = ind3;
-            
-            cm(c+1,1) = ind1;
-            cm(c+1,2) = ind3;
-            cm(c+1,3) = ind4;
-          }
-      }
-      else if (nj1 == 1)
+      #pragma omp for collapse(2)
+      for (E_Int j = 0; j < jm1; j++)
+      for (E_Int i = 0; i < im1; i++)
       {
-#pragma omp for
-        for (E_Int k = 0; k < nk1; k++)
-          for (E_Int i = 0; i < ni1; i++)
-          {
-            ind1 = i + k*ninj + 1;  //(i,1,k)
-            ind2 = ind1 + ninj;     //(i,1,k+1)
-            ind3 = ind2 + 1;        //(i+1,1,k+1)
-            ind4 = ind3 - 1;        //(i,1,k+1)
-            c = 2*(k*ni1 + i);
-                
-            cm(c,1) = ind1;
-            cm(c,2) = ind2;
-            cm(c,3) = ind3;
-            
-            cm(c+1,1) = ind1;
-            cm(c+1,2) = ind3;
-            cm(c+1,3) = ind4;
-          }
+        //starts from 1
+        ind1 = 1 + i + j*im; //(i,j,1)
+        ind2 = ind1 + 1;     //(i+1,j,1)
+        ind3 = ind2 + im;    //(i+1,j+1,1)
+        ind4 = ind3 - 1;     //(i,j+1,1)
+        c = 2*(j*im1 + i);
+        cm(c,1) = ind1;
+        cm(c,2) = ind2;
+        cm(c,3) = ind3;
+
+        cm(c+1,1) = ind1;
+        cm(c+1,2) = ind3;
+        cm(c+1,3) = ind4;
       }
-      else // ni1 = 1 
-      {
-#pragma omp for
-        for (E_Int j = 0; j < nj1; j++)
-          for (E_Int k = 0; k < nk1; k++)
-          {
-            ind1 = 1 + j*ni + k*ninj; //(1,j,k)
-            ind2 = ind1 + ni;         //(1,j+1,k)
-            ind3 = ind2 + ninj;       //(1,j+1,k+1)
-            ind4 = ind3 - ni;         //(1,j,k+1)
-            c = 2*(j*nk1 + k);
-                
-            cm(c,1) = ind1;
-            cm(c,2) = ind2;
-            cm(c,3) = ind3;
-            
-            cm(c+1,1) = ind1;
-            cm(c+1,2) = ind3;
-            cm(c+1,3) = ind4;
-          }
-      }// ni1 = 1
     }
     else
     {
       E_Int ind1, ind2, ind3, ind4, ind5, ind6, ind7, ind8, sum;
-#pragma omp for
-      for(E_Int k = 0; k < nk1; k++)
-        for (E_Int j = 0; j < nj1; j++)
-          for (E_Int i = 0; i < ni1; i++)
-          {
-            sum = i+j+k;
-            ind1 = 1 + i + j*ni + k*ninj; //A(  i,  j,k)
-            ind2 = ind1 + 1;              //B(i+1,  j,k)
-            ind3 = ind2 + ni;             //C(i+1,j+1,k)
-            ind4 = ind3 - 1;              //D(  i,j+1,k)
-            ind5 = ind1 + ninj;           //E(  i,  j,k+1)
-            ind6 = ind2 + ninj;           //F(i+1,  j,k+1)
-            ind7 = ind3 + ninj;           //G(i+1,j+1,k+1)
-            ind8 = ind4 + ninj;           //H(  i,j+1,k+1) 
-            c = 5*((k*nj1 + j)*ni1 + i);
-            
-            if (sum%2 == 0) // pair 
-            {
-              //tetra ABDE
-              cm(c,1) = ind1;
-              cm(c,2) = ind2;
-              cm(c,3) = ind4;
-              cm(c,4) = ind5;
-              
-              //tetra BCDG
-              cm(c+1,1) = ind2;
-              cm(c+1,2) = ind3;
-              cm(c+1,3) = ind4;
-              cm(c+1,4) = ind7;
-              
-              //tetra DEGH
-              cm(c+2,1) = ind4;
-              cm(c+2,2) = ind5;
-              cm(c+2,3) = ind7;
-              cm(c+2,4) = ind8;
-              
-              //tetra BEFG
-              cm(c+3,1) = ind2;
-              cm(c+3,2) = ind5;
-              cm(c+3,3) = ind6;
-              cm(c+3,4) = ind7;
-              
-              //tetra BDEG
-              cm(c+4,1) = ind2;
-              cm(c+4,2) = ind4;
-              cm(c+4,3) = ind5;
-              cm(c+4,4) = ind7;   
-            }
-            else // impair 
-            {
-              //tetra ACDH : 1348
-              cm(c,1) = ind1;
-              cm(c,2) = ind3;
-              cm(c,3) = ind4;
-              cm(c,4) = ind8;
-              
-              //tetra AFBC : 1623
-              cm(c+1,1) = ind1;
-              cm(c+1,2) = ind6;
-              cm(c+1,3) = ind2;
-              cm(c+1,4) = ind3;
-              
-              //tetra HFGC : 8763
-              cm(c+2,1) = ind8;
-              cm(c+2,2) = ind7;
-              cm(c+2,3) = ind6;
-              cm(c+2,4) = ind3;
-              
-              //tetra FHAE : 6815
-              cm(c+3,1) = ind6;
-              cm(c+3,2) = ind8;
-              cm(c+3,3) = ind1;
-              cm(c+3,4) = ind5;
-              
-              //tetra FHAC : 6183
-              cm(c+4,1) = ind6;
-              cm(c+4,2) = ind1;
-              cm(c+4,3) = ind8;
-              cm(c+4,4) = ind3;
-            }
-          }
+      
+      #pragma omp for collapse(3)
+      for (E_Int k = 0; k < nk1; k++)
+      for (E_Int j = 0; j < nj1; j++)
+      for (E_Int i = 0; i < ni1; i++)
+      {
+        sum = i+j+k;
+        ind1 = 1 + i + j*ni + k*ninj; //A(  i,  j,k)
+        ind2 = ind1 + 1;              //B(i+1,  j,k)
+        ind3 = ind2 + ni;             //C(i+1,j+1,k)
+        ind4 = ind3 - 1;              //D(  i,j+1,k)
+        ind5 = ind1 + ninj;           //E(  i,  j,k+1)
+        ind6 = ind2 + ninj;           //F(i+1,  j,k+1)
+        ind7 = ind3 + ninj;           //G(i+1,j+1,k+1)
+        ind8 = ind4 + ninj;           //H(  i,j+1,k+1) 
+        c = 5*((k*nj1 + j)*ni1 + i);
+        
+        if (sum%2 == 0) // pair 
+        {
+          //tetra ABDE
+          cm(c,1) = ind1;
+          cm(c,2) = ind2;
+          cm(c,3) = ind4;
+          cm(c,4) = ind5;
+          
+          //tetra BCDG
+          cm(c+1,1) = ind2;
+          cm(c+1,2) = ind3;
+          cm(c+1,3) = ind4;
+          cm(c+1,4) = ind7;
+          
+          //tetra DEGH
+          cm(c+2,1) = ind4;
+          cm(c+2,2) = ind5;
+          cm(c+2,3) = ind7;
+          cm(c+2,4) = ind8;
+          
+          //tetra BEFG
+          cm(c+3,1) = ind2;
+          cm(c+3,2) = ind5;
+          cm(c+3,3) = ind6;
+          cm(c+3,4) = ind7;
+          
+          //tetra BDEG
+          cm(c+4,1) = ind2;
+          cm(c+4,2) = ind4;
+          cm(c+4,3) = ind5;
+          cm(c+4,4) = ind7;   
+        }
+        else // impair 
+        {
+          //tetra ACDH : 1348
+          cm(c,1) = ind1;
+          cm(c,2) = ind3;
+          cm(c,3) = ind4;
+          cm(c,4) = ind8;
+          
+          //tetra AFBC : 1623
+          cm(c+1,1) = ind1;
+          cm(c+1,2) = ind6;
+          cm(c+1,3) = ind2;
+          cm(c+1,4) = ind3;
+          
+          //tetra HFGC : 8763
+          cm(c+2,1) = ind8;
+          cm(c+2,2) = ind7;
+          cm(c+2,3) = ind6;
+          cm(c+2,4) = ind3;
+          
+          //tetra FHAE : 6815
+          cm(c+3,1) = ind6;
+          cm(c+3,2) = ind8;
+          cm(c+3,3) = ind1;
+          cm(c+3,4) = ind5;
+          
+          //tetra FHAC : 6183
+          cm(c+4,1) = ind6;
+          cm(c+4,2) = ind1;
+          cm(c+4,3) = ind8;
+          cm(c+4,4) = ind3;
+        }
+      }
     }
   }
 

--- a/Cassiopee/Generator/test/cartHexaPT_t1.py
+++ b/Cassiopee/Generator/test/cartHexaPT_t1.py
@@ -1,14 +1,42 @@
 # - cartHexa (pyTree) -
 import Generator.PyTree as G
+import Converter.PyTree as C
 import KCore.test as test
 
-# 1D
-a = G.cartHexa((0.,0.,0.), (0.1,0.1,0.2), (10,1,1))
+# BAR
+a = G.cartHexa((0.,0.,0.), (0.1,0.1,0.2), (10,1,1)) # BAR - dir x
 test.testT(a, 1)
-# 2D
-a = G.cartHexa((0.,0.,0.), (0.1,0.1,0.2), (10,10,1))
+
+a = G.cartHexa((0.,0.,0.), (0.1,0.1,0.2), (1,10,1)) # BAR - dir y
+test.testT(a, 11)
+
+a = G.cartHexa((0.,0.,0.), (0.1,0.1,0.2), (1,1,10)) # BAR - dir z
+test.testT(a, 12)
+
+a = G.cartHexa((0.,0.,0.), (1.,1.,1.), (2,1,1))
+b = G.cartHexa((0.,0.,0.), (1.,1.,1.), (1,2,1))
+c = G.cartHexa((0.,0.,0.), (1.,1.,1.), (1,1,2))
+a = C.newPyTree(['Base',[a,b,c]]) # mono-cell in each directions
+test.testT(a, 13)
+
+# QUAD
+a = G.cartHexa((0.,0.,0.), (0.1,0.1,0.2), (10,10,1)) # QUAD - dir x/y
 test.testT(a, 2)
-# 3D
+
+a = G.cartHexa((0.,0.,0.), (0.1,0.1,0.2), (10,1,10)) # QUAD - dir x/z
+test.testT(a, 21)
+
+a = G.cartHexa((0.,0.,0.), (0.1,0.1,0.2), (1,10,10)) # QUAD - dir y/z
+test.testT(a, 22)
+
+a = G.cartHexa((0.,0.,0.), (1.,1.,1.), (2,2,1))
+b = G.cartHexa((0.,0.,0.), (1.,1.,1.), (2,1,2))
+c = G.cartHexa((0.,0.,0.), (1.,1.,1.), (1,2,2))
+a = C.newPyTree(['Base',[a,b,c]]) # mono-cell in each directions
+test.testT(a, 23)
+
+# HEXA
 a = G.cartHexa((0.,0.,0.), (0.1,0.1,0.2), (10,10,10))
 test.testT(a, 3)
+
 test.writeCoverage(100)

--- a/Cassiopee/Generator/test/cartTetraPT_t1.py
+++ b/Cassiopee/Generator/test/cartTetraPT_t1.py
@@ -1,13 +1,40 @@
 # - cartTetra (pyTree) -
 import Generator.PyTree as G
+import Converter.PyTree as C
 import KCore.test as test
 
 # BAR
-a = G.cartTetra((0.,0.,0.), (0.1,0.1,0.2), (10,1,1))
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,0.2), (10,1,1)) # BAR - dir x
 test.testT(a, 1)
+
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,0.2), (1,10,1)) # BAR - dir y
+test.testT(a, 11)
+
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,0.2), (1,1,10)) # BAR - dir z
+test.testT(a, 12)
+
+a = G.cartTetra((0.,0.,0.), (1.,1.,1.), (2,1,1))
+b = G.cartTetra((0.,0.,0.), (1.,1.,1.), (1,2,1))
+c = G.cartTetra((0.,0.,0.), (1.,1.,1.), (1,1,2))
+a = C.newPyTree(['Base',[a,b,c]]) # mono-cell in each directions
+test.testT(a, 13)
+
 # TRI
-a = G.cartTetra((0.,0.,0.), (0.1,0.1,0.2), (10,10,1))
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,0.2), (10,10,1)) # TRI - dir x/y
 test.testT(a, 2)
+
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,0.2), (10,1,10)) # TRI - dir x/z
+test.testT(a, 21)
+
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,0.2), (1,10,10)) # TRI - dir y/z
+test.testT(a, 22)
+
+a = G.cartTetra((0.,0.,0.), (1.,1.,1.), (2,2,1))
+b = G.cartTetra((0.,0.,0.), (1.,1.,1.), (2,1,2))
+c = G.cartTetra((0.,0.,0.), (1.,1.,1.), (1,2,2))
+a = C.newPyTree(['Base',[a,b,c]]) # mono-cell in each directions
+test.testT(a, 23)
+
 # TETRA
 a = G.cartTetra((0.,0.,0.), (1.,1.,1.), (2,2,2))
 test.testT(a, 3)


### PR DESCRIPTION
Bug fix for 2D unstructured meshes generated with cartHexa and cartTetra when nj=1, or for mono-cell meshes.
Algorithm factorization for 1D and 2D cases using local ni/nj values (im/jm) based on actual ni/nj/nk input values.
Update of cartTetraPT_t1.py and cartHexaPT_t1.py test cases with uncovered configurations.

/!\ Four regressions due to previous wrong indexing of quad and tri meshes when oriented in the y/z plane (ni=1). /!\
addBC2Zone_t4.py , projectAllDirsPT_t1.py , projectDirPT_t1.py  et projectRayPT_t1.py.