### PR TITLE
Generator: new getOrthogonalityMap (struct and BE/ME)

### DIFF
--- a/Cassiopee/Generator/Generator/Generator.py
+++ b/Cassiopee/Generator/Generator/Generator.py
@@ -2383,16 +2383,16 @@ def addNormalLayersUnstr__(surface, distrib, check=0, niterType=0, niter=0, nite
     return m
 
 # Fonction retournant la carte d'orthogonalite d'une grille
-def getOrthogonalityMap(array):
+def getOrthogonalityMap(array, normalized=False):
     """Return the orthogonality map in an array.
     Usage: getOrthogonalityMap(array)"""
     if isinstance(array[0], list):
         b = []
         for i in array:
-            b.append(generator.getOrthogonalityMap(i))
+            b.append(generator.getOrthogonalityMap(i, normalized))
         return b
     else:
-        return generator.getOrthogonalityMap(array)
+        return generator.getOrthogonalityMap(array, normalized)
 
 # Fonction retournant la carte de regularite d'une grille
 def getRegularityMap(array):

--- a/Cassiopee/Generator/Generator/PyTree.py
+++ b/Cassiopee/Generator/Generator/PyTree.py
@@ -1869,13 +1869,13 @@ def mapSplit(z, d, split_crit, dens_max=1000):
 # 2D: retourne un tableau d'angles alpha
 # 3D: retourne 3 tableaux d'angles alpha (dans l'ordre alpha_IJ, alpha_IK and alpha_JK pour les grilles structures)
 #------------------------------------------------------------------------------
-def getOrthogonalityMap(t):
+def getOrthogonalityMap(t, normalized=False):
     """Return the orthogonality map in an array.
     Usage: getOrthogonalityMap(t)"""
-    return C.TZGC1(t, 'centers', True, Generator.getOrthogonalityMap)
+    return C.TZGC3(t, 'centers', True, Generator.getOrthogonalityMap, normalized)
 
-def _getOrthogonalityMap(t):
-    return C._TZGC1(t, 'centers', False, Generator.getOrthogonalityMap)
+def _getOrthogonalityMap(t, normalized=False):
+    return C._TZGC3(t, 'centers', False, Generator.getOrthogonalityMap, normalized)
 
 #------------------------------------------------------------------------------
 # Calcul de la regularite (ratio entre des mailles adjacentes) d'une grille

--- a/Cassiopee/Generator/Generator/getOrthogonalityMap.cpp
+++ b/Cassiopee/Generator/Generator/getOrthogonalityMap.cpp
@@ -265,11 +265,16 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
       return NULL;
     }
 
+    // get eltTypes
+    std::vector<char*> eltTypes;
+    K_ARRAY::extractVars(eltType, eltTypes);
+
     
     // calcul de l'orthogonalite
     #pragma omp parallel
     {
       E_Float skewness1, skewness2, skewness3, skewness4;
+      E_Int ind1, ind2, ind3, ind4;
       E_Int nelts, nvpf;
       // loop over all connectivities
       for (E_Int ic = 0; ic < nc; ic++)
@@ -277,7 +282,7 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
         K_FLD::FldArrayI& cm = *(cn->getConnect(ic));
         nelts = cm.getSize();
         std::vector<std::vector<E_Int> > facets;
-        // K_CONNECT::getEVFacets(facets, eltTypes[ic], true); // say yes to degenerated elements
+        K_CONNECT::getEVFacets(facets, eltTypes[ic], false, false);
         
         // loop over all elements of connectivity cm
         #pragma omp for
@@ -288,267 +293,39 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
           // loop over all faces of element i
           for (E_Int f = 0; f < nfpe[ic]; f++)
           {
-            // nvpf = facets[f].size();  // number of vertices per facet
+            nvpf = facets[f].size();  // number of vertices per facet
             if (nvpf == 4) // QUAD face
-            { 
-              //
+            {
+              ind1 = cm(i,facets[f][0])-1;
+              ind2 = cm(i,facets[f][1])-1;
+              ind3 = cm(i,facets[f][2])-1;
+              ind4 = cm(i,facets[f][3])-1;
+
+              skewness1 = computeSkewness(x, y, z, ind1, ind4, ind2, 90.);
+              skewness2 = computeSkewness(x, y, z, ind2, ind1, ind3, 90.);
+              skewness3 = computeSkewness(x, y, z, ind3, ind2, ind4, 90.);
+              skewness4 = computeSkewness(x, y, z, ind4, ind3, ind1, 90.);
+
+              skewness[i] = E_max(E_max(E_max(E_max(skewness1,skewness2),skewness3),skewness4),skewness[i]);
             }
             else if (nvpf == 3) // TRI face
             {
-              // do somtehing
+              ind1 = cm(i,facets[f][0])-1;
+              ind2 = cm(i,facets[f][1])-1;
+              ind3 = cm(i,facets[f][2])-1;
+
+              skewness1 = computeSkewness(x, y, z, ind1, ind3, ind2, 60.);
+              skewness2 = computeSkewness(x, y, z, ind2, ind1, ind3, 60.);
+              skewness3 = computeSkewness(x, y, z, ind3, ind2, ind1, 60.);
+
+              skewness[i] = E_max(E_max(E_max(skewness1,skewness2),skewness3),skewness[i]);
             }
           }
         }
       }
     }
- 
-    // if (strcmp(eltType, "TRI") == 0)
-    // {
-    //   E_Int* cn1 = cn->begin(1); E_Int* cn2 = cn->begin(2); E_Int* cn3 = cn->begin(3);
-    //   E_Float eps = 1.e-6;
-    //   #pragma omp parallel
-    //   {
-    //     E_Float d1, d2, d3, alpha12, alpha23, alpha31, sqrtd1, sqrtd2, sqrtd3;
-    //     E_Int ind1, ind2, ind3;
-    //     #pragma omp for
-    //     for (E_Int et = 0; et < nelts; et++)
-    //     {
-    //       ind1 = cn1[et]-1;
-    //       ind2 = cn2[et]-1;
-    //       ind3 = cn3[et]-1;
 
-    //       d1 = (x[ind2]-x[ind1])*(x[ind2]-x[ind1])+(y[ind2]-y[ind1])*(y[ind2]-y[ind1])+(z[ind2]-z[ind1])*(z[ind2]-z[ind1]); sqrtd1 = sqrt(d1);
-    //       d2 = (x[ind3]-x[ind2])*(x[ind3]-x[ind2])+(y[ind3]-y[ind2])*(y[ind3]-y[ind2])+(z[ind3]-z[ind2])*(z[ind3]-z[ind2]); sqrtd2 = sqrt(d2);
-    //       d3 = (x[ind1]-x[ind3])*(x[ind1]-x[ind3])+(y[ind1]-y[ind3])*(y[ind1]-y[ind3])+(z[ind1]-z[ind3])*(z[ind1]-z[ind3]); sqrtd3 = sqrt(d3);
-
-    //       if (( K_FUNC::fEqualZero(d1,eps) == true )||
-    //           ( K_FUNC::fEqualZero(d2,eps) == true )||
-    //           ( K_FUNC::fEqualZero(d3,eps) == true ))
-    //       {
-    //         // degenerated element
-    //         skewness[et] = 120.; // 180. - 60.
-    //       }
-    //       else
-    //       {
-    //         alpha12 = E_abs(acos((d1 + d2 - d3)/(E_max(TWO*sqrtd1*sqrtd2,E_GEOM_CUTOFF)))*degconst - 60.);
-    //         alpha23 = E_abs(acos((d2 + d3 - d1)/(E_max(TWO*sqrtd2*sqrtd3,E_GEOM_CUTOFF)))*degconst - 60.);
-    //         alpha31 = E_abs(acos((d3 + d1 - d2)/(E_max(TWO*sqrtd3*sqrtd1,E_GEOM_CUTOFF)))*degconst - 60.);
-    //         skewness[et] = E_max(E_max(alpha12,alpha23),alpha31);
-    //       }
-    //     }
-    //   }
-    // }
-    // else if (strcmp(eltType, "QUAD") == 0)
-    // {
-    //   E_Int* cn1 = cn->begin(1); E_Int* cn2 = cn->begin(2); E_Int* cn3 = cn->begin(3); E_Int* cn4 = cn->begin(4);
-    //   E_Int ind1, ind2, ind3, ind4;
-    //   E_Float d1, d2, d3, d4, diag13, diag24, alpha12, alpha14, alpha32, alpha34;
-    //   E_Float sqrtd1, sqrtd2, sqrtd3, sqrtd4;
-    //   #pragma omp for
-    //   for (E_Int et = 0; et < nelts; et++)
-    //   {
-    //     ind1 = cn1[et]-1;
-    //     ind2 = cn2[et]-1;
-    //     ind3 = cn3[et]-1;
-    //     ind4 = cn4[et]-1;
-
-    //     d1     = (x[ind2]-x[ind1])*(x[ind2]-x[ind1])+(y[ind2]-y[ind1])*(y[ind2]-y[ind1])+(z[ind2]-z[ind1])*(z[ind2]-z[ind1]); sqrtd1 = sqrt(d1);
-    //     d2     = (x[ind3]-x[ind2])*(x[ind3]-x[ind2])+(y[ind3]-y[ind2])*(y[ind3]-y[ind2])+(z[ind3]-z[ind2])*(z[ind3]-z[ind2]); sqrtd2 = sqrt(d2);
-    //     d3     = (x[ind4]-x[ind3])*(x[ind4]-x[ind3])+(y[ind4]-y[ind3])*(y[ind4]-y[ind3])+(z[ind4]-z[ind3])*(z[ind4]-z[ind3]); sqrtd3 = sqrt(d3);
-    //     d4     = (x[ind1]-x[ind4])*(x[ind1]-x[ind4])+(y[ind1]-y[ind4])*(y[ind1]-y[ind4])+(z[ind1]-z[ind4])*(z[ind1]-z[ind4]); sqrtd4 = sqrt(d4);
-    //     diag13 = (x[ind1]-x[ind3])*(x[ind1]-x[ind3])+(y[ind1]-y[ind3])*(y[ind1]-y[ind3])+(z[ind1]-z[ind3])*(z[ind1]-z[ind3]);
-    //     diag24 = (x[ind2]-x[ind4])*(x[ind2]-x[ind4])+(y[ind2]-y[ind4])*(y[ind2]-y[ind4])+(z[ind2]-z[ind4])*(z[ind2]-z[ind4]);
-
-    //     alpha12 = E_abs(acos((d1 + d2 - diag13)/(E_max(TWO*sqrtd1*sqrtd2,E_GEOM_CUTOFF)))*degconst - 90.);
-    //     alpha14 = E_abs(acos((d1 + d4 - diag24)/(E_max(TWO*sqrtd1*sqrtd4,E_GEOM_CUTOFF)))*degconst - 90.);
-    //     alpha32 = E_abs(acos((d3 + d2 - diag24)/(E_max(TWO*sqrtd3*sqrtd2,E_GEOM_CUTOFF)))*degconst - 90.);
-    //     alpha34 = E_abs(acos((d3 + d4 - diag13)/(E_max(TWO*sqrtd3*sqrtd4,E_GEOM_CUTOFF)))*degconst - 90.);
-    //     skewness[et] = E_max(E_max(alpha12,alpha14),E_max(alpha32,alpha34));
-    //   }
-    // }
-    // else if (strcmp(eltType, "TETRA") == 0)
-    // {
-    //   // Compute surface normals
-    //   E_Int nvpe = cn->getNfld();
-    //   FldArrayF nsurfx(nelts, nvpe);
-    //   FldArrayF nsurfy(nelts, nvpe);
-    //   FldArrayF nsurfz(nelts, nvpe);
-    //   FldArrayF surf(nelts, nvpe);
-    //   K_METRIC::compSurfUnstruct(
-    //     *cn, "TETRA", 
-    //     f->begin(posx), f->begin(posy), f->begin(posz), 
-    //     nsurfx.begin(), nsurfy.begin(), nsurfz.begin(), surf.begin());
-
-    //   // Compute dihedral angle
-    //   E_Float* nsurf1x = nsurfx.begin(1); E_Float* nsurf2x = nsurfx.begin(2);
-    //   E_Float* nsurf3x = nsurfx.begin(3);E_Float* nsurf4x = nsurfx.begin(4);
-    //   E_Float* nsurf1y = nsurfy.begin(1); E_Float* nsurf2y = nsurfy.begin(2);
-    //   E_Float* nsurf3y = nsurfy.begin(3);E_Float* nsurf4y = nsurfy.begin(4);
-    //   E_Float* nsurf1z = nsurfz.begin(1); E_Float* nsurf2z = nsurfz.begin(2);
-    //   E_Float* nsurf3z = nsurfz.begin(3);E_Float* nsurf4z = nsurfz.begin(4);
-    //   E_Float* surf1 = surf.begin(1); E_Float* surf2 = surf.begin(2); 
-    //   E_Float* surf3 = surf.begin(3); E_Float* surf4 = surf.begin(4);
-    
-    //   #pragma omp parallel
-    //   {
-    //     E_Float s1, s2, s3,s4, s12, s13, s23, s14, s24, s34;
-    //     E_Float alpha12, alpha14, alpha24, alpha13, alpha23, alpha34;
-    //     E_Float skewness1, skewness2, skewness3;
-    //     #pragma omp for
-    //     for (E_Int et = 0; et < nelts; et++)
-    //     {
-    //       s1 = surf1[et]; s2 = surf2[et]; s3 = surf3[et]; s4 = surf4[et];
-    //       s12 = s1*s2; s13 = s1*s3; s14 = s1*s4;  
-    //       s23 = s2*s3; s24 = s2*s4; s34 = s3*s4;
-    //       alpha12 = E_abs(acos((nsurf1x[et]*nsurf2x[et] + nsurf1y[et]*nsurf2y[et] + nsurf1z[et]*nsurf2z[et])/s12)*degconst - 120.);
-    //       alpha14 = E_abs(acos((nsurf1x[et]*nsurf4x[et] + nsurf1y[et]*nsurf4y[et] + nsurf1z[et]*nsurf4z[et])/s14)*degconst - 120.);
-    //       alpha24 = E_abs(acos((nsurf2x[et]*nsurf4x[et] + nsurf2y[et]*nsurf4y[et] + nsurf2z[et]*nsurf4z[et])/s24)*degconst - 120.);
-    //       alpha13 = E_abs(acos((nsurf1x[et]*nsurf3x[et] + nsurf1y[et]*nsurf3y[et] + nsurf1z[et]*nsurf3z[et])/s13)*degconst - 120.);
-    //       alpha23 = E_abs(acos((nsurf2x[et]*nsurf3x[et] + nsurf2y[et]*nsurf3y[et] + nsurf2z[et]*nsurf3z[et])/s23)*degconst - 120.);
-    //       alpha34 = E_abs(acos((nsurf3x[et]*nsurf4x[et] + nsurf3y[et]*nsurf4y[et] + nsurf3z[et]*nsurf4z[et])/s34)*degconst - 120.);
-    //       skewness1 = E_max(alpha12,alpha14);
-    //       skewness2 = E_max(alpha24,alpha13);
-    //       skewness3 = E_max(alpha23,alpha34);
-    //       skewness[et] = E_max(E_max(skewness1,skewness2),skewness3);
-    //     }
-    //   }
-    // }
-    // else if (strcmp(eltType, "PYRA") == 0)
-    // {
-    //   PyErr_SetString(PyExc_TypeError,
-    //                 "getOrthogonalityMap: not yet implemented for PYRA.");
-    //   RELEASESHAREDS(tpl, f2);
-    //   RELEASESHAREDU(array, f, cn);
-    //   return NULL;
-    // }
-    // else if (strcmp(eltType, "PENTA") == 0)
-    // {
-    //   // Compute surface normals
-    //   E_Int nvpe = cn->getNfld();
-    //   FldArrayF nsurfx(nelts, nvpe);
-    //   FldArrayF nsurfy(nelts, nvpe);
-    //   FldArrayF nsurfz(nelts, nvpe);
-    //   FldArrayF surf(nelts, nvpe);
-    //   K_METRIC::compSurfUnstruct(
-    //     *cn, "PENTA",
-    //     f->begin(posx), f->begin(posy), f->begin(posz), 
-    //     nsurfx.begin(), nsurfy.begin(), nsurfz.begin(), surf.begin());
-
-    //   // Compute dihedral angle
-    //   E_Float* nsurf1x = nsurfx.begin(1); E_Float* nsurf2x = nsurfx.begin(2);
-    //   E_Float* nsurf3x = nsurfx.begin(3);
-    //   E_Float* nsurf4x = nsurfx.begin(4); E_Float* nsurf5x = nsurfx.begin(5);
-    //   E_Float* nsurf1y = nsurfy.begin(1); E_Float* nsurf2y = nsurfy.begin(2);
-    //   E_Float* nsurf3y = nsurfy.begin(3);
-    //   E_Float* nsurf4y = nsurfy.begin(4); E_Float* nsurf5y = nsurfy.begin(5);
-    //   E_Float* nsurf1z = nsurfz.begin(1); E_Float* nsurf2z = nsurfz.begin(2);
-    //   E_Float* nsurf3z = nsurfz.begin(3);
-    //   E_Float* nsurf4z = nsurfz.begin(4); E_Float* nsurf5z = nsurfz.begin(5);
-    //   E_Float* surf1 = surf.begin(1); E_Float* surf2 = surf.begin(2); 
-    //   E_Float* surf3 = surf.begin(3); E_Float* surf4 = surf.begin(4); E_Float* surf5 = surf.begin(5);
-      
-    //   #pragma omp parallel
-    //   {
-    //     E_Float s1, s2, s3, s4, s5, s13, s14, s15, s23, s24, s25, s34, s35, s45;
-    //     E_Float alpha13, alpha14, alpha15, alpha23, alpha24, alpha25, alpha34, alpha35, alpha45;
-    //     E_Float skewness1, skewness2, skewness3;  
-    //     #pragma omp for
-    //     for (E_Int et = 0; et < nelts; et++)
-    //     {
-    //       s1 = surf1[et]; s2 = surf2[et]; s3 = surf3[et]; s4 = surf4[et]; s5 = surf5[et];
-    //       s13 = s1*s3; s14 = s1*s4; s15 = s1*s5;  
-    //       s23 = s2*s3; s24 = s2*s4; s25 = s2*s5;  
-    //       s34 = s3*s4; s35 = s3*s5; s45 = s4*s5;  
-    //       alpha13 = E_abs(acos((nsurf1x[et]*nsurf3x[et] + nsurf1y[et]*nsurf3y[et] + nsurf1z[et]*nsurf3z[et])/s13)*degconst - 90.);
-    //       alpha14 = E_abs(acos((nsurf1x[et]*nsurf4x[et] + nsurf1y[et]*nsurf4y[et] + nsurf1z[et]*nsurf4z[et])/s14)*degconst - 90.);
-    //       alpha15 = E_abs(acos((nsurf1x[et]*nsurf5x[et] + nsurf1y[et]*nsurf5y[et] + nsurf1z[et]*nsurf5z[et])/s15)*degconst - 90.);
-    //       alpha23 = E_abs(acos((nsurf2x[et]*nsurf3x[et] + nsurf2y[et]*nsurf3y[et] + nsurf2z[et]*nsurf3z[et])/s23)*degconst - 90.);
-    //       alpha24 = E_abs(acos((nsurf2x[et]*nsurf4x[et] + nsurf2y[et]*nsurf4y[et] + nsurf2z[et]*nsurf4z[et])/s24)*degconst - 90.);
-    //       alpha25 = E_abs(acos((nsurf2x[et]*nsurf5x[et] + nsurf2y[et]*nsurf5y[et] + nsurf2z[et]*nsurf5z[et])/s25)*degconst - 90.);
-    //       alpha34 = E_abs(acos((nsurf3x[et]*nsurf4x[et] + nsurf3y[et]*nsurf4y[et] + nsurf3z[et]*nsurf4z[et])/s34)*degconst - 120.);
-    //       alpha35 = E_abs(acos((nsurf3x[et]*nsurf5x[et] + nsurf3y[et]*nsurf5y[et] + nsurf3z[et]*nsurf5z[et])/s35)*degconst - 120.);
-    //       alpha45 = E_abs(acos((nsurf4x[et]*nsurf5x[et] + nsurf4y[et]*nsurf5y[et] + nsurf4z[et]*nsurf5z[et])/s45)*degconst - 120.);
-    //       skewness1 = E_max(E_max(alpha13,alpha14),alpha15);
-    //       skewness2 = E_max(E_max(alpha23,alpha24),alpha25);
-    //       skewness3 = E_max(E_max(alpha34,alpha35),alpha45);
-    //       skewness[et] = E_max(E_max(skewness1,skewness2),skewness3);
-    //     }
-    //   }
-    // }
-    // else if (strcmp(eltType, "HEXA") == 0)
-    // {
-    //   // Compute surface normals
-    //   E_Int nvpe = cn->getNfld();
-    //   FldArrayF nsurfx(nelts, nvpe);
-    //   FldArrayF nsurfy(nelts, nvpe);
-    //   FldArrayF nsurfz(nelts, nvpe);
-    //   FldArrayF surf(nelts, nvpe);
-    //   K_METRIC::compSurfUnstruct(
-    //     *cn, "HEXA",
-    //     f->begin(posx), f->begin(posy), f->begin(posz), 
-    //     nsurfx.begin(), nsurfy.begin(), nsurfz.begin(), surf.begin());
-
-    //   // Compute dihedral angle
-    //   E_Float* nsurf1x = nsurfx.begin(1); E_Float* nsurf2x = nsurfx.begin(2); E_Float* nsurf3x = nsurfx.begin(3);
-    //   E_Float* nsurf4x = nsurfx.begin(4); E_Float* nsurf5x = nsurfx.begin(5); E_Float* nsurf6x = nsurfx.begin(6);
-    //   E_Float* nsurf1y = nsurfy.begin(1); E_Float* nsurf2y = nsurfy.begin(2); E_Float* nsurf3y = nsurfy.begin(3);
-    //   E_Float* nsurf4y = nsurfy.begin(4); E_Float* nsurf5y = nsurfy.begin(5); E_Float* nsurf6y = nsurfy.begin(6);
-    //   E_Float* nsurf1z = nsurfz.begin(1); E_Float* nsurf2z = nsurfz.begin(2); E_Float* nsurf3z = nsurfz.begin(3);
-    //   E_Float* nsurf4z = nsurfz.begin(4); E_Float* nsurf5z = nsurfz.begin(5); E_Float* nsurf6z = nsurfz.begin(6);
-    //   E_Float* surf1 = surf.begin(1); E_Float* surf2 = surf.begin(2); E_Float* surf3 = surf.begin(3);
-    //   E_Float* surf4 = surf.begin(4); E_Float* surf5 = surf.begin(5); E_Float* surf6 = surf.begin(6);
-      
-    //   #pragma omp parallel
-    //   {
-    //     E_Float s1, s2, s3, s4, s5, s6;
-    //     E_Float s13, s14, s15, s16, s23, s24, s25, s26, s35, s36, s45, s46;
-    //     E_Float alpha13, alpha14, alpha15, alpha16, alpha23, alpha24, alpha25, alpha26;
-    //     E_Float alpha35, alpha36, alpha45, alpha46;
-    //     E_Float skewness1, skewness2, skewness3, skewness4;
-        
-    //     #pragma omp for
-    //     for (E_Int et = 0; et < nelts; et++)
-    //     {
-    //       s1 = surf1[et]; s2 = surf2[et]; s3 = surf3[et];
-    //       s4 = surf4[et]; s5 = surf5[et]; s6 = surf6[et];
-    //       s13 = s1*s3; s14 = s1*s4; s15 = s1*s5; s16 = s1*s6; 
-    //       s23 = s2*s3; s24 = s2*s4; s25 = s2*s5; s26 = s2*s6; 
-    //       s35 = s3*s5; s36 = s3*s6; s45 = s4*s5; s46 = s4*s6; 
-    //       alpha13 = E_abs(acos((nsurf1x[et]*nsurf3x[et] + nsurf1y[et]*nsurf3y[et] + nsurf1z[et]*nsurf3z[et])/s13)*degconst - 90.);
-    //       alpha14 = E_abs(acos((nsurf1x[et]*nsurf4x[et] + nsurf1y[et]*nsurf4y[et] + nsurf1z[et]*nsurf4z[et])/s14)*degconst - 90.);
-    //       alpha15 = E_abs(acos((nsurf1x[et]*nsurf5x[et] + nsurf1y[et]*nsurf5y[et] + nsurf1z[et]*nsurf5z[et])/s15)*degconst - 90.);
-    //       alpha16 = E_abs(acos((nsurf1x[et]*nsurf6x[et] + nsurf1y[et]*nsurf6y[et] + nsurf1z[et]*nsurf6z[et])/s16)*degconst - 90.);
-    //       alpha23 = E_abs(acos((nsurf2x[et]*nsurf3x[et] + nsurf2y[et]*nsurf3y[et] + nsurf2z[et]*nsurf3z[et])/s23)*degconst - 90.);
-    //       alpha24 = E_abs(acos((nsurf2x[et]*nsurf4x[et] + nsurf2y[et]*nsurf4y[et] + nsurf2z[et]*nsurf4z[et])/s24)*degconst - 90.);
-    //       alpha25 = E_abs(acos((nsurf2x[et]*nsurf5x[et] + nsurf2y[et]*nsurf5y[et] + nsurf2z[et]*nsurf5z[et])/s25)*degconst - 90.);
-    //       alpha26 = E_abs(acos((nsurf2x[et]*nsurf6x[et] + nsurf2y[et]*nsurf6y[et] + nsurf2z[et]*nsurf6z[et])/s26)*degconst - 90.);
-    //       alpha35 = E_abs(acos((nsurf3x[et]*nsurf5x[et] + nsurf3y[et]*nsurf5y[et] + nsurf3z[et]*nsurf5z[et])/s35)*degconst - 90.);
-    //       alpha36 = E_abs(acos((nsurf3x[et]*nsurf6x[et] + nsurf3y[et]*nsurf6y[et] + nsurf3z[et]*nsurf6z[et])/s36)*degconst - 90.);
-    //       alpha45 = E_abs(acos((nsurf4x[et]*nsurf5x[et] + nsurf4y[et]*nsurf5y[et] + nsurf4z[et]*nsurf5z[et])/s45)*degconst - 90.);
-    //       alpha46 = E_abs(acos((nsurf4x[et]*nsurf6x[et] + nsurf4y[et]*nsurf6y[et] + nsurf4z[et]*nsurf6z[et])/s46)*degconst - 90.);
-    //       skewness1 = E_max(E_max(alpha13,alpha14),alpha15);
-    //       skewness2 = E_max(E_max(alpha16,alpha23),alpha24);
-    //       skewness3 = E_max(E_max(alpha25,alpha26),alpha35);
-    //       skewness4 = E_max(E_max(alpha36,alpha45),alpha46);
-    //       skewness[et] = E_max(E_max(skewness1,skewness2),E_max(skewness3,skewness4));
-    //     }
-    //   }
-    // }
-    // else if (strcmp(eltType, "BAR") == 0)
-    // {
-    //   for (E_Int et = 0; et < nelts; et++)
-    //   {
-    //     skewness[et] = 0.;
-    //   }
-    // }
-    // else
-    // {
-    //   PyErr_SetString(PyExc_TypeError,
-    //                   "getOrthogonalityMap: unknown type of element.");
-    //   RELEASESHAREDS(tpl, f2);
-    //   RELEASESHAREDU(array, f, cn);
-    //   return NULL;
-    // }
+    for (size_t ic = 0; ic < eltTypes.size(); ic++) delete [] eltTypes[ic];
     RELEASESHAREDS(tpl, f2);
     RELEASESHAREDU(array, f, cn); 
     return tpl;

--- a/Cassiopee/Generator/Generator/getOrthogonalityMap.cpp
+++ b/Cassiopee/Generator/Generator/getOrthogonalityMap.cpp
@@ -283,21 +283,23 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
     #pragma omp parallel
     {
       E_Float skewness1, skewness2, skewness3, skewness4;
-      E_Int ind1, ind2, ind3, ind4;
+      E_Int ind, ind1, ind2, ind3, ind4;
       E_Int nelts, nvpf;
+      E_Int elOffset = 0;
+      std::vector<std::vector<E_Int> > facets;
       // loop over all connectivities
       for (E_Int ic = 0; ic < nc; ic++)
       {
         K_FLD::FldArrayI& cm = *(cn->getConnect(ic));
         nelts = cm.getSize();
-        std::vector<std::vector<E_Int> > facets;
         K_CONNECT::getEVFacets(facets, eltTypes[ic], false, false);
         
         // loop over all elements of connectivity cm
         #pragma omp for
         for (E_Int i = 0; i < nelts; i++)
         {
-          skewness[i] = 0.;
+          ind = i + elOffset; // true element index
+          skewness[ind] = 0.;
 
           // loop over all faces of element i
           for (E_Int f = 0; f < nfpe[ic]; f++)
@@ -310,12 +312,12 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
               ind3 = cm(i,facets[f][2])-1;
               ind4 = cm(i,facets[f][3])-1;
 
-              skewness1 = computeSkewness(x, y, z, ind1, ind4, ind2, 90., normalized);
-              skewness2 = computeSkewness(x, y, z, ind2, ind1, ind3, 90., normalized);
-              skewness3 = computeSkewness(x, y, z, ind3, ind2, ind4, 90., normalized);
-              skewness4 = computeSkewness(x, y, z, ind4, ind3, ind1, 90., normalized);
+              skewness1 = computeSkewness(x, y, z, ind1, ind4, ind2, 90., normalized); // angle 412
+              skewness2 = computeSkewness(x, y, z, ind2, ind1, ind3, 90., normalized); // angle 123
+              skewness3 = computeSkewness(x, y, z, ind3, ind2, ind4, 90., normalized); // angle 234
+              skewness4 = computeSkewness(x, y, z, ind4, ind3, ind1, 90., normalized); // angle 341
 
-              skewness[i] = E_max(E_max(E_max(E_max(skewness1,skewness2),skewness3),skewness4),skewness[i]);
+              skewness[ind] = E_max(E_max(E_max(E_max(skewness1,skewness2),skewness3),skewness4),skewness[ind]);
             }
             else if (nvpf == 3) // TRI face
             {
@@ -323,14 +325,15 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
               ind2 = cm(i,facets[f][1])-1;
               ind3 = cm(i,facets[f][2])-1;
 
-              skewness1 = computeSkewness(x, y, z, ind1, ind3, ind2, 60., normalized);
-              skewness2 = computeSkewness(x, y, z, ind2, ind1, ind3, 60., normalized);
-              skewness3 = computeSkewness(x, y, z, ind3, ind2, ind1, 60., normalized);
+              skewness1 = computeSkewness(x, y, z, ind1, ind3, ind2, 60., normalized); // angle 312
+              skewness2 = computeSkewness(x, y, z, ind2, ind1, ind3, 60., normalized); // angle 123
+              skewness3 = computeSkewness(x, y, z, ind3, ind2, ind1, 60., normalized); // angle 231
 
-              skewness[i] = E_max(E_max(E_max(skewness1,skewness2),skewness3),skewness[i]);
+              skewness[ind] = E_max(E_max(E_max(skewness1,skewness2),skewness3),skewness[ind]);
             }
           }
         }
+        elOffset += nelts;
       }
     }
 

--- a/Cassiopee/Generator/Generator/getOrthogonalityMap.cpp
+++ b/Cassiopee/Generator/Generator/getOrthogonalityMap.cpp
@@ -57,8 +57,7 @@ inline E_Float computeSkewness(
   E_Float refAngle, E_Int normalized
 )
 {
-  E_Float pi = 4*atan(1.);
-  E_Float degconst = 180.0 / pi;
+  E_Float degconst = 180.0 / K_CONST::E_PI;
   E_Float alpha = computeAngle(x, y, z, ind1, ind2, ind3)*degconst;
   
   E_Float skewness = E_abs(alpha - refAngle);
@@ -122,10 +121,6 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
   E_Float* x = f->begin(posx);
   E_Float* y = f->begin(posy);
   E_Float* z = f->begin(posz);
-
-  // valeur de pi pour exprimer les angles en degre
-  E_Float pi = 4*atan(1.);
-  E_Float degconst = 180.0 / pi;
 
   if (res == 1) // cas structure
   {

--- a/Cassiopee/Generator/Generator/getOrthogonalityMap.cpp
+++ b/Cassiopee/Generator/Generator/getOrthogonalityMap.cpp
@@ -20,10 +20,49 @@
 // getOrthogonalityMap
 
 # include "generator.h"
+# include <math.h>
 
 using namespace K_CONST;
 using namespace K_FLD;
 using namespace K_FUNC;
+
+inline E_Float computeAngle(
+  const E_Float* x, const E_Float* y, const E_Float* z,
+  E_Int ind1, E_Int ind2, E_Int ind3
+)
+{
+  E_Float x1 = x[ind1], x2 = x[ind2], x3 = x[ind3];
+  E_Float y1 = y[ind1], y2 = y[ind2], y3 = y[ind3];
+  E_Float z1 = z[ind1], z2 = z[ind2], z3 = z[ind3];
+
+  E_Float a2 = (x2-x1)*(x2-x1)+(y2-y1)*(y2-y1)+(z2-z1)*(z2-z1);
+  E_Float b2 = (x3-x1)*(x3-x1)+(y3-y1)*(y3-y1)+(z3-z1)*(z3-z1);
+  E_Float c2 = (x3-x2)*(x3-x2)+(y3-y2)*(y3-y2)+(z3-z2)*(z3-z2);
+
+  if (a2 < E_GEOM_CUTOFF || b2 < E_GEOM_CUTOFF) // security check
+  { 
+    return 0.;
+  }
+
+  E_Float a = sqrt(a2);
+  E_Float b = sqrt(b2);
+  E_Float cosalpha = E_max(E_min((a2+b2-c2)/(2.*a*b),1.),-1.); // law of cosines
+
+  return acos(cosalpha);
+}
+
+inline E_Float computeSkewness(
+  const E_Float* x, const E_Float* y, const E_Float* z,
+  E_Int ind1, E_Int ind2, E_Int ind3,
+  E_Float refAngle
+)
+{
+  E_Float pi = 4*atan(1.);
+  E_Float degconst = 180.0 / pi;
+  E_Float alpha = computeAngle(x, y, z, ind1, ind2, ind3);
+
+  return E_abs(alpha*degconst - refAngle);
+}
 
 // ============================================================================
 /* Return orthogonality map */
@@ -53,7 +92,10 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
     return NULL;
   }
 
+  E_Int api = f->getApi();
+  E_Int npts = f->getSize();
   PyObject* tpl = NULL;
+  FldArrayF* f2;
   
   posx = K_ARRAY::isCoordinateXPresent(varString);
   posy = K_ARRAY::isCoordinateYPresent(varString);
@@ -71,12 +113,10 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
   E_Float* x = f->begin(posx);
   E_Float* y = f->begin(posy);
   E_Float* z = f->begin(posz);
+
   // valeur de pi pour exprimer les angles en degre
   E_Float pi = 4*atan(1.);
   E_Float degconst = 180.0 / pi;
-
-  E_Int api = f->getApi();
-  E_Int nvertex = f->getSize();
 
   if (res == 1) // cas structure
   {
@@ -88,398 +128,427 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
     if (im == 1) im1 = 1;
     if (jm == 1) jm1 = 1;
     if (km == 1) km1 = 1;
-    // Direction constante (en 2D)
-    // 0: 3D
-    // 1: 2D i constant
-    // 2: 2D j constant
-    // 3: 2D k constant
-    E_Int dir = 0;
-    if (im == 1)
+    E_Int ni = im;
+    E_Int nj = jm;
+    E_Int nk = km;
+
+    if (im == 1) // i constant
     {
-      dim = 2; dir=1;
-      if ((jm ==1)||(km == 1)) dim = 1;
+      if (jm == 1 || km == 1) dim = 1;
+      else
+      {
+        dim = 2;
+        ni = jm; nj = km;
+      }
     }
-    else if (jm == 1)
+    else if (jm == 1) // i constant
     {
-      dim = 2; dir = 2;
-      if ((im ==1)||(km == 1)) dim = 1;
+      if (im == 1 || km == 1) dim = 1;
+      else
+      {
+        dim = 2;
+        ni = im; nj = km;
+      }
     } 
-    else if (km == 1)
+    else if (km == 1) // k constant
     {
-      dim = 2; dir = 3;
-      if ((im ==1)||(jm == 1)) dim = 1;
+      if (im == 1 || jm == 1) dim = 1;
+      else
+      {
+        dim = 2;
+        ni = im; nj = jm;
+      }
     }
+
+    E_Int ni1 = ni-1; E_Int nj1 = nj-1; E_Int nk1 = nk-1;
+    if (ni == 1) ni1 = 1;
+    if (nj == 1) nj1 = 1;
+    if (nk == 1) nk1 = 1;
     
     // Construction du tableau numpy stockant les angles 
     // definissant l'orthogonalite
     tpl = K_ARRAY::buildArray3(1, "orthogonality", im1, jm1, km1, api);
-    // pointeur sur le tableau d'angle
-    FldArrayF* f2;
     K_ARRAY::getFromArray3(tpl, f2);
-    E_Float* alphamax = f2->begin(1);
+    E_Float* skewness = f2->begin(1); // pointeur sur le tableau d'angle
 
     E_Int ncells = im1*jm1*km1;
     
     // calcul de l'orthogonalite
-    if (dim == 1)         // dimension = 1D
+    #pragma omp parallel
     {
-      for (E_Int i = 0; i < ncells; i++) alphamax[i] = 0.;
-    }
-    else if (dim == 2) // dimension = 2D
-    {
-      // (ni,nj) : dimensions of 2D-grid 
-      E_Int ni=1, nj=1;
-      switch (dir)
+      E_Float skewness1, skewness2, skewness3;
+      E_Int inext, jnext, knext, ind, ind1, ind2, ind3;
+      if (dim == 1)
       {
-        case 3: // k constant
-          ni = im; nj = jm;
-          break;
-        case 2: // j constant
-          ni = im; nj = km;
-          break;
-        case 1: // i constant
-          ni = jm; nj = km;
-          break;
+        #pragma omp for
+        for (E_Int i = 0; i < ncells; i++) skewness[i] = 0.;
       }
-
-      E_Int ni1 = ni - 1; E_Int nj1 = nj - 1;
-      if (ni == 1) ni1 = 1;
-      if (nj == 1) nj1 = 1;
-
-      // Boucle sur les indices de la grille
-      for (E_Int j = 0; j < nj1; j++)
+      else if (dim == 2)
+      {
+        #pragma omp for collapse(2)
+        for (E_Int j = 0; j < nj1; j++)
         for (E_Int i = 0; i < ni1; i++)
         {
           // indices pour le calcul de l'angle definissant l'orthogonalite
-          E_Int inext = i+1;
-          E_Int jnext = j+1;
+          inext = i+1;
+          jnext = j+1;
           // calcul de l'angle
-          E_Int ind = j*ni1+i;
-          E_Int ind1 = j*ni+i;
-          E_Int ind2 = j*ni+inext;
-          E_Int ind3 = jnext*ni+i;
-          E_Float a2 = (x[ind2]-x[ind1])*(x[ind2]-x[ind1])+(y[ind2]-y[ind1])*(y[ind2]-y[ind1])+(z[ind2]-z[ind1])*(z[ind2]-z[ind1]);
-          E_Float b2 = (x[ind3]-x[ind1])*(x[ind3]-x[ind1])+(y[ind3]-y[ind1])*(y[ind3]-y[ind1])+(z[ind3]-z[ind1])*(z[ind3]-z[ind1]);
-          E_Float c2 = (x[ind3]-x[ind2])*(x[ind3]-x[ind2])+(y[ind3]-y[ind2])*(y[ind3]-y[ind2])+(z[ind3]-z[ind2])*(z[ind3]-z[ind2]);
-          E_Float a = sqrt(a2);
-          E_Float b = sqrt(b2);
-          alphamax[ind] = E_abs(acos((a2+b2-c2)/(2.*a*b))*degconst - 90.);
+          ind = j*ni1+i;
+          ind1 = j*ni+i;
+          ind2 = j*ni+inext;
+          ind3 = jnext*ni+i;
+          skewness[ind] = computeSkewness(x, y, z, ind1, ind2, ind3, 90.);
         }
-    }
-    else  // dim == 3 (dimension = 3D)
-    {	      
-      // (ni,nj,nk) : dimensions of 3D-grid 
-      E_Int ni = im;
-      E_Int nj = jm;
-      E_Int nk = km;
-      E_Int ni1 = ni - 1; E_Int nj1 = nj - 1; E_Int nk1 = nk - 1;
-      if (ni == 1) ni1 = 1;
-      if (nj == 1) nj1 = 1;
-      if (nk == 1) nk1 = 1;
-
-      // angle by mesh direction
-      // Boucle sur les indices de la grille
-      #pragma omp parallel
+      }
+      else // dim == 3
       {
-        E_Float alpha1, alpha2, alpha3, a2, b2, c2, a, b;
-        E_Int inext, jnext, knext, ind, ind1, ind2, ind3;
-
-        for (E_Int k=0; k < nk1; k++)
-        for (E_Int j=0; j < nj1; j++)
-          #pragma omp for
-          for (E_Int i=0; i < ni1; i++)
-          {
-            // indices pour le calcul des angles definissant l'orthogonalite
-            inext = i+1;
-            jnext = j+1;
-            knext = k+1;
-            // calcul des angles
-            ind  = k*ni1*nj1+j*ni1+i;
-            ind1 = k*ni*nj+j*ni+i;
-            ind2 = k*ni*nj+j*ni+inext;
-            ind3 = k*ni*nj+jnext*ni+i;
-            a2 = (x[ind2]-x[ind1])*(x[ind2]-x[ind1])+(y[ind2]-y[ind1])*(y[ind2]-y[ind1])+(z[ind2]-z[ind1])*(z[ind2]-z[ind1]);
-            b2 = (x[ind3]-x[ind1])*(x[ind3]-x[ind1])+(y[ind3]-y[ind1])*(y[ind3]-y[ind1])+(z[ind3]-z[ind1])*(z[ind3]-z[ind1]);
-            c2 = (x[ind3]-x[ind2])*(x[ind3]-x[ind2])+(y[ind3]-y[ind2])*(y[ind3]-y[ind2])+(z[ind3]-z[ind2])*(z[ind3]-z[ind2]);
-            a = sqrt(a2);
-            b = sqrt(b2);
-            // ... angle correspondant aux indices (ij)
-            alpha1 = E_abs(acos((a2+b2-c2)/(2.*a*b))*degconst - 90.);
-            // ... angle correspondant aux indices (ik)
-            ind3 = knext*ni*nj+j*ni+i;
-            b2 = (x[ind3]-x[ind1])*(x[ind3]-x[ind1])+(y[ind3]-y[ind1])*(y[ind3]-y[ind1])+(z[ind3]-z[ind1])*(z[ind3]-z[ind1]);
-            c2 = (x[ind3]-x[ind2])*(x[ind3]-x[ind2])+(y[ind3]-y[ind2])*(y[ind3]-y[ind2])+(z[ind3]-z[ind2])*(z[ind3]-z[ind2]);
-            b = sqrt(b2);
-            alpha2 = E_abs(acos((a2+b2-c2)/(2.*a*b))*degconst - 90.);
-            // ... angle correspondant aux indices (jk)
-            ind2 = k*ni*nj+jnext*ni+i;
-            a2 = (x[ind2]-x[ind1])*(x[ind2]-x[ind1])+(y[ind2]-y[ind1])*(y[ind2]-y[ind1])+(z[ind2]-z[ind1])*(z[ind2]-z[ind1]);
-            c2 = (x[ind3]-x[ind2])*(x[ind3]-x[ind2])+(y[ind3]-y[ind2])*(y[ind3]-y[ind2])+(z[ind3]-z[ind2])*(z[ind3]-z[ind2]);
-            a = sqrt(a2);
-            alpha3 = E_abs(acos((a2+b2-c2)/(2.*a*b))*degconst - 90.);
-            alphamax[ind] = E_max(E_max(alpha1,alpha2),alpha3);
-          }
+        #pragma omp for collapse(3)  
+        for (E_Int k = 0; k < nk1; k++)
+        for (E_Int j = 0; j < nj1; j++)
+        for (E_Int i = 0; i < ni1; i++)
+        {
+          // indices pour le calcul des angles definissant l'orthogonalite
+          inext = i+1;
+          jnext = j+1;
+          knext = k+1;
+          // calcul des angles
+          ind  = k*ni1*nj1+j*ni1+i;
+          ind1 = k*ni*nj+j*ni+i;
+          ind2 = k*ni*nj+j*ni+inext;
+          ind3 = k*ni*nj+jnext*ni+i;
+          // ... angle correspondant aux indices (ij)
+          skewness1 = computeSkewness(x, y, z, ind1, ind2, ind3, 90.);
+          // ... angle correspondant aux indices (ik)
+          ind3 = knext*ni*nj+j*ni+i;
+          skewness2 = computeSkewness(x, y, z, ind1, ind2, ind3, 90.);
+          // ... angle correspondant aux indices (jk)
+          ind2 = k*ni*nj+jnext*ni+i;
+          skewness3 = computeSkewness(x, y, z, ind1, ind2, ind3, 90.);
+          // max skewness
+          skewness[ind] = E_max(E_max(skewness1,skewness2),skewness3);
+        }
       }
     }
+
     RELEASESHAREDS(tpl, f2);
     RELEASESHAREDS(array, f);
     return tpl;
   }
   else // Cas non structure
   {
-    E_Int nelts = cn->getSize(); // nb d'elements
-    PyObject* tpl = K_ARRAY::buildArray3(1, "orthogonality", nvertex, *cn, eltType, 1, api, true);
-    FldArrayF* f2;
+    tpl = K_ARRAY::buildArray3(
+      1, "orthogonality", npts, *cn, eltType, true, api, true
+    );
     K_ARRAY::getFromArray3(tpl, f2);
-    E_Float* alphamax = f2->begin(1);
- 
-    if (strcmp(eltType, "TRI") == 0)
+    E_Float* skewness = f2->begin(1); // pointeur sur le tableau d'angle
+
+    if (strcmp(eltType, "NGON") == 0)
     {
-      E_Int* cn1 = cn->begin(1); E_Int* cn2 = cn->begin(2); E_Int* cn3 = cn->begin(3);
-      E_Float eps = 1.e-6;
-      #pragma omp parallel
-      {
-        E_Float d1, d2, d3, alpha12, alpha23, alpha31, sqrtd1, sqrtd2, sqrtd3;
-        E_Int ind1, ind2, ind3;
-        #pragma omp for
-        for (E_Int et = 0; et < nelts; et++)
-        {
-          ind1 = cn1[et]-1;
-          ind2 = cn2[et]-1;
-          ind3 = cn3[et]-1;
-
-          d1 = (x[ind2]-x[ind1])*(x[ind2]-x[ind1])+(y[ind2]-y[ind1])*(y[ind2]-y[ind1])+(z[ind2]-z[ind1])*(z[ind2]-z[ind1]); sqrtd1 = sqrt(d1);
-          d2 = (x[ind3]-x[ind2])*(x[ind3]-x[ind2])+(y[ind3]-y[ind2])*(y[ind3]-y[ind2])+(z[ind3]-z[ind2])*(z[ind3]-z[ind2]); sqrtd2 = sqrt(d2);
-          d3 = (x[ind1]-x[ind3])*(x[ind1]-x[ind3])+(y[ind1]-y[ind3])*(y[ind1]-y[ind3])+(z[ind1]-z[ind3])*(z[ind1]-z[ind3]); sqrtd3 = sqrt(d3);
-
-          if (( K_FUNC::fEqualZero(d1,eps) == true )||
-              ( K_FUNC::fEqualZero(d2,eps) == true )||
-              ( K_FUNC::fEqualZero(d3,eps) == true ))
-          {
-            // degenerated element
-            alphamax[et] = 120.; // 180. - 60.
-          }
-          else
-          {
-            alpha12 = E_abs(acos((d1 + d2 - d3)/(E_max(TWO*sqrtd1*sqrtd2,E_GEOM_CUTOFF)))*degconst - 60.);
-            alpha23 = E_abs(acos((d2 + d3 - d1)/(E_max(TWO*sqrtd2*sqrtd3,E_GEOM_CUTOFF)))*degconst - 60.);
-            alpha31 = E_abs(acos((d3 + d1 - d2)/(E_max(TWO*sqrtd3*sqrtd1,E_GEOM_CUTOFF)))*degconst - 60.);
-            alphamax[et] = E_max(E_max(alpha12,alpha23),alpha31);
-          }
-        }
-      }
+      PyErr_SetString(PyExc_TypeError,
+                      "getOrthogonalityMap: not implemented for NGON arrays.");
+      RELEASESHAREDS(tpl, f2);
+      RELEASESHAREDU(array, f, cn);
+      return NULL;
     }
-    else if (strcmp(eltType, "QUAD") == 0)
+
+    E_Int nc = cn->getNConnect();
+
+    // Number of facets per element
+    std::vector<E_Int> nfpe;
+    E_Int ierr = K_CONNECT::getNFPE(nfpe, eltType, false);
+    if (ierr != 0)
     {
-      E_Int* cn1 = cn->begin(1); E_Int* cn2 = cn->begin(2); E_Int* cn3 = cn->begin(3); E_Int* cn4 = cn->begin(4);
-      E_Int ind1, ind2, ind3, ind4;
-      E_Float d1, d2, d3, d4, diag13, diag24, alpha12, alpha14, alpha32, alpha34;
-      E_Float sqrtd1, sqrtd2, sqrtd3, sqrtd4;
-      #pragma omp for
-      for (E_Int et = 0; et < nelts; et++)
-      {
-        ind1 = cn1[et]-1;
-        ind2 = cn2[et]-1;
-        ind3 = cn3[et]-1;
-        ind4 = cn4[et]-1;
-
-        d1     = (x[ind2]-x[ind1])*(x[ind2]-x[ind1])+(y[ind2]-y[ind1])*(y[ind2]-y[ind1])+(z[ind2]-z[ind1])*(z[ind2]-z[ind1]); sqrtd1 = sqrt(d1);
-        d2     = (x[ind3]-x[ind2])*(x[ind3]-x[ind2])+(y[ind3]-y[ind2])*(y[ind3]-y[ind2])+(z[ind3]-z[ind2])*(z[ind3]-z[ind2]); sqrtd2 = sqrt(d2);
-        d3     = (x[ind4]-x[ind3])*(x[ind4]-x[ind3])+(y[ind4]-y[ind3])*(y[ind4]-y[ind3])+(z[ind4]-z[ind3])*(z[ind4]-z[ind3]); sqrtd3 = sqrt(d3);
-        d4     = (x[ind1]-x[ind4])*(x[ind1]-x[ind4])+(y[ind1]-y[ind4])*(y[ind1]-y[ind4])+(z[ind1]-z[ind4])*(z[ind1]-z[ind4]); sqrtd4 = sqrt(d4);
-        diag13 = (x[ind1]-x[ind3])*(x[ind1]-x[ind3])+(y[ind1]-y[ind3])*(y[ind1]-y[ind3])+(z[ind1]-z[ind3])*(z[ind1]-z[ind3]);
-        diag24 = (x[ind2]-x[ind4])*(x[ind2]-x[ind4])+(y[ind2]-y[ind4])*(y[ind2]-y[ind4])+(z[ind2]-z[ind4])*(z[ind2]-z[ind4]);
-
-        alpha12 = E_abs(acos((d1 + d2 - diag13)/(E_max(TWO*sqrtd1*sqrtd2,E_GEOM_CUTOFF)))*degconst - 90.);
-        alpha14 = E_abs(acos((d1 + d4 - diag24)/(E_max(TWO*sqrtd1*sqrtd4,E_GEOM_CUTOFF)))*degconst - 90.);
-        alpha32 = E_abs(acos((d3 + d2 - diag24)/(E_max(TWO*sqrtd3*sqrtd2,E_GEOM_CUTOFF)))*degconst - 90.);
-        alpha34 = E_abs(acos((d3 + d4 - diag13)/(E_max(TWO*sqrtd3*sqrtd4,E_GEOM_CUTOFF)))*degconst - 90.);
-        alphamax[et] = E_max(E_max(alpha12,alpha14),E_max(alpha32,alpha34));
-      }
+      PyErr_SetString(PyExc_TypeError,
+                      "getOrthogonalityMap: Error computing nfpe.");
+      RELEASESHAREDS(tpl, f2);
+      RELEASESHAREDU(array, f, cn);
+      return NULL;
     }
-    else if (strcmp(eltType, "TETRA") == 0)
-    {
-      // Compute surface normals
-      E_Int nvpe = cn->getNfld();
-      FldArrayF nsurfx(nelts, nvpe);
-      FldArrayF nsurfy(nelts, nvpe);
-      FldArrayF nsurfz(nelts, nvpe);
-      FldArrayF surf(nelts, nvpe);
-      K_METRIC::compSurfUnstruct(
-        *cn, "TETRA", 
-        f->begin(posx), f->begin(posy), f->begin(posz), 
-        nsurfx.begin(), nsurfy.begin(), nsurfz.begin(), surf.begin());
 
-      // Compute dihedral angle
-      E_Float* nsurf1x = nsurfx.begin(1); E_Float* nsurf2x = nsurfx.begin(2);
-      E_Float* nsurf3x = nsurfx.begin(3);E_Float* nsurf4x = nsurfx.begin(4);
-      E_Float* nsurf1y = nsurfy.begin(1); E_Float* nsurf2y = nsurfy.begin(2);
-      E_Float* nsurf3y = nsurfy.begin(3);E_Float* nsurf4y = nsurfy.begin(4);
-      E_Float* nsurf1z = nsurfz.begin(1); E_Float* nsurf2z = nsurfz.begin(2);
-      E_Float* nsurf3z = nsurfz.begin(3);E_Float* nsurf4z = nsurfz.begin(4);
-      E_Float* surf1 = surf.begin(1); E_Float* surf2 = surf.begin(2); 
-      E_Float* surf3 = surf.begin(3); E_Float* surf4 = surf.begin(4);
     
-      #pragma omp parallel
-      {
-        E_Float s1, s2, s3,s4, s12, s13, s23, s14, s24, s34;
-        E_Float alpha12, alpha14, alpha24, alpha13, alpha23, alpha34;
-        E_Float alphamax1, alphamax2, alphamax3;
-        #pragma omp for
-        for (E_Int et = 0; et < nelts; et++)
-        {
-          s1 = surf1[et]; s2 = surf2[et]; s3 = surf3[et]; s4 = surf4[et];
-          s12 = s1*s2; s13 = s1*s3; s14 = s1*s4;  
-          s23 = s2*s3; s24 = s2*s4; s34 = s3*s4;
-          alpha12 = E_abs(acos((nsurf1x[et]*nsurf2x[et] + nsurf1y[et]*nsurf2y[et] + nsurf1z[et]*nsurf2z[et])/s12)*degconst - 120.);
-          alpha14 = E_abs(acos((nsurf1x[et]*nsurf4x[et] + nsurf1y[et]*nsurf4y[et] + nsurf1z[et]*nsurf4z[et])/s14)*degconst - 120.);
-          alpha24 = E_abs(acos((nsurf2x[et]*nsurf4x[et] + nsurf2y[et]*nsurf4y[et] + nsurf2z[et]*nsurf4z[et])/s24)*degconst - 120.);
-          alpha13 = E_abs(acos((nsurf1x[et]*nsurf3x[et] + nsurf1y[et]*nsurf3y[et] + nsurf1z[et]*nsurf3z[et])/s13)*degconst - 120.);
-          alpha23 = E_abs(acos((nsurf2x[et]*nsurf3x[et] + nsurf2y[et]*nsurf3y[et] + nsurf2z[et]*nsurf3z[et])/s23)*degconst - 120.);
-          alpha34 = E_abs(acos((nsurf3x[et]*nsurf4x[et] + nsurf3y[et]*nsurf4y[et] + nsurf3z[et]*nsurf4z[et])/s34)*degconst - 120.);
-          alphamax1 = E_max(alpha12,alpha14);
-          alphamax2 = E_max(alpha24,alpha13);
-          alphamax3 = E_max(alpha23,alpha34);
-          alphamax[et] = E_max(E_max(alphamax1,alphamax2),alphamax3);
-        }
-      }
-    }
-    else if (strcmp(eltType, "PYRA") == 0)
+    // calcul de l'orthogonalite
+    #pragma omp parallel
     {
-      PyErr_SetString(PyExc_TypeError,
-                    "getOrthogonalityMap: not yet implemented for PYRA.");
-      RELEASESHAREDS(tpl, f2);
-      RELEASESHAREDU(array, f, cn);
-      return NULL;
-    }
-    else if (strcmp(eltType, "PENTA") == 0)
-    {
-      // Compute surface normals
-      E_Int nvpe = cn->getNfld();
-      FldArrayF nsurfx(nelts, nvpe);
-      FldArrayF nsurfy(nelts, nvpe);
-      FldArrayF nsurfz(nelts, nvpe);
-      FldArrayF surf(nelts, nvpe);
-      K_METRIC::compSurfUnstruct(
-        *cn, "PENTA",
-        f->begin(posx), f->begin(posy), f->begin(posz), 
-        nsurfx.begin(), nsurfy.begin(), nsurfz.begin(), surf.begin());
-
-      // Compute dihedral angle
-      E_Float* nsurf1x = nsurfx.begin(1); E_Float* nsurf2x = nsurfx.begin(2);
-      E_Float* nsurf3x = nsurfx.begin(3);
-      E_Float* nsurf4x = nsurfx.begin(4); E_Float* nsurf5x = nsurfx.begin(5);
-      E_Float* nsurf1y = nsurfy.begin(1); E_Float* nsurf2y = nsurfy.begin(2);
-      E_Float* nsurf3y = nsurfy.begin(3);
-      E_Float* nsurf4y = nsurfy.begin(4); E_Float* nsurf5y = nsurfy.begin(5);
-      E_Float* nsurf1z = nsurfz.begin(1); E_Float* nsurf2z = nsurfz.begin(2);
-      E_Float* nsurf3z = nsurfz.begin(3);
-      E_Float* nsurf4z = nsurfz.begin(4); E_Float* nsurf5z = nsurfz.begin(5);
-      E_Float* surf1 = surf.begin(1); E_Float* surf2 = surf.begin(2); 
-      E_Float* surf3 = surf.begin(3); E_Float* surf4 = surf.begin(4); E_Float* surf5 = surf.begin(5);
-      
-      #pragma omp parallel
+      E_Float skewness1, skewness2, skewness3, skewness4;
+      E_Int nelts, nvpf;
+      // loop over all connectivities
+      for (E_Int ic = 0; ic < nc; ic++)
       {
-        E_Float s1, s2, s3, s4, s5, s13, s14, s15, s23, s24, s25, s34, s35, s45;
-        E_Float alpha13, alpha14, alpha15, alpha23, alpha24, alpha25, alpha34, alpha35, alpha45;
-        E_Float alphamax1, alphamax2, alphamax3;  
-        #pragma omp for
-        for (E_Int et = 0; et < nelts; et++)
-        {
-          s1 = surf1[et]; s2 = surf2[et]; s3 = surf3[et]; s4 = surf4[et]; s5 = surf5[et];
-          s13 = s1*s3; s14 = s1*s4; s15 = s1*s5;  
-          s23 = s2*s3; s24 = s2*s4; s25 = s2*s5;  
-          s34 = s3*s4; s35 = s3*s5; s45 = s4*s5;  
-          alpha13 = E_abs(acos((nsurf1x[et]*nsurf3x[et] + nsurf1y[et]*nsurf3y[et] + nsurf1z[et]*nsurf3z[et])/s13)*degconst - 90.);
-          alpha14 = E_abs(acos((nsurf1x[et]*nsurf4x[et] + nsurf1y[et]*nsurf4y[et] + nsurf1z[et]*nsurf4z[et])/s14)*degconst - 90.);
-          alpha15 = E_abs(acos((nsurf1x[et]*nsurf5x[et] + nsurf1y[et]*nsurf5y[et] + nsurf1z[et]*nsurf5z[et])/s15)*degconst - 90.);
-          alpha23 = E_abs(acos((nsurf2x[et]*nsurf3x[et] + nsurf2y[et]*nsurf3y[et] + nsurf2z[et]*nsurf3z[et])/s23)*degconst - 90.);
-          alpha24 = E_abs(acos((nsurf2x[et]*nsurf4x[et] + nsurf2y[et]*nsurf4y[et] + nsurf2z[et]*nsurf4z[et])/s24)*degconst - 90.);
-          alpha25 = E_abs(acos((nsurf2x[et]*nsurf5x[et] + nsurf2y[et]*nsurf5y[et] + nsurf2z[et]*nsurf5z[et])/s25)*degconst - 90.);
-          alpha34 = E_abs(acos((nsurf3x[et]*nsurf4x[et] + nsurf3y[et]*nsurf4y[et] + nsurf3z[et]*nsurf4z[et])/s34)*degconst - 120.);
-          alpha35 = E_abs(acos((nsurf3x[et]*nsurf5x[et] + nsurf3y[et]*nsurf5y[et] + nsurf3z[et]*nsurf5z[et])/s35)*degconst - 120.);
-          alpha45 = E_abs(acos((nsurf4x[et]*nsurf5x[et] + nsurf4y[et]*nsurf5y[et] + nsurf4z[et]*nsurf5z[et])/s45)*degconst - 120.);
-          alphamax1 = E_max(E_max(alpha13,alpha14),alpha15);
-          alphamax2 = E_max(E_max(alpha23,alpha24),alpha25);
-          alphamax3 = E_max(E_max(alpha34,alpha35),alpha45);
-          alphamax[et] = E_max(E_max(alphamax1,alphamax2),alphamax3);
-        }
-      }
-    }
-    else if (strcmp(eltType, "HEXA") == 0)
-    {
-      // Compute surface normals
-      E_Int nvpe = cn->getNfld();
-      FldArrayF nsurfx(nelts, nvpe);
-      FldArrayF nsurfy(nelts, nvpe);
-      FldArrayF nsurfz(nelts, nvpe);
-      FldArrayF surf(nelts, nvpe);
-      K_METRIC::compSurfUnstruct(
-        *cn, "HEXA",
-        f->begin(posx), f->begin(posy), f->begin(posz), 
-        nsurfx.begin(), nsurfy.begin(), nsurfz.begin(), surf.begin());
-
-      // Compute dihedral angle
-      E_Float* nsurf1x = nsurfx.begin(1); E_Float* nsurf2x = nsurfx.begin(2); E_Float* nsurf3x = nsurfx.begin(3);
-      E_Float* nsurf4x = nsurfx.begin(4); E_Float* nsurf5x = nsurfx.begin(5); E_Float* nsurf6x = nsurfx.begin(6);
-      E_Float* nsurf1y = nsurfy.begin(1); E_Float* nsurf2y = nsurfy.begin(2); E_Float* nsurf3y = nsurfy.begin(3);
-      E_Float* nsurf4y = nsurfy.begin(4); E_Float* nsurf5y = nsurfy.begin(5); E_Float* nsurf6y = nsurfy.begin(6);
-      E_Float* nsurf1z = nsurfz.begin(1); E_Float* nsurf2z = nsurfz.begin(2); E_Float* nsurf3z = nsurfz.begin(3);
-      E_Float* nsurf4z = nsurfz.begin(4); E_Float* nsurf5z = nsurfz.begin(5); E_Float* nsurf6z = nsurfz.begin(6);
-      E_Float* surf1 = surf.begin(1); E_Float* surf2 = surf.begin(2); E_Float* surf3 = surf.begin(3);
-      E_Float* surf4 = surf.begin(4); E_Float* surf5 = surf.begin(5); E_Float* surf6 = surf.begin(6);
-      
-      #pragma omp parallel
-      {
-        E_Float s1, s2, s3, s4, s5, s6;
-        E_Float s13, s14, s15, s16, s23, s24, s25, s26, s35, s36, s45, s46;
-        E_Float alpha13, alpha14, alpha15, alpha16, alpha23, alpha24, alpha25, alpha26;
-        E_Float alpha35, alpha36, alpha45, alpha46;
-        E_Float alphamax1, alphamax2, alphamax3, alphamax4;
+        K_FLD::FldArrayI& cm = *(cn->getConnect(ic));
+        nelts = cm.getSize();
+        std::vector<std::vector<E_Int> > facets;
+        // K_CONNECT::getEVFacets(facets, eltTypes[ic], true); // say yes to degenerated elements
         
+        // loop over all elements of connectivity cm
         #pragma omp for
-        for (E_Int et = 0; et < nelts; et++)
+        for (E_Int i = 0; i < nelts; i++)
         {
-          s1 = surf1[et]; s2 = surf2[et]; s3 = surf3[et];
-          s4 = surf4[et]; s5 = surf5[et]; s6 = surf6[et];
-          s13 = s1*s3; s14 = s1*s4; s15 = s1*s5; s16 = s1*s6; 
-          s23 = s2*s3; s24 = s2*s4; s25 = s2*s5; s26 = s2*s6; 
-          s35 = s3*s5; s36 = s3*s6; s45 = s4*s5; s46 = s4*s6; 
-          alpha13 = E_abs(acos((nsurf1x[et]*nsurf3x[et] + nsurf1y[et]*nsurf3y[et] + nsurf1z[et]*nsurf3z[et])/s13)*degconst - 90.);
-          alpha14 = E_abs(acos((nsurf1x[et]*nsurf4x[et] + nsurf1y[et]*nsurf4y[et] + nsurf1z[et]*nsurf4z[et])/s14)*degconst - 90.);
-          alpha15 = E_abs(acos((nsurf1x[et]*nsurf5x[et] + nsurf1y[et]*nsurf5y[et] + nsurf1z[et]*nsurf5z[et])/s15)*degconst - 90.);
-          alpha16 = E_abs(acos((nsurf1x[et]*nsurf6x[et] + nsurf1y[et]*nsurf6y[et] + nsurf1z[et]*nsurf6z[et])/s16)*degconst - 90.);
-          alpha23 = E_abs(acos((nsurf2x[et]*nsurf3x[et] + nsurf2y[et]*nsurf3y[et] + nsurf2z[et]*nsurf3z[et])/s23)*degconst - 90.);
-          alpha24 = E_abs(acos((nsurf2x[et]*nsurf4x[et] + nsurf2y[et]*nsurf4y[et] + nsurf2z[et]*nsurf4z[et])/s24)*degconst - 90.);
-          alpha25 = E_abs(acos((nsurf2x[et]*nsurf5x[et] + nsurf2y[et]*nsurf5y[et] + nsurf2z[et]*nsurf5z[et])/s25)*degconst - 90.);
-          alpha26 = E_abs(acos((nsurf2x[et]*nsurf6x[et] + nsurf2y[et]*nsurf6y[et] + nsurf2z[et]*nsurf6z[et])/s26)*degconst - 90.);
-          alpha35 = E_abs(acos((nsurf3x[et]*nsurf5x[et] + nsurf3y[et]*nsurf5y[et] + nsurf3z[et]*nsurf5z[et])/s35)*degconst - 90.);
-          alpha36 = E_abs(acos((nsurf3x[et]*nsurf6x[et] + nsurf3y[et]*nsurf6y[et] + nsurf3z[et]*nsurf6z[et])/s36)*degconst - 90.);
-          alpha45 = E_abs(acos((nsurf4x[et]*nsurf5x[et] + nsurf4y[et]*nsurf5y[et] + nsurf4z[et]*nsurf5z[et])/s45)*degconst - 90.);
-          alpha46 = E_abs(acos((nsurf4x[et]*nsurf6x[et] + nsurf4y[et]*nsurf6y[et] + nsurf4z[et]*nsurf6z[et])/s46)*degconst - 90.);
-          alphamax1 = E_max(E_max(alpha13,alpha14),alpha15);
-          alphamax2 = E_max(E_max(alpha16,alpha23),alpha24);
-          alphamax3 = E_max(E_max(alpha25,alpha26),alpha35);
-          alphamax4 = E_max(E_max(alpha36,alpha45),alpha46);
-          alphamax[et] = E_max(E_max(alphamax1,alphamax2),E_max(alphamax3,alphamax4));
+          skewness[i] = 0.;
+
+          // loop over all faces of element i
+          for (E_Int f = 0; f < nfpe[ic]; f++)
+          {
+            // nvpf = facets[f].size();  // number of vertices per facet
+            if (nvpf == 4) // QUAD face
+            { 
+              //
+            }
+            else if (nvpf == 3) // TRI face
+            {
+              // do somtehing
+            }
+          }
         }
       }
     }
-    else if (strcmp(eltType, "BAR") == 0)
-    {
-      for (E_Int et = 0; et < nelts; et++)
-      {
-        alphamax[et] = 0.;
-      }
-    }
-    else
-    {
-      PyErr_SetString(PyExc_TypeError,
-                      "getOrthogonalityMap: unknown type of element.");
-      RELEASESHAREDS(tpl, f2);
-      RELEASESHAREDU(array, f, cn);
-      return NULL;
-    }
+ 
+    // if (strcmp(eltType, "TRI") == 0)
+    // {
+    //   E_Int* cn1 = cn->begin(1); E_Int* cn2 = cn->begin(2); E_Int* cn3 = cn->begin(3);
+    //   E_Float eps = 1.e-6;
+    //   #pragma omp parallel
+    //   {
+    //     E_Float d1, d2, d3, alpha12, alpha23, alpha31, sqrtd1, sqrtd2, sqrtd3;
+    //     E_Int ind1, ind2, ind3;
+    //     #pragma omp for
+    //     for (E_Int et = 0; et < nelts; et++)
+    //     {
+    //       ind1 = cn1[et]-1;
+    //       ind2 = cn2[et]-1;
+    //       ind3 = cn3[et]-1;
+
+    //       d1 = (x[ind2]-x[ind1])*(x[ind2]-x[ind1])+(y[ind2]-y[ind1])*(y[ind2]-y[ind1])+(z[ind2]-z[ind1])*(z[ind2]-z[ind1]); sqrtd1 = sqrt(d1);
+    //       d2 = (x[ind3]-x[ind2])*(x[ind3]-x[ind2])+(y[ind3]-y[ind2])*(y[ind3]-y[ind2])+(z[ind3]-z[ind2])*(z[ind3]-z[ind2]); sqrtd2 = sqrt(d2);
+    //       d3 = (x[ind1]-x[ind3])*(x[ind1]-x[ind3])+(y[ind1]-y[ind3])*(y[ind1]-y[ind3])+(z[ind1]-z[ind3])*(z[ind1]-z[ind3]); sqrtd3 = sqrt(d3);
+
+    //       if (( K_FUNC::fEqualZero(d1,eps) == true )||
+    //           ( K_FUNC::fEqualZero(d2,eps) == true )||
+    //           ( K_FUNC::fEqualZero(d3,eps) == true ))
+    //       {
+    //         // degenerated element
+    //         skewness[et] = 120.; // 180. - 60.
+    //       }
+    //       else
+    //       {
+    //         alpha12 = E_abs(acos((d1 + d2 - d3)/(E_max(TWO*sqrtd1*sqrtd2,E_GEOM_CUTOFF)))*degconst - 60.);
+    //         alpha23 = E_abs(acos((d2 + d3 - d1)/(E_max(TWO*sqrtd2*sqrtd3,E_GEOM_CUTOFF)))*degconst - 60.);
+    //         alpha31 = E_abs(acos((d3 + d1 - d2)/(E_max(TWO*sqrtd3*sqrtd1,E_GEOM_CUTOFF)))*degconst - 60.);
+    //         skewness[et] = E_max(E_max(alpha12,alpha23),alpha31);
+    //       }
+    //     }
+    //   }
+    // }
+    // else if (strcmp(eltType, "QUAD") == 0)
+    // {
+    //   E_Int* cn1 = cn->begin(1); E_Int* cn2 = cn->begin(2); E_Int* cn3 = cn->begin(3); E_Int* cn4 = cn->begin(4);
+    //   E_Int ind1, ind2, ind3, ind4;
+    //   E_Float d1, d2, d3, d4, diag13, diag24, alpha12, alpha14, alpha32, alpha34;
+    //   E_Float sqrtd1, sqrtd2, sqrtd3, sqrtd4;
+    //   #pragma omp for
+    //   for (E_Int et = 0; et < nelts; et++)
+    //   {
+    //     ind1 = cn1[et]-1;
+    //     ind2 = cn2[et]-1;
+    //     ind3 = cn3[et]-1;
+    //     ind4 = cn4[et]-1;
+
+    //     d1     = (x[ind2]-x[ind1])*(x[ind2]-x[ind1])+(y[ind2]-y[ind1])*(y[ind2]-y[ind1])+(z[ind2]-z[ind1])*(z[ind2]-z[ind1]); sqrtd1 = sqrt(d1);
+    //     d2     = (x[ind3]-x[ind2])*(x[ind3]-x[ind2])+(y[ind3]-y[ind2])*(y[ind3]-y[ind2])+(z[ind3]-z[ind2])*(z[ind3]-z[ind2]); sqrtd2 = sqrt(d2);
+    //     d3     = (x[ind4]-x[ind3])*(x[ind4]-x[ind3])+(y[ind4]-y[ind3])*(y[ind4]-y[ind3])+(z[ind4]-z[ind3])*(z[ind4]-z[ind3]); sqrtd3 = sqrt(d3);
+    //     d4     = (x[ind1]-x[ind4])*(x[ind1]-x[ind4])+(y[ind1]-y[ind4])*(y[ind1]-y[ind4])+(z[ind1]-z[ind4])*(z[ind1]-z[ind4]); sqrtd4 = sqrt(d4);
+    //     diag13 = (x[ind1]-x[ind3])*(x[ind1]-x[ind3])+(y[ind1]-y[ind3])*(y[ind1]-y[ind3])+(z[ind1]-z[ind3])*(z[ind1]-z[ind3]);
+    //     diag24 = (x[ind2]-x[ind4])*(x[ind2]-x[ind4])+(y[ind2]-y[ind4])*(y[ind2]-y[ind4])+(z[ind2]-z[ind4])*(z[ind2]-z[ind4]);
+
+    //     alpha12 = E_abs(acos((d1 + d2 - diag13)/(E_max(TWO*sqrtd1*sqrtd2,E_GEOM_CUTOFF)))*degconst - 90.);
+    //     alpha14 = E_abs(acos((d1 + d4 - diag24)/(E_max(TWO*sqrtd1*sqrtd4,E_GEOM_CUTOFF)))*degconst - 90.);
+    //     alpha32 = E_abs(acos((d3 + d2 - diag24)/(E_max(TWO*sqrtd3*sqrtd2,E_GEOM_CUTOFF)))*degconst - 90.);
+    //     alpha34 = E_abs(acos((d3 + d4 - diag13)/(E_max(TWO*sqrtd3*sqrtd4,E_GEOM_CUTOFF)))*degconst - 90.);
+    //     skewness[et] = E_max(E_max(alpha12,alpha14),E_max(alpha32,alpha34));
+    //   }
+    // }
+    // else if (strcmp(eltType, "TETRA") == 0)
+    // {
+    //   // Compute surface normals
+    //   E_Int nvpe = cn->getNfld();
+    //   FldArrayF nsurfx(nelts, nvpe);
+    //   FldArrayF nsurfy(nelts, nvpe);
+    //   FldArrayF nsurfz(nelts, nvpe);
+    //   FldArrayF surf(nelts, nvpe);
+    //   K_METRIC::compSurfUnstruct(
+    //     *cn, "TETRA", 
+    //     f->begin(posx), f->begin(posy), f->begin(posz), 
+    //     nsurfx.begin(), nsurfy.begin(), nsurfz.begin(), surf.begin());
+
+    //   // Compute dihedral angle
+    //   E_Float* nsurf1x = nsurfx.begin(1); E_Float* nsurf2x = nsurfx.begin(2);
+    //   E_Float* nsurf3x = nsurfx.begin(3);E_Float* nsurf4x = nsurfx.begin(4);
+    //   E_Float* nsurf1y = nsurfy.begin(1); E_Float* nsurf2y = nsurfy.begin(2);
+    //   E_Float* nsurf3y = nsurfy.begin(3);E_Float* nsurf4y = nsurfy.begin(4);
+    //   E_Float* nsurf1z = nsurfz.begin(1); E_Float* nsurf2z = nsurfz.begin(2);
+    //   E_Float* nsurf3z = nsurfz.begin(3);E_Float* nsurf4z = nsurfz.begin(4);
+    //   E_Float* surf1 = surf.begin(1); E_Float* surf2 = surf.begin(2); 
+    //   E_Float* surf3 = surf.begin(3); E_Float* surf4 = surf.begin(4);
+    
+    //   #pragma omp parallel
+    //   {
+    //     E_Float s1, s2, s3,s4, s12, s13, s23, s14, s24, s34;
+    //     E_Float alpha12, alpha14, alpha24, alpha13, alpha23, alpha34;
+    //     E_Float skewness1, skewness2, skewness3;
+    //     #pragma omp for
+    //     for (E_Int et = 0; et < nelts; et++)
+    //     {
+    //       s1 = surf1[et]; s2 = surf2[et]; s3 = surf3[et]; s4 = surf4[et];
+    //       s12 = s1*s2; s13 = s1*s3; s14 = s1*s4;  
+    //       s23 = s2*s3; s24 = s2*s4; s34 = s3*s4;
+    //       alpha12 = E_abs(acos((nsurf1x[et]*nsurf2x[et] + nsurf1y[et]*nsurf2y[et] + nsurf1z[et]*nsurf2z[et])/s12)*degconst - 120.);
+    //       alpha14 = E_abs(acos((nsurf1x[et]*nsurf4x[et] + nsurf1y[et]*nsurf4y[et] + nsurf1z[et]*nsurf4z[et])/s14)*degconst - 120.);
+    //       alpha24 = E_abs(acos((nsurf2x[et]*nsurf4x[et] + nsurf2y[et]*nsurf4y[et] + nsurf2z[et]*nsurf4z[et])/s24)*degconst - 120.);
+    //       alpha13 = E_abs(acos((nsurf1x[et]*nsurf3x[et] + nsurf1y[et]*nsurf3y[et] + nsurf1z[et]*nsurf3z[et])/s13)*degconst - 120.);
+    //       alpha23 = E_abs(acos((nsurf2x[et]*nsurf3x[et] + nsurf2y[et]*nsurf3y[et] + nsurf2z[et]*nsurf3z[et])/s23)*degconst - 120.);
+    //       alpha34 = E_abs(acos((nsurf3x[et]*nsurf4x[et] + nsurf3y[et]*nsurf4y[et] + nsurf3z[et]*nsurf4z[et])/s34)*degconst - 120.);
+    //       skewness1 = E_max(alpha12,alpha14);
+    //       skewness2 = E_max(alpha24,alpha13);
+    //       skewness3 = E_max(alpha23,alpha34);
+    //       skewness[et] = E_max(E_max(skewness1,skewness2),skewness3);
+    //     }
+    //   }
+    // }
+    // else if (strcmp(eltType, "PYRA") == 0)
+    // {
+    //   PyErr_SetString(PyExc_TypeError,
+    //                 "getOrthogonalityMap: not yet implemented for PYRA.");
+    //   RELEASESHAREDS(tpl, f2);
+    //   RELEASESHAREDU(array, f, cn);
+    //   return NULL;
+    // }
+    // else if (strcmp(eltType, "PENTA") == 0)
+    // {
+    //   // Compute surface normals
+    //   E_Int nvpe = cn->getNfld();
+    //   FldArrayF nsurfx(nelts, nvpe);
+    //   FldArrayF nsurfy(nelts, nvpe);
+    //   FldArrayF nsurfz(nelts, nvpe);
+    //   FldArrayF surf(nelts, nvpe);
+    //   K_METRIC::compSurfUnstruct(
+    //     *cn, "PENTA",
+    //     f->begin(posx), f->begin(posy), f->begin(posz), 
+    //     nsurfx.begin(), nsurfy.begin(), nsurfz.begin(), surf.begin());
+
+    //   // Compute dihedral angle
+    //   E_Float* nsurf1x = nsurfx.begin(1); E_Float* nsurf2x = nsurfx.begin(2);
+    //   E_Float* nsurf3x = nsurfx.begin(3);
+    //   E_Float* nsurf4x = nsurfx.begin(4); E_Float* nsurf5x = nsurfx.begin(5);
+    //   E_Float* nsurf1y = nsurfy.begin(1); E_Float* nsurf2y = nsurfy.begin(2);
+    //   E_Float* nsurf3y = nsurfy.begin(3);
+    //   E_Float* nsurf4y = nsurfy.begin(4); E_Float* nsurf5y = nsurfy.begin(5);
+    //   E_Float* nsurf1z = nsurfz.begin(1); E_Float* nsurf2z = nsurfz.begin(2);
+    //   E_Float* nsurf3z = nsurfz.begin(3);
+    //   E_Float* nsurf4z = nsurfz.begin(4); E_Float* nsurf5z = nsurfz.begin(5);
+    //   E_Float* surf1 = surf.begin(1); E_Float* surf2 = surf.begin(2); 
+    //   E_Float* surf3 = surf.begin(3); E_Float* surf4 = surf.begin(4); E_Float* surf5 = surf.begin(5);
+      
+    //   #pragma omp parallel
+    //   {
+    //     E_Float s1, s2, s3, s4, s5, s13, s14, s15, s23, s24, s25, s34, s35, s45;
+    //     E_Float alpha13, alpha14, alpha15, alpha23, alpha24, alpha25, alpha34, alpha35, alpha45;
+    //     E_Float skewness1, skewness2, skewness3;  
+    //     #pragma omp for
+    //     for (E_Int et = 0; et < nelts; et++)
+    //     {
+    //       s1 = surf1[et]; s2 = surf2[et]; s3 = surf3[et]; s4 = surf4[et]; s5 = surf5[et];
+    //       s13 = s1*s3; s14 = s1*s4; s15 = s1*s5;  
+    //       s23 = s2*s3; s24 = s2*s4; s25 = s2*s5;  
+    //       s34 = s3*s4; s35 = s3*s5; s45 = s4*s5;  
+    //       alpha13 = E_abs(acos((nsurf1x[et]*nsurf3x[et] + nsurf1y[et]*nsurf3y[et] + nsurf1z[et]*nsurf3z[et])/s13)*degconst - 90.);
+    //       alpha14 = E_abs(acos((nsurf1x[et]*nsurf4x[et] + nsurf1y[et]*nsurf4y[et] + nsurf1z[et]*nsurf4z[et])/s14)*degconst - 90.);
+    //       alpha15 = E_abs(acos((nsurf1x[et]*nsurf5x[et] + nsurf1y[et]*nsurf5y[et] + nsurf1z[et]*nsurf5z[et])/s15)*degconst - 90.);
+    //       alpha23 = E_abs(acos((nsurf2x[et]*nsurf3x[et] + nsurf2y[et]*nsurf3y[et] + nsurf2z[et]*nsurf3z[et])/s23)*degconst - 90.);
+    //       alpha24 = E_abs(acos((nsurf2x[et]*nsurf4x[et] + nsurf2y[et]*nsurf4y[et] + nsurf2z[et]*nsurf4z[et])/s24)*degconst - 90.);
+    //       alpha25 = E_abs(acos((nsurf2x[et]*nsurf5x[et] + nsurf2y[et]*nsurf5y[et] + nsurf2z[et]*nsurf5z[et])/s25)*degconst - 90.);
+    //       alpha34 = E_abs(acos((nsurf3x[et]*nsurf4x[et] + nsurf3y[et]*nsurf4y[et] + nsurf3z[et]*nsurf4z[et])/s34)*degconst - 120.);
+    //       alpha35 = E_abs(acos((nsurf3x[et]*nsurf5x[et] + nsurf3y[et]*nsurf5y[et] + nsurf3z[et]*nsurf5z[et])/s35)*degconst - 120.);
+    //       alpha45 = E_abs(acos((nsurf4x[et]*nsurf5x[et] + nsurf4y[et]*nsurf5y[et] + nsurf4z[et]*nsurf5z[et])/s45)*degconst - 120.);
+    //       skewness1 = E_max(E_max(alpha13,alpha14),alpha15);
+    //       skewness2 = E_max(E_max(alpha23,alpha24),alpha25);
+    //       skewness3 = E_max(E_max(alpha34,alpha35),alpha45);
+    //       skewness[et] = E_max(E_max(skewness1,skewness2),skewness3);
+    //     }
+    //   }
+    // }
+    // else if (strcmp(eltType, "HEXA") == 0)
+    // {
+    //   // Compute surface normals
+    //   E_Int nvpe = cn->getNfld();
+    //   FldArrayF nsurfx(nelts, nvpe);
+    //   FldArrayF nsurfy(nelts, nvpe);
+    //   FldArrayF nsurfz(nelts, nvpe);
+    //   FldArrayF surf(nelts, nvpe);
+    //   K_METRIC::compSurfUnstruct(
+    //     *cn, "HEXA",
+    //     f->begin(posx), f->begin(posy), f->begin(posz), 
+    //     nsurfx.begin(), nsurfy.begin(), nsurfz.begin(), surf.begin());
+
+    //   // Compute dihedral angle
+    //   E_Float* nsurf1x = nsurfx.begin(1); E_Float* nsurf2x = nsurfx.begin(2); E_Float* nsurf3x = nsurfx.begin(3);
+    //   E_Float* nsurf4x = nsurfx.begin(4); E_Float* nsurf5x = nsurfx.begin(5); E_Float* nsurf6x = nsurfx.begin(6);
+    //   E_Float* nsurf1y = nsurfy.begin(1); E_Float* nsurf2y = nsurfy.begin(2); E_Float* nsurf3y = nsurfy.begin(3);
+    //   E_Float* nsurf4y = nsurfy.begin(4); E_Float* nsurf5y = nsurfy.begin(5); E_Float* nsurf6y = nsurfy.begin(6);
+    //   E_Float* nsurf1z = nsurfz.begin(1); E_Float* nsurf2z = nsurfz.begin(2); E_Float* nsurf3z = nsurfz.begin(3);
+    //   E_Float* nsurf4z = nsurfz.begin(4); E_Float* nsurf5z = nsurfz.begin(5); E_Float* nsurf6z = nsurfz.begin(6);
+    //   E_Float* surf1 = surf.begin(1); E_Float* surf2 = surf.begin(2); E_Float* surf3 = surf.begin(3);
+    //   E_Float* surf4 = surf.begin(4); E_Float* surf5 = surf.begin(5); E_Float* surf6 = surf.begin(6);
+      
+    //   #pragma omp parallel
+    //   {
+    //     E_Float s1, s2, s3, s4, s5, s6;
+    //     E_Float s13, s14, s15, s16, s23, s24, s25, s26, s35, s36, s45, s46;
+    //     E_Float alpha13, alpha14, alpha15, alpha16, alpha23, alpha24, alpha25, alpha26;
+    //     E_Float alpha35, alpha36, alpha45, alpha46;
+    //     E_Float skewness1, skewness2, skewness3, skewness4;
+        
+    //     #pragma omp for
+    //     for (E_Int et = 0; et < nelts; et++)
+    //     {
+    //       s1 = surf1[et]; s2 = surf2[et]; s3 = surf3[et];
+    //       s4 = surf4[et]; s5 = surf5[et]; s6 = surf6[et];
+    //       s13 = s1*s3; s14 = s1*s4; s15 = s1*s5; s16 = s1*s6; 
+    //       s23 = s2*s3; s24 = s2*s4; s25 = s2*s5; s26 = s2*s6; 
+    //       s35 = s3*s5; s36 = s3*s6; s45 = s4*s5; s46 = s4*s6; 
+    //       alpha13 = E_abs(acos((nsurf1x[et]*nsurf3x[et] + nsurf1y[et]*nsurf3y[et] + nsurf1z[et]*nsurf3z[et])/s13)*degconst - 90.);
+    //       alpha14 = E_abs(acos((nsurf1x[et]*nsurf4x[et] + nsurf1y[et]*nsurf4y[et] + nsurf1z[et]*nsurf4z[et])/s14)*degconst - 90.);
+    //       alpha15 = E_abs(acos((nsurf1x[et]*nsurf5x[et] + nsurf1y[et]*nsurf5y[et] + nsurf1z[et]*nsurf5z[et])/s15)*degconst - 90.);
+    //       alpha16 = E_abs(acos((nsurf1x[et]*nsurf6x[et] + nsurf1y[et]*nsurf6y[et] + nsurf1z[et]*nsurf6z[et])/s16)*degconst - 90.);
+    //       alpha23 = E_abs(acos((nsurf2x[et]*nsurf3x[et] + nsurf2y[et]*nsurf3y[et] + nsurf2z[et]*nsurf3z[et])/s23)*degconst - 90.);
+    //       alpha24 = E_abs(acos((nsurf2x[et]*nsurf4x[et] + nsurf2y[et]*nsurf4y[et] + nsurf2z[et]*nsurf4z[et])/s24)*degconst - 90.);
+    //       alpha25 = E_abs(acos((nsurf2x[et]*nsurf5x[et] + nsurf2y[et]*nsurf5y[et] + nsurf2z[et]*nsurf5z[et])/s25)*degconst - 90.);
+    //       alpha26 = E_abs(acos((nsurf2x[et]*nsurf6x[et] + nsurf2y[et]*nsurf6y[et] + nsurf2z[et]*nsurf6z[et])/s26)*degconst - 90.);
+    //       alpha35 = E_abs(acos((nsurf3x[et]*nsurf5x[et] + nsurf3y[et]*nsurf5y[et] + nsurf3z[et]*nsurf5z[et])/s35)*degconst - 90.);
+    //       alpha36 = E_abs(acos((nsurf3x[et]*nsurf6x[et] + nsurf3y[et]*nsurf6y[et] + nsurf3z[et]*nsurf6z[et])/s36)*degconst - 90.);
+    //       alpha45 = E_abs(acos((nsurf4x[et]*nsurf5x[et] + nsurf4y[et]*nsurf5y[et] + nsurf4z[et]*nsurf5z[et])/s45)*degconst - 90.);
+    //       alpha46 = E_abs(acos((nsurf4x[et]*nsurf6x[et] + nsurf4y[et]*nsurf6y[et] + nsurf4z[et]*nsurf6z[et])/s46)*degconst - 90.);
+    //       skewness1 = E_max(E_max(alpha13,alpha14),alpha15);
+    //       skewness2 = E_max(E_max(alpha16,alpha23),alpha24);
+    //       skewness3 = E_max(E_max(alpha25,alpha26),alpha35);
+    //       skewness4 = E_max(E_max(alpha36,alpha45),alpha46);
+    //       skewness[et] = E_max(E_max(skewness1,skewness2),E_max(skewness3,skewness4));
+    //     }
+    //   }
+    // }
+    // else if (strcmp(eltType, "BAR") == 0)
+    // {
+    //   for (E_Int et = 0; et < nelts; et++)
+    //   {
+    //     skewness[et] = 0.;
+    //   }
+    // }
+    // else
+    // {
+    //   PyErr_SetString(PyExc_TypeError,
+    //                   "getOrthogonalityMap: unknown type of element.");
+    //   RELEASESHAREDS(tpl, f2);
+    //   RELEASESHAREDU(array, f, cn);
+    //   return NULL;
+    // }
     RELEASESHAREDS(tpl, f2);
     RELEASESHAREDU(array, f, cn); 
     return tpl;

--- a/Cassiopee/Generator/Generator/getOrthogonalityMap.cpp
+++ b/Cassiopee/Generator/Generator/getOrthogonalityMap.cpp
@@ -54,14 +54,21 @@ inline E_Float computeAngle(
 inline E_Float computeSkewness(
   const E_Float* x, const E_Float* y, const E_Float* z,
   E_Int ind1, E_Int ind2, E_Int ind3,
-  E_Float refAngle
+  E_Float refAngle, E_Int normalized
 )
 {
   E_Float pi = 4*atan(1.);
   E_Float degconst = 180.0 / pi;
-  E_Float alpha = computeAngle(x, y, z, ind1, ind2, ind3);
+  E_Float alpha = computeAngle(x, y, z, ind1, ind2, ind3)*degconst;
+  
+  E_Float skewness = E_abs(alpha - refAngle);
+  if (normalized) // skewness in [0,1] range
+  {  
+    if (alpha > refAngle) skewness = skewness/(180.-refAngle);
+    else skewness = skewness/refAngle;
+  }
 
-  return E_abs(alpha*degconst - refAngle);
+  return skewness;
 }
 
 // ============================================================================
@@ -74,7 +81,9 @@ inline E_Float computeSkewness(
 PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
 {
   PyObject* array;
-  if (!PYPARSETUPLE_(args, O_, &array)) return NULL;
+  E_Int normalized;
+
+  if (!PYPARSETUPLE_(args, O_ B_, &array, &normalized)) return NULL;
   
   // Check array
   E_Int im, jm, km;
@@ -197,7 +206,7 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
           ind1 = j*ni+i;
           ind2 = j*ni+inext;
           ind3 = jnext*ni+i;
-          skewness[ind] = computeSkewness(x, y, z, ind1, ind2, ind3, 90.);
+          skewness[ind] = computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
         }
       }
       else // dim == 3
@@ -217,13 +226,13 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
           ind2 = k*ni*nj+j*ni+inext;
           ind3 = k*ni*nj+jnext*ni+i;
           // ... angle correspondant aux indices (ij)
-          skewness1 = computeSkewness(x, y, z, ind1, ind2, ind3, 90.);
+          skewness1 = computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
           // ... angle correspondant aux indices (ik)
           ind3 = knext*ni*nj+j*ni+i;
-          skewness2 = computeSkewness(x, y, z, ind1, ind2, ind3, 90.);
+          skewness2 = computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
           // ... angle correspondant aux indices (jk)
           ind2 = k*ni*nj+jnext*ni+i;
-          skewness3 = computeSkewness(x, y, z, ind1, ind2, ind3, 90.);
+          skewness3 = computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
           // max skewness
           skewness[ind] = E_max(E_max(skewness1,skewness2),skewness3);
         }
@@ -301,10 +310,10 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
               ind3 = cm(i,facets[f][2])-1;
               ind4 = cm(i,facets[f][3])-1;
 
-              skewness1 = computeSkewness(x, y, z, ind1, ind4, ind2, 90.);
-              skewness2 = computeSkewness(x, y, z, ind2, ind1, ind3, 90.);
-              skewness3 = computeSkewness(x, y, z, ind3, ind2, ind4, 90.);
-              skewness4 = computeSkewness(x, y, z, ind4, ind3, ind1, 90.);
+              skewness1 = computeSkewness(x, y, z, ind1, ind4, ind2, 90., normalized);
+              skewness2 = computeSkewness(x, y, z, ind2, ind1, ind3, 90., normalized);
+              skewness3 = computeSkewness(x, y, z, ind3, ind2, ind4, 90., normalized);
+              skewness4 = computeSkewness(x, y, z, ind4, ind3, ind1, 90., normalized);
 
               skewness[i] = E_max(E_max(E_max(E_max(skewness1,skewness2),skewness3),skewness4),skewness[i]);
             }
@@ -314,9 +323,9 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
               ind2 = cm(i,facets[f][1])-1;
               ind3 = cm(i,facets[f][2])-1;
 
-              skewness1 = computeSkewness(x, y, z, ind1, ind3, ind2, 60.);
-              skewness2 = computeSkewness(x, y, z, ind2, ind1, ind3, 60.);
-              skewness3 = computeSkewness(x, y, z, ind3, ind2, ind1, 60.);
+              skewness1 = computeSkewness(x, y, z, ind1, ind3, ind2, 60., normalized);
+              skewness2 = computeSkewness(x, y, z, ind2, ind1, ind3, 60., normalized);
+              skewness3 = computeSkewness(x, y, z, ind3, ind2, ind1, 60., normalized);
 
               skewness[i] = E_max(E_max(E_max(skewness1,skewness2),skewness3),skewness[i]);
             }

--- a/Cassiopee/Generator/test/getOrthogonalityMapPT_t1.py
+++ b/Cassiopee/Generator/test/getOrthogonalityMapPT_t1.py
@@ -14,6 +14,8 @@ a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
 a = G.getOrthogonalityMap(a)
 t = C.newPyTree(['Base']); t[2][1][2].append(a)
 test.testT(t, 1)
+t = G.getOrthogonalityMap(t, normalized=True)
+test.testT(t, 11)
 
 # Test 2D structure
 a = G.cart((0.,0.,0.), (0.1,0.1,0.2), (10,10,1))
@@ -21,9 +23,13 @@ a = C.addBC2Zone(a, 'wall1','BCWall','imin')
 a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
 t = G.getOrthogonalityMap(a)
 test.testT(t, 2)
+t = G.getOrthogonalityMap(t, normalized=True)
+test.testT(t, 21)
 
-# Test 2D structure
+# Test 1D structure
 a = G.cart((0.,0.,0.), (0.1,0.1,0.2), (1,10,1))
 a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
 t = G.getOrthogonalityMap(a)
 test.testT(t, 3)
+t = G.getOrthogonalityMap(t, normalized=True)
+test.testT(t, 31)

--- a/Cassiopee/Generator/test/getOrthogonalityMapPT_t2.py
+++ b/Cassiopee/Generator/test/getOrthogonalityMapPT_t2.py
@@ -1,0 +1,84 @@
+# - getOrthogonalityMap (pyTree) -
+import Generator.PyTree as G
+import Converter.PyTree as C
+import Geom.PyTree as D
+import KCore.test as test
+
+# --- BE ---
+# 1D unstructured bar
+a = D.line((0,0,0), (1,0,0), 11)
+a = C.convertArray2Tetra(a)
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getOrthogonalityMap(a)
+test.testT(t, 1)
+
+# 2D unstructured tri
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,1), (10,10,1))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getOrthogonalityMap(a)
+test.testT(t, 2)
+
+# 2D unstructured quad
+a = G.cartHexa((0.,0.,0.), (0.1,0.1,1), (10,10,1))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getOrthogonalityMap(a)
+test.testT(t, 3)
+
+# 3D unstructured hexa
+a = G.cartHexa((0.,0.,0.), (0.1,0.1,0.1), (10,10,10))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getOrthogonalityMap(a)
+test.testT(t, 4)
+
+# 3D unstructured tetra
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,0.1), (10,10,10))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getOrthogonalityMap(a)
+test.testT(t, 5)
+
+# 3D unstructured pyra
+a = G.cartPyra((0.,0.,0.), (0.1,0.1,0.1), (10,10,10))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getOrthogonalityMap(a)
+test.testT(t, 6)
+
+# 3D unstructured penta
+a = G.cartPenta((0.,0.,0.), (0.1,0.1,0.1), (10,10,10))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getOrthogonalityMap(a)
+test.testT(t, 7)
+
+# --- ME ---
+# 1D unstructured ME
+a = G.cartHexa((0.,0.,0.), (0.1,0.0,0.0), (5,1,1))
+b = G.cartHexa((0.4,0.,0.), (0.0,0.1,0.0), (1,11,1))
+c = G.cartHexa((0.4,1.,0.), (0.1,0.0,0.), (4,1,1))
+d = G.cartHexa((0.7,1.,0.), (0.1,0.1,0.05), (1,1,12))
+a = C.mergeConnectivity([a, b, c, d], None)
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getOrthogonalityMap(a)
+test.testT(t, 8)
+
+# 2D unstructured ME: tri-quad-tri
+#                          |
+#                         tri
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,0.2), (5,10,1))
+b = G.cartHexa((0.4,0.,0.), (0.1,0.1,0.2), (5,10,1))
+c = G.cartTetra((0.8,0.,0.), (0.1,0.1,0.2), (5,10,1))
+d = G.cartTetra((0.4,-0.9,0.), (0.1,0.1,0.2), (5,10,1))
+a = C.mergeConnectivity([a, b, c, d], None)
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getOrthogonalityMap(a)
+test.testT(t, 9)
+
+# 3D unstructured ME: tetra   pyra
+#                              |
+#                     penta - hexa
+a = G.cartTetra((-0.05,0.45,0.05), (0.1,0.1,0.1), (5,5,5))
+b = G.cartPyra((0.4,0.4,0.), (0.1,0.1,0.1), (5,5,5))
+c = G.cartPenta((0.,0.,0.), (0.1,0.1,0.1), (5,5,5))
+d = G.cartHexa((0.4,0.,0.), (0.1,0.1,0.1), (5,5,5))
+a = C.mergeConnectivity([a, b, c, d], None)
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getOrthogonalityMap(a)
+test.testT(t, 10)

--- a/Cassiopee/KCore/KCore/Connect/connect.h
+++ b/Cassiopee/KCore/KCore/Connect/connect.h
@@ -172,7 +172,8 @@ namespace K_CONNECT
 
   /* Get all facets of a basic element*/
   E_Int getEVFacets(std::vector<std::vector<E_Int> >& facets,
-                    const char* eltType, E_Bool allow_degenerated=true);
+                    const char* eltType, E_Bool allow_degenerated=true,
+                    E_Bool expandToLowerDim=true);
   
   /* Change a Elts-Vertex connectivity to a Vertex-Elts connectivity.
      cVE doit deja etre alloue au nombre de noeuds. */

--- a/Cassiopee/KCore/KCore/Connect/getEVFacets.cpp
+++ b/Cassiopee/KCore/KCore/Connect/getEVFacets.cpp
@@ -27,28 +27,52 @@
   IN: allow_degenerated: whether to allow degenerated elements (in which case
                          the last vertex of a degenerated facet is a repetition
                          of the first)
+  IN: expandToLowerDim: 'faces' of 1D and 2D elements are vertices and edges, 
+                         respectively if expandToLowerDim is set to True
   OUT: facets: vertex indices for each of the facets - indexing starts at 1
   Return: error index 0 (ok), 1 (error) */
 //=============================================================================
 E_Int K_CONNECT::getEVFacets(std::vector<std::vector<E_Int> >& facets,
-                             const char* eltType, E_Bool allow_degenerated)
+  const char* eltType, E_Bool allow_degenerated, E_Bool expandToLowerDim
+)
 {
   E_Int ierr = 0;
   facets.clear();
 
   if (K_STRING::cmp(eltType, "BAR") == 0 || K_STRING::cmp(eltType, "BAR*") == 0)
   {
-    facets.push_back({1}); facets.push_back({2});
+    if (expandToLowerDim)
+    {
+      facets.push_back({1}); facets.push_back({2});
+    }
+    else
+    {
+      facets.push_back({1, 2});
+    }
   }
   else if (K_STRING::cmp(eltType, "TRI") == 0 || K_STRING::cmp(eltType, "TRI*") == 0)
   {
-    facets.push_back({1, 2}); facets.push_back({2, 3});
-    facets.push_back({3, 1});
+    if (expandToLowerDim)
+    {
+      facets.push_back({1, 2}); facets.push_back({2, 3});
+      facets.push_back({3, 1});
+    }
+    else
+    {
+      facets.push_back({1, 2, 3});
+    }
   }
   else if (K_STRING::cmp(eltType, "QUAD") == 0 || K_STRING::cmp(eltType, "QUAD*") == 0)
   {
-    facets.push_back({1, 2}); facets.push_back({2, 3});
-    facets.push_back({3, 4}); facets.push_back({4, 1});
+    if (expandToLowerDim)
+    {
+      facets.push_back({1, 2}); facets.push_back({2, 3});
+      facets.push_back({3, 4}); facets.push_back({4, 1});
+    }
+    else
+    {
+      facets.push_back({1, 2, 3, 4});
+    }
   }
   else if (K_STRING::cmp(eltType, "TETRA") == 0 || K_STRING::cmp(eltType, "TETRA*") == 0)
   {


### PR DESCRIPTION
No regressions.
Simplify the general code with two inline functions: computeAngle and computeSkewness.
Keep the current behavior for structured cases (only first angle is analyzed per cell).
For unstructured cases, each angle of each element face is analyzed to compute the local angle skewness. 
Add a Boolean parameter to the function to normalize the final angle criteria, if needed. This normalization follows the recommendation from Fluent and Pointwise to ensure that the parameter stays within the [0,1] range.
Add new test cases to test out BE/ME capabilities, as well as the normalization.

In future commits, this function is likely to become "getAngleSkewnessMap" instead of "getOrthogonalityMap".

In getEVFacets, add expandToLowerDim Boolean with a similar behavior to getNFPE. The idea is to get one QUAD (resp. TRI) facet for a QUAD (resp. TRI) element instead of four (resp. three) edges, if expandToLowerDim is set to False. Set to True by default to keep current behavior.

You may squatch! 😄 