### PR TITLE
Converter: recoverBCs BE: from subzone instead of faceList

### DIFF
--- a/Cassiopee/Converter/Converter/PyTree.py
+++ b/Cassiopee/Converter/Converter/PyTree.py
@@ -4516,12 +4516,12 @@ def _recoverBCs(t, BCInfo, tol=1.e-11, removeBC=True, indices=None):
                     ids = ids[validIds]
                     sizebc = ids.size
                     if sizebc == 0: continue
-                    #if dim[3] == 'NGON':
-                    id2 = numpy.empty(sizebc, dtype=Internal.E_NpyInt)
-                    id2[:] = indicesF[ids[:]-1]
-                    _addBC2Zone(z, BCNames[c], BCTypes[c], faceList=id2)
-                    #else:
-                    #    _addBC2Zone(z, BCNames[c], BCTypes[c], subzone=b)
+                    if dim[3] == 'NGON':
+                        id2 = numpy.empty(sizebc, dtype=Internal.E_NpyInt)
+                        id2[:] = indicesF[ids[:]-1]
+                        _addBC2Zone(z, BCNames[c], BCTypes[c], faceList=id2)
+                    else:
+                        _addBC2Zone(z, BCNames[c], BCTypes[c], subzone=b)
 
                     # Recover BCDataSets
                     fsc = Internal.getNodeFromName(b, Internal.__FlowSolutionCenters__)


### PR DESCRIPTION
Regression: 
Converter : recoverBCsPT_t2.py

```
Converter/recoverBCsPT_t2.py with Nprocs=0 and Nthreads=8
Reading Data_ld/recoverBCsPT_t2.ref1 (bin_pickle)...done.
DIFF: longueur des fils differente pour le noeud: cart.
  - Noms des noeuds de courant qui ne sont pas dans ref:
cart\wall1, cart\wall2.
DIFF: longueur des fils differente pour le noeud: wall1.1.
  - Noms des noeuds de courant qui ne sont pas dans ref:
ElementRange.
  - Noms des noeuds de ref qui ne sont pas dans courant:
GridLocation, PointList.
DIFF: node ./CGNSTree/Base/cart/ZoneBC/wall1.1/GridLocation exists in reference but not in current.
DIFF: node ./CGNSTree/Base/cart/ZoneBC/wall1.1/PointList exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: wall2.1.
  - Noms des noeuds de courant qui ne sont pas dans ref:
ElementRange.
  - Noms des noeuds de ref qui ne sont pas dans courant:
GridLocation, PointList.
DIFF: node ./CGNSTree/Base/cart/ZoneBC/wall2.1/GridLocation exists in reference but not in current.
DIFF: node ./CGNSTree/Base/cart/ZoneBC/wall2.1/PointList exists in reference but not in current.
DIFF: node ./CGNSTree/Base/cart/cart\wall1 exists in current but not in reference.
DIFF: node ./CGNSTree/Base/cart/ZoneBC/wall1.1/ElementRange exists in current but not in reference.
DIFF: node ./CGNSTree/Base/cart/ZoneBC/wall2.1/ElementRange exists in current but not in reference.
DIFF: node ./CGNSTree/Base/cart/cart\wall2 exists in current but not in reference.
Reading Data_ld/recoverBCsPT_t2.ref2 (bin_pickle)...done.
DIFF: longueur des fils differente pour le noeud: cart.
  - Noms des noeuds de courant qui ne sont pas dans ref:
cart\wall1, cart\wall2.
DIFF: longueur des fils differente pour le noeud: wall1.2.
  - Noms des noeuds de courant qui ne sont pas dans ref:
ElementRange.
  - Noms des noeuds de ref qui ne sont pas dans courant:
GridLocation, PointList.
DIFF: node ./CGNSTree/Base/cart/ZoneBC/wall1.2/GridLocation exists in reference but not in current.
DIFF: node ./CGNSTree/Base/cart/ZoneBC/wall1.2/PointList exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: wall2.2.
  - Noms des noeuds de courant qui ne sont pas dans ref:
ElementRange.
  - Noms des noeuds de ref qui ne sont pas dans courant:
GridLocation, PointList.
DIFF: node ./CGNSTree/Base/cart/ZoneBC/wall2.2/GridLocation exists in reference but not in current.
DIFF: node ./CGNSTree/Base/cart/ZoneBC/wall2.2/PointList exists in reference but not in current.
DIFF: node ./CGNSTree/Base/cart/cart\wall1 exists in current but not in reference.
DIFF: node ./CGNSTree/Base/cart/ZoneBC/wall1.2/ElementRange exists in current but not in reference.
DIFF: node ./CGNSTree/Base/cart/ZoneBC/wall2.2/ElementRange exists in current but not in reference.
DIFF: node ./CGNSTree/Base/cart/cart\wall2 exists in current but not in reference.
Reading Data_ld/recoverBCsPT_t2.ref3 (bin_pickle)...done.
DIFF: longueur des fils differente pour le noeud: cartHexa.
  - Noms des noeuds de courant qui ne sont pas dans ref:
cartHexa\sym1.
DIFF: longueur des fils differente pour le noeud: sym1.0.
  - Noms des noeuds de courant qui ne sont pas dans ref:
ElementRange.
  - Noms des noeuds de ref qui ne sont pas dans courant:
GridLocation, PointList.
DIFF: node ./CGNSTree/Base/cartHexa/ZoneBC/sym1.0/GridLocation exists in reference but not in current.
DIFF: node ./CGNSTree/Base/cartHexa/ZoneBC/sym1.0/PointList exists in reference but not in current.
DIFF: node ./CGNSTree/Base/cartHexa/cartHexa\sym1 exists in current but not in reference.
DIFF: node ./CGNSTree/Base/cartHexa/ZoneBC/sym1.0/ElementRange exists in current but not in reference.
Reading Data_ld/recoverBCsPT_t2.ref4 (bin_pickle)...done.
DIFF: longueur des fils differente pour le noeud: cartHexa.
  - Noms des noeuds de courant qui ne sont pas dans ref:
cartHexa\sym1.
DIFF: longueur des fils differente pour le noeud: sym1.1.
  - Noms des noeuds de courant qui ne sont pas dans ref:
ElementRange.
  - Noms des noeuds de ref qui ne sont pas dans courant:
GridLocation, PointList.
DIFF: node ./CGNSTree/Base/cartHexa/ZoneBC/sym1.1/GridLocation exists in reference but not in current.
DIFF: node ./CGNSTree/Base/cartHexa/ZoneBC/sym1.1/PointList exists in reference but not in current.
DIFF: node ./CGNSTree/Base/cartHexa/cartHexa\sym1 exists in current but not in reference.
DIFF: node ./CGNSTree/Base/cartHexa/ZoneBC/sym1.1/ElementRange exists in current but not in reference.
Reading Data_ld/recoverBCsPT_t2.ref5 (bin_pickle)...done.
Reading Data_ld/recoverBCsPT_t2.ref6 (bin_pickle)...done.
Warning: diffIndex: listB is not a subset of listA - proceed anyway
Elapsed CPU time: 0m0.5s
****************************************************************************************
```