### PR TITLE
KCore/Post: HEXA/PENTA facet reordering using CGNS conventions

### DIFF
--- a/Cassiopee/KCore/KCore/Metric/compSurfUnstruct.cpp
+++ b/Cassiopee/KCore/KCore/Metric/compSurfUnstruct.cpp
@@ -443,43 +443,7 @@ void K_METRIC::compPentaSurf(
     ind5 = cm(i, 5) - 1;  // A5
     ind6 = cm(i, 6) - 1;  // A6
 
-    // First face: triangle A1A2A3
-    l1x = xt[ind1] - xt[ind2];
-    l1y = yt[ind1] - yt[ind2];
-    l1z = zt[ind1] - zt[ind2];
-    l2x = xt[ind3] - xt[ind2];
-    l2y = yt[ind3] - yt[ind2];
-    l2z = zt[ind3] - zt[ind2];
-    surfx = l1y * l2z - l1z * l2y;
-    surfy = l1z * l2x - l1x * l2z;
-    surfz = l1x * l2y - l1y * l2x;
-    surf = sqrt(surfx * surfx + surfy * surfy + surfz * surfz);
-
-    pos = fctOffset + i * nfpe;
-    surfnx[pos] = K_CONST::ONE_HALF * surfx;
-    surfny[pos] = K_CONST::ONE_HALF * surfy;
-    surfnz[pos] = K_CONST::ONE_HALF * surfz;
-    surface[pos] = K_CONST::ONE_HALF * surf;
-
-    // Second face: triangle A4A5A6
-    l1x = xt[ind5] - xt[ind4];
-    l1y = yt[ind5] - yt[ind4];
-    l1z = zt[ind5] - zt[ind4];
-    l2x = xt[ind6] - xt[ind4];
-    l2y = yt[ind6] - yt[ind4];
-    l2z = zt[ind6] - zt[ind4];
-    surfx = l1y * l2z - l1z * l2y;
-    surfy = l1z * l2x - l1x * l2z;
-    surfz = l1x * l2y - l1y * l2x;
-    surf = sqrt(surfx * surfx + surfy * surfy + surfz * surfz);
-
-    pos += 1;
-    surfnx[pos] = K_CONST::ONE_HALF * surfx;
-    surfny[pos] = K_CONST::ONE_HALF * surfy;
-    surfnz[pos] = K_CONST::ONE_HALF * surfz;
-    surface[pos] = K_CONST::ONE_HALF * surf;
-
-    // Third face: quad 1254
+    // First face: quad 1254
     l1x = xt[ind2] - xt[ind1];
     l1y = yt[ind2] - yt[ind1];
     l1z = zt[ind2] - zt[ind1];
@@ -505,13 +469,13 @@ void K_METRIC::compPentaSurf(
     surfz = surf1z + surf2z;
     surf = sqrt(surfx * surfx + surfy * surfy + surfz * surfz);
 
-    pos += 1;
+    pos = fctOffset + i * nfpe;
     surfnx[pos] = K_CONST::ONE_HALF * surfx;
     surfny[pos] = K_CONST::ONE_HALF * surfy;
     surfnz[pos] = K_CONST::ONE_HALF * surfz;
     surface[pos] = K_CONST::ONE_HALF * surf;
 
-    // Fourth face: quad 2365
+    // Second face: quad 2365
     l1x = xt[ind3] - xt[ind2];
     l1y = yt[ind3] - yt[ind2];
     l1z = zt[ind3] - zt[ind2];
@@ -543,7 +507,7 @@ void K_METRIC::compPentaSurf(
     surfnz[pos] = K_CONST::ONE_HALF * surfz;
     surface[pos] = K_CONST::ONE_HALF * surf;
 
-    // Fifth face: quad 3146
+    // Third face: quad 3146
     l1x = xt[ind1] - xt[ind3];
     l1y = yt[ind1] - yt[ind3];
     l1z = zt[ind1] - zt[ind3];
@@ -567,6 +531,42 @@ void K_METRIC::compPentaSurf(
     surfx = surf1x + surf2x;
     surfy = surf1y + surf2y;
     surfz = surf1z + surf2z;
+    surf = sqrt(surfx * surfx + surfy * surfy + surfz * surfz);
+
+    pos += 1;
+    surfnx[pos] = K_CONST::ONE_HALF * surfx;
+    surfny[pos] = K_CONST::ONE_HALF * surfy;
+    surfnz[pos] = K_CONST::ONE_HALF * surfz;
+    surface[pos] = K_CONST::ONE_HALF * surf;
+
+    // Fourth face: triangle A1A2A3
+    l1x = xt[ind1] - xt[ind2];
+    l1y = yt[ind1] - yt[ind2];
+    l1z = zt[ind1] - zt[ind2];
+    l2x = xt[ind3] - xt[ind2];
+    l2y = yt[ind3] - yt[ind2];
+    l2z = zt[ind3] - zt[ind2];
+    surfx = l1y * l2z - l1z * l2y;
+    surfy = l1z * l2x - l1x * l2z;
+    surfz = l1x * l2y - l1y * l2x;
+    surf = sqrt(surfx * surfx + surfy * surfy + surfz * surfz);
+
+    pos += 1;
+    surfnx[pos] = K_CONST::ONE_HALF * surfx;
+    surfny[pos] = K_CONST::ONE_HALF * surfy;
+    surfnz[pos] = K_CONST::ONE_HALF * surfz;
+    surface[pos] = K_CONST::ONE_HALF * surf;
+
+    // Fifth face: triangle A4A5A6
+    l1x = xt[ind5] - xt[ind4];
+    l1y = yt[ind5] - yt[ind4];
+    l1z = zt[ind5] - zt[ind4];
+    l2x = xt[ind6] - xt[ind4];
+    l2y = yt[ind6] - yt[ind4];
+    l2z = zt[ind6] - zt[ind4];
+    surfx = l1y * l2z - l1z * l2y;
+    surfy = l1z * l2x - l1x * l2z;
+    surfz = l1x * l2y - l1y * l2x;
     surf = sqrt(surfx * surfx + surfy * surfy + surfz * surfz);
 
     pos += 1;
@@ -601,7 +601,7 @@ void K_METRIC::compHexaSurf(
     ind7 = cm(i, 7) - 1;  // A7
     ind8 = cm(i, 8) - 1;  // A8
 
-    // premiere facette A1A2A3A4
+    // First face: A1A2A3A4
     // A2A1 x A2A3
     l1x = xt[ind1] - xt[ind2];
     l1y = yt[ind1] - yt[ind2];
@@ -639,121 +639,7 @@ void K_METRIC::compHexaSurf(
     surfnz[pos] = K_CONST::ONE_HALF * surfz;
     surface[pos] = K_CONST::ONE_HALF * surf;
 
-    // deuxieme facette A5A6A7A8
-    // A5A6 x A5A7
-    l1x = xt[ind6] - xt[ind5];
-    l1y = yt[ind6] - yt[ind5];
-    l1z = zt[ind6] - zt[ind5];
-
-    l2x = xt[ind7] - xt[ind5];
-    l2y = yt[ind7] - yt[ind5];
-    l2z = zt[ind7] - zt[ind5];
-
-    surf1x = (l1y * l2z - l1z * l2y);
-    surf1y = (l1z * l2x - l1x * l2z);
-    surf1z = (l1x * l2y - l1y * l2x);
-
-    // A5A7 x A5A8
-    l1x = xt[ind7] - xt[ind5];
-    l1y = yt[ind7] - yt[ind5];
-    l1z = zt[ind7] - zt[ind5];
-
-    l2x = xt[ind8] - xt[ind5];
-    l2y = yt[ind8] - yt[ind5];
-    l2z = zt[ind8] - zt[ind5];
-
-    surf2x = (l1y * l2z - l1z * l2y);
-    surf2y = (l1z * l2x - l1x * l2z);
-    surf2z = (l1x * l2y - l1y * l2x);
-
-    surfx = surf1x + surf2x;
-    surfy = surf1y + surf2y;
-    surfz = surf1z + surf2z;
-    surf = sqrt(surfx * surfx + surfy * surfy + surfz * surfz);
-
-    pos += 1;
-    surfnx[pos] = K_CONST::ONE_HALF * surfx;
-    surfny[pos] = K_CONST::ONE_HALF * surfy;
-    surfnz[pos] = K_CONST::ONE_HALF * surfz;
-    surface[pos] = K_CONST::ONE_HALF * surf;
-
-    // troisieme facette 4158
-    // A4A1 x A4A5
-    l1x = xt[ind1] - xt[ind4];
-    l1y = yt[ind1] - yt[ind4];
-    l1z = zt[ind1] - zt[ind4];
-
-    l2x = xt[ind5] - xt[ind4];
-    l2y = yt[ind5] - yt[ind4];
-    l2z = zt[ind5] - zt[ind4];
-
-    surf1x = (l1y * l2z - l1z * l2y);
-    surf1y = (l1z * l2x - l1x * l2z);
-    surf1z = (l1x * l2y - l1y * l2x);
-
-    // A4A5 x A4A8
-    l1x = xt[ind5] - xt[ind4];
-    l1y = yt[ind5] - yt[ind4];
-    l1z = zt[ind5] - zt[ind4];
-
-    l2x = xt[ind8] - xt[ind4];
-    l2y = yt[ind8] - yt[ind4];
-    l2z = zt[ind8] - zt[ind4];
-
-    surf2x = (l1y * l2z - l1z * l2y);
-    surf2y = (l1z * l2x - l1x * l2z);
-    surf2z = (l1x * l2y - l1y * l2x);
-
-    surfx = surf1x + surf2x;
-    surfy = surf1y + surf2y;
-    surfz = surf1z + surf2z;
-    surf = sqrt(surfx * surfx + surfy * surfy + surfz * surfz);
-
-    pos += 1;
-    surfnx[pos] = K_CONST::ONE_HALF * surfx;
-    surfny[pos] = K_CONST::ONE_HALF * surfy;
-    surfnz[pos] = K_CONST::ONE_HALF * surfz;
-    surface[pos] = K_CONST::ONE_HALF * surf;
-
-    // quatrieme facette A2A3A7A6
-    // A2A3x A2A7
-    l1x = xt[ind3] - xt[ind2];
-    l1y = yt[ind3] - yt[ind2];
-    l1z = zt[ind3] - zt[ind2];
-
-    l2x = xt[ind7] - xt[ind2];
-    l2y = yt[ind7] - yt[ind2];
-    l2z = zt[ind7] - zt[ind2];
-
-    surf1x = (l1y * l2z - l1z * l2y);
-    surf1y = (l1z * l2x - l1x * l2z);
-    surf1z = (l1x * l2y - l1y * l2x);
-
-    // A2A7 x A2A6
-    l1x = xt[ind7] - xt[ind2];
-    l1y = yt[ind7] - yt[ind2];
-    l1z = zt[ind7] - zt[ind2];
-
-    l2x = xt[ind6] - xt[ind2];
-    l2y = yt[ind6] - yt[ind2];
-    l2z = zt[ind6] - zt[ind2];
-
-    surf2x = (l1y * l2z - l1z * l2y);
-    surf2y = (l1z * l2x - l1x * l2z);
-    surf2z = (l1x * l2y - l1y * l2x);
-
-    surfx = surf1x + surf2x;
-    surfy = surf1y + surf2y;
-    surfz = surf1z + surf2z;
-    surf = sqrt(surfx * surfx + surfy * surfy + surfz * surfz);
-
-    pos += 1;
-    surfnx[pos] = K_CONST::ONE_HALF * surfx;
-    surfny[pos] = K_CONST::ONE_HALF * surfy;
-    surfnz[pos] = K_CONST::ONE_HALF * surfz;
-    surface[pos] = K_CONST::ONE_HALF * surf;
-
-    // cinquieme facette A1A2A6A5
+    // Second face: A1A2A6A5
     // A1A2 x A1A6
     l1x = xt[ind2] - xt[ind1];
     l1y = yt[ind2] - yt[ind1];
@@ -791,7 +677,45 @@ void K_METRIC::compHexaSurf(
     surfnz[pos] = K_CONST::ONE_HALF * surfz;
     surface[pos] = K_CONST::ONE_HALF * surf;
 
-    // sixieme facette A3A4A8A7
+    // Third face: A2A3A7A6
+    // A2A3x A2A7
+    l1x = xt[ind3] - xt[ind2];
+    l1y = yt[ind3] - yt[ind2];
+    l1z = zt[ind3] - zt[ind2];
+
+    l2x = xt[ind7] - xt[ind2];
+    l2y = yt[ind7] - yt[ind2];
+    l2z = zt[ind7] - zt[ind2];
+
+    surf1x = (l1y * l2z - l1z * l2y);
+    surf1y = (l1z * l2x - l1x * l2z);
+    surf1z = (l1x * l2y - l1y * l2x);
+
+    // A2A7 x A2A6
+    l1x = xt[ind7] - xt[ind2];
+    l1y = yt[ind7] - yt[ind2];
+    l1z = zt[ind7] - zt[ind2];
+
+    l2x = xt[ind6] - xt[ind2];
+    l2y = yt[ind6] - yt[ind2];
+    l2z = zt[ind6] - zt[ind2];
+
+    surf2x = (l1y * l2z - l1z * l2y);
+    surf2y = (l1z * l2x - l1x * l2z);
+    surf2z = (l1x * l2y - l1y * l2x);
+
+    surfx = surf1x + surf2x;
+    surfy = surf1y + surf2y;
+    surfz = surf1z + surf2z;
+    surf = sqrt(surfx * surfx + surfy * surfy + surfz * surfz);
+
+    pos += 1;
+    surfnx[pos] = K_CONST::ONE_HALF * surfx;
+    surfny[pos] = K_CONST::ONE_HALF * surfy;
+    surfnz[pos] = K_CONST::ONE_HALF * surfz;
+    surface[pos] = K_CONST::ONE_HALF * surf;
+
+    // Fourth face: A3A4A8A7
     // A3A4 x A3A8
     l1x = xt[ind4] - xt[ind3];
     l1y = yt[ind4] - yt[ind3];
@@ -813,6 +737,82 @@ void K_METRIC::compHexaSurf(
     l2x = xt[ind7] - xt[ind3];
     l2y = yt[ind7] - yt[ind3];
     l2z = zt[ind7] - zt[ind3];
+
+    surf2x = (l1y * l2z - l1z * l2y);
+    surf2y = (l1z * l2x - l1x * l2z);
+    surf2z = (l1x * l2y - l1y * l2x);
+
+    surfx = surf1x + surf2x;
+    surfy = surf1y + surf2y;
+    surfz = surf1z + surf2z;
+    surf = sqrt(surfx * surfx + surfy * surfy + surfz * surfz);
+
+    pos += 1;
+    surfnx[pos] = K_CONST::ONE_HALF * surfx;
+    surfny[pos] = K_CONST::ONE_HALF * surfy;
+    surfnz[pos] = K_CONST::ONE_HALF * surfz;
+    surface[pos] = K_CONST::ONE_HALF * surf;
+
+    // Fifth face: A4A1A5A8
+    // A4A1 x A4A5
+    l1x = xt[ind1] - xt[ind4];
+    l1y = yt[ind1] - yt[ind4];
+    l1z = zt[ind1] - zt[ind4];
+
+    l2x = xt[ind5] - xt[ind4];
+    l2y = yt[ind5] - yt[ind4];
+    l2z = zt[ind5] - zt[ind4];
+
+    surf1x = (l1y * l2z - l1z * l2y);
+    surf1y = (l1z * l2x - l1x * l2z);
+    surf1z = (l1x * l2y - l1y * l2x);
+
+    // A4A5 x A4A8
+    l1x = xt[ind5] - xt[ind4];
+    l1y = yt[ind5] - yt[ind4];
+    l1z = zt[ind5] - zt[ind4];
+
+    l2x = xt[ind8] - xt[ind4];
+    l2y = yt[ind8] - yt[ind4];
+    l2z = zt[ind8] - zt[ind4];
+
+    surf2x = (l1y * l2z - l1z * l2y);
+    surf2y = (l1z * l2x - l1x * l2z);
+    surf2z = (l1x * l2y - l1y * l2x);
+
+    surfx = surf1x + surf2x;
+    surfy = surf1y + surf2y;
+    surfz = surf1z + surf2z;
+    surf = sqrt(surfx * surfx + surfy * surfy + surfz * surfz);
+
+    pos += 1;
+    surfnx[pos] = K_CONST::ONE_HALF * surfx;
+    surfny[pos] = K_CONST::ONE_HALF * surfy;
+    surfnz[pos] = K_CONST::ONE_HALF * surfz;
+    surface[pos] = K_CONST::ONE_HALF * surf;
+
+    // Sixth face: A5A6A7A8
+    // A5A6 x A5A7
+    l1x = xt[ind6] - xt[ind5];
+    l1y = yt[ind6] - yt[ind5];
+    l1z = zt[ind6] - zt[ind5];
+
+    l2x = xt[ind7] - xt[ind5];
+    l2y = yt[ind7] - yt[ind5];
+    l2z = zt[ind7] - zt[ind5];
+
+    surf1x = (l1y * l2z - l1z * l2y);
+    surf1y = (l1z * l2x - l1x * l2z);
+    surf1z = (l1x * l2y - l1y * l2x);
+
+    // A5A7 x A5A8
+    l1x = xt[ind7] - xt[ind5];
+    l1y = yt[ind7] - yt[ind5];
+    l1z = zt[ind7] - zt[ind5];
+
+    l2x = xt[ind8] - xt[ind5];
+    l2y = yt[ind8] - yt[ind5];
+    l2z = zt[ind8] - zt[ind5];
 
     surf2x = (l1y * l2z - l1z * l2y);
     surf2y = (l1z * l2x - l1x * l2z);

--- a/Cassiopee/KCore/KCore/Metric/compUnstrCenterInt.cpp
+++ b/Cassiopee/KCore/KCore/Metric/compUnstrCenterInt.cpp
@@ -234,41 +234,41 @@ void K_METRIC::compUnstructCenterInt(
           z1 = zt[ind1]; z2 = zt[ind2]; z3 = zt[ind3]; z4 = zt[ind4];
           z5 = zt[ind5]; z6 = zt[ind6]; z7 = zt[ind7]; z8 = zt[ind8];
 
-          // facette 1234
+          // First face: 1234
           pos = fctOffset + i * nfpe[ic];
           xint[pos] = K_CONST::ONE_FOURTH * (x1 + x2 + x3 + x4);
           yint[pos] = K_CONST::ONE_FOURTH * (y1 + y2 + y3 + y4);
           zint[pos] = K_CONST::ONE_FOURTH * (z1 + z2 + z3 + z4);
 
-          // facette 5678
-          pos += 1;
-          xint[pos] = K_CONST::ONE_FOURTH * (x5 + x6 + x7 + x8);
-          yint[pos] = K_CONST::ONE_FOURTH * (y5 + y6 + y7 + y8);
-          zint[pos] = K_CONST::ONE_FOURTH * (z5 + z6 + z7 + z8);
-
-          // facette 1485
-          pos += 1;
-          xint[pos] = K_CONST::ONE_FOURTH * (x1 + x4 + x8 + x5);
-          yint[pos] = K_CONST::ONE_FOURTH * (y1 + y4 + y8 + y5);
-          zint[pos] = K_CONST::ONE_FOURTH * (z1 + z4 + z8 + z5);
-
-          // facette 2376
-          pos += 1;
-          xint[pos] = K_CONST::ONE_FOURTH * (x2 + x3 + x7 + x6);
-          yint[pos] = K_CONST::ONE_FOURTH * (y2 + y3 + y7 + y6);
-          zint[pos] = K_CONST::ONE_FOURTH * (z2 + z3 + z7 + z6);
-
-          // facette 1265
+          // Second face: 1265
           pos += 1;
           xint[pos] = K_CONST::ONE_FOURTH * (x1 + x2 + x6 + x5);
           yint[pos] = K_CONST::ONE_FOURTH * (y1 + y2 + y6 + y5);
           zint[pos] = K_CONST::ONE_FOURTH * (z1 + z2 + z6 + z5);
 
-          // facette 4378
+          // Third face: 2376
+          pos += 1;
+          xint[pos] = K_CONST::ONE_FOURTH * (x2 + x3 + x7 + x6);
+          yint[pos] = K_CONST::ONE_FOURTH * (y2 + y3 + y7 + y6);
+          zint[pos] = K_CONST::ONE_FOURTH * (z2 + z3 + z7 + z6);
+
+          // Fourth face: 4378
           pos += 1;
           xint[pos] = K_CONST::ONE_FOURTH * (x4 + x3 + x7 + x8);
           yint[pos] = K_CONST::ONE_FOURTH * (y4 + y3 + y7 + y8);
           zint[pos] = K_CONST::ONE_FOURTH * (z4 + z3 + z7 + z8);
+
+          // Fifth face: 1485
+          pos += 1;
+          xint[pos] = K_CONST::ONE_FOURTH * (x1 + x4 + x8 + x5);
+          yint[pos] = K_CONST::ONE_FOURTH * (y1 + y4 + y8 + y5);
+          zint[pos] = K_CONST::ONE_FOURTH * (z1 + z4 + z8 + z5);
+
+          // Sixth face: 5678
+          pos += 1;
+          xint[pos] = K_CONST::ONE_FOURTH * (x5 + x6 + x7 + x8);
+          yint[pos] = K_CONST::ONE_FOURTH * (y5 + y6 + y7 + y8);
+          zint[pos] = K_CONST::ONE_FOURTH * (z5 + z6 + z7 + z8);
         }
       }
     }
@@ -300,35 +300,35 @@ void K_METRIC::compUnstructCenterInt(
           z1 = zt[ind1]; z2 = zt[ind2]; z3 = zt[ind3];
           z4 = zt[ind4]; z5 = zt[ind5]; z6 = zt[ind6];
 
-          // facette triangle 1 : 123
+          // premiere facette quad 1254
           pos = fctOffset + i * nfpe[ic];
-          xint[pos] = K_CONST::ONE_THIRD * (x1 + x2 + x3);
-          yint[pos] = K_CONST::ONE_THIRD * (y1 + y2 + y3);
-          zint[pos] = K_CONST::ONE_THIRD * (z1 + z2 + z3);
-
-          // facette triangle 2 : 456
-          pos += 1;
-          xint[pos] = K_CONST::ONE_THIRD * (x4 + x5 + x6);
-          yint[pos] = K_CONST::ONE_THIRD * (y4 + y5 + y6);
-          zint[pos] = K_CONST::ONE_THIRD * (z4 + z5 + z6);
-
-          // troisieme facette quad 1254
-          pos += 1;
           xint[pos] = K_CONST::ONE_FOURTH * (x1 + x2 + x5 + x4);
           yint[pos] = K_CONST::ONE_FOURTH * (y1 + y2 + y5 + y4);
           zint[pos] = K_CONST::ONE_FOURTH * (z1 + z2 + z5 + z4);
 
-          // quatrieme facette quad 2365
+          // deuxieme facette quad 2365
           pos += 1;
           xint[pos] = K_CONST::ONE_FOURTH * (x2 + x3 + x6 + x5);
           yint[pos] = K_CONST::ONE_FOURTH * (y2 + y3 + y6 + y5);
           zint[pos] = K_CONST::ONE_FOURTH * (z2 + z3 + z6 + z5);
 
-          // cinquieme facette quad 3146
+          // troisieme facette quad 3146
           pos += 1;
           xint[pos] = K_CONST::ONE_FOURTH * (x3 + x1 + x4 + x6);
           yint[pos] = K_CONST::ONE_FOURTH * (y3 + y1 + y4 + y6);
           zint[pos] = K_CONST::ONE_FOURTH * (z3 + z1 + z4 + z6);
+
+          // cinquieme facette tri : 123
+          pos += 1;
+          xint[pos] = K_CONST::ONE_THIRD * (x1 + x2 + x3);
+          yint[pos] = K_CONST::ONE_THIRD * (y1 + y2 + y3);
+          zint[pos] = K_CONST::ONE_THIRD * (z1 + z2 + z3);
+
+          // sixieme facette tri : 456
+          pos += 1;
+          xint[pos] = K_CONST::ONE_THIRD * (x4 + x5 + x6);
+          yint[pos] = K_CONST::ONE_THIRD * (y4 + y5 + y6);
+          zint[pos] = K_CONST::ONE_THIRD * (z4 + z5 + z6);
         }
       }
     }

--- a/Cassiopee/Post/Post/Fortran/compUnstrNodes2Faces.cpp
+++ b/Cassiopee/Post/Post/Fortran/compUnstrNodes2Faces.cpp
@@ -158,7 +158,6 @@ void K_POST::compUnstrNodes2Faces(
           fieldf[pos + 4] = K_CONST::ONE_THIRD * (f4 + f1 + f5);    // A4A1A5
         }
       }
-      
       else if (strcmp(eltTypes[ic], "PENTA") == 0)
       {
         E_Int ind1, ind2, ind3, ind4, ind5, ind6, pos;
@@ -182,11 +181,11 @@ void K_POST::compUnstrNodes2Faces(
           f6 = fieldn[ind6];
 
           pos = fctOffset + i * 5;
-          fieldf[pos] = K_CONST::ONE_THIRD * (f1 + f2 + f3);            // A1A2A3
-          fieldf[pos + 1] = K_CONST::ONE_THIRD * (f4 + f5 + f6);        // A4A5A6
-          fieldf[pos + 2] = K_CONST::ONE_FOURTH * (f1 + f2 + f5 + f4);  // 1254
-          fieldf[pos + 3] = K_CONST::ONE_FOURTH * (f2 + f3 + f6 + f5);  // 2365
-          fieldf[pos + 4] = K_CONST::ONE_FOURTH * (f3 + f1 + f4 + f6);  // 3146
+          fieldf[pos] = K_CONST::ONE_FOURTH * (f1 + f2 + f5 + f4);      // 1254
+          fieldf[pos + 1] = K_CONST::ONE_FOURTH * (f2 + f3 + f6 + f5);  // 2365
+          fieldf[pos + 2] = K_CONST::ONE_FOURTH * (f3 + f1 + f4 + f6);  // 3146
+          fieldf[pos + 3] = K_CONST::ONE_THIRD * (f1 + f2 + f3);        // 123
+          fieldf[pos + 4] = K_CONST::ONE_THIRD * (f4 + f5 + f6);        // 456
         }
       }
       else if (strcmp(eltTypes[ic], "HEXA") == 0)
@@ -217,11 +216,11 @@ void K_POST::compUnstrNodes2Faces(
 
           pos = fctOffset + i * 6;
           fieldf[pos] = K_CONST::ONE_FOURTH * (f1 + f2 + f3 + f4);      // A1A2A3A4
-          fieldf[pos + 1] = K_CONST::ONE_FOURTH * (f5 + f6 + f7 + f8);  // A5A6A7A8
-          fieldf[pos + 2] = K_CONST::ONE_FOURTH * (f4 + f1 + f5 + f8);  // 4158
-          fieldf[pos + 3] = K_CONST::ONE_FOURTH * (f2 + f3 + f7 + f6);  // A2A3A7A6
-          fieldf[pos + 4] = K_CONST::ONE_FOURTH * (f1 + f2 + f6 + f5);  // A1A2A6A5
-          fieldf[pos + 5] = K_CONST::ONE_FOURTH * (f3 + f4 + f8 + f7);  // A3A4A8A7
+          fieldf[pos + 1] = K_CONST::ONE_FOURTH * (f1 + f2 + f6 + f5);  // A1A2A6A5
+          fieldf[pos + 2] = K_CONST::ONE_FOURTH * (f2 + f3 + f7 + f6);  // A2A3A7A6
+          fieldf[pos + 3] = K_CONST::ONE_FOURTH * (f3 + f4 + f8 + f7);  // A3A4A8A7
+          fieldf[pos + 4] = K_CONST::ONE_FOURTH * (f4 + f1 + f5 + f8);  // A4A1A5A8
+          fieldf[pos + 5] = K_CONST::ONE_FOURTH * (f5 + f6 + f7 + f8);  // A5A6A7A8
         }
       }
     }


### PR DESCRIPTION
Change facet ordering for both PENTA and HEXA basic elements in compUnstrCenterInt.cpp, compSurfUnstruct.cpp, and compUnstrNodes2Faces.cpp to comply with the CGNS conventions. This also ensures consistency with the correct facet ordering in getEVFacets.cpp!

No regression.