### PR TITLE
Generator/KCore: updated getAngleRegularityMap for unstr. meshes

### DIFF
--- a/Cassiopee/Generator/Generator/Generator.py
+++ b/Cassiopee/Generator/Generator/Generator.py
@@ -2406,16 +2406,16 @@ def getRegularityMap(array):
     else:
         return generator.getRegularityMap(array)
 
-def getAngleRegularityMap(array):
+def getAngleRegularityMap(array, normalized=False):
     """Return the regularity map in an array.
     Usage: getAngleRegularityMap(array)"""
     if isinstance(array[0], list):
         b = []
         for i in array:
-            b.append(generator.getAngleRegularityMap(i))
+            b.append(generator.getAngleRegularityMap(i, normalized))
         return b
     else:
-        return generator.getAngleRegularityMap(array)
+        return generator.getAngleRegularityMap(array, normalized)
 
 # Fonction retournant la carte de qualite d'une maillage TRI
 # (0. pour un triangle degenere. pour un triangle equilateral)

--- a/Cassiopee/Generator/Generator/PyTree.py
+++ b/Cassiopee/Generator/Generator/PyTree.py
@@ -1910,7 +1910,7 @@ def getAngleRegularityMap(t, addGC=False):
     """Return the regularity map in an array (wrt angles).
     Usage: getAngleRegularityMap(t)"""
     if addGC: t = Internal.addGhostCells(t, t, 1, adaptBCs=0, modified=[], fillCorner=1)
-    t = C.TZGC1(t, 'centers', True, Generator.getAngleRegularityMap)
+    t = C.TZGC3(t, 'centers', True, Generator.getAngleRegularityMap)
     if addGC: t = Internal.rmGhostCells(t, t, 1, adaptBCs=0, modified=[])
     return t
 
@@ -1918,7 +1918,7 @@ def _getAngleRegularityMap(t, addGC=False):
     """Return the regularity map in an array (wrt angles).
     Usage: getAngleRegularityMap(t)"""
     if addGC: Internal._addGhostCells(t, t, 1, adaptBCs=0, modified=[], fillCorner=1)
-    C._TZGC1(t, 'centers', False, Generator.getAngleRegularityMap)
+    C._TZGC3(t, 'centers', False, Generator.getAngleRegularityMap)
     if addGC: Internal._rmGhostCells(t, t, 1, adaptBCs=0, modified=[])
     return None
 

--- a/Cassiopee/Generator/Generator/PyTree.py
+++ b/Cassiopee/Generator/Generator/PyTree.py
@@ -1879,9 +1879,6 @@ def _getOrthogonalityMap(t, normalized=False):
 
 #------------------------------------------------------------------------------
 # Calcul de la regularite (ratio entre des mailles adjacentes) d'une grille
-# 1D: retourne un champ "reg"
-# 2D: retourne deux champs "reg_i", "reg_j"
-# 3D: retourne 3 champs (dans l'ordre "reg_i", "reg_j", "reg_k" pour les grilles structurees)
 #------------------------------------------------------------------------------
 def getRegularityMap(t, addGC=False):
     """Return the regularity map in an array.
@@ -1901,24 +1898,20 @@ def _getRegularityMap(t, addGC=False):
 
 #------------------------------------------------------------------------------
 # Calcul de la regularite (angles entre mailles adjacentes) d'une grille
-# 1D: retourne un champ "reg"
-# 2D: retourne deux champs "reg_i", "reg_j"
-# 3D: retourne 3 champs (dans l'ordre "reg_i", "reg_j", "reg_k" pour les grilles structurees)
-# WARNING !! : ONLY FOR STRUCTURED GRIDS
 #------------------------------------------------------------------------------
-def getAngleRegularityMap(t, addGC=False):
+def getAngleRegularityMap(t, addGC=False, normalized=False):
     """Return the regularity map in an array (wrt angles).
     Usage: getAngleRegularityMap(t)"""
     if addGC: t = Internal.addGhostCells(t, t, 1, adaptBCs=0, modified=[], fillCorner=1)
-    t = C.TZGC3(t, 'centers', True, Generator.getAngleRegularityMap)
+    t = C.TZGC3(t, 'centers', True, Generator.getAngleRegularityMap, normalized)
     if addGC: t = Internal.rmGhostCells(t, t, 1, adaptBCs=0, modified=[])
     return t
 
-def _getAngleRegularityMap(t, addGC=False):
+def _getAngleRegularityMap(t, addGC=False, normalized=False):
     """Return the regularity map in an array (wrt angles).
     Usage: getAngleRegularityMap(t)"""
     if addGC: Internal._addGhostCells(t, t, 1, adaptBCs=0, modified=[], fillCorner=1)
-    C._TZGC3(t, 'centers', False, Generator.getAngleRegularityMap)
+    C._TZGC3(t, 'centers', False, Generator.getAngleRegularityMap, normalized)
     if addGC: Internal._rmGhostCells(t, t, 1, adaptBCs=0, modified=[])
     return None
 

--- a/Cassiopee/Generator/Generator/generator.h
+++ b/Cassiopee/Generator/Generator/generator.h
@@ -439,8 +439,8 @@ namespace K_GENERATOR
   )
   {
     E_Float a2 = (x2-x1)*(x2-x1)+(y2-y1)*(y2-y1)+(z2-z1)*(z2-z1);
-    E_Float b2 = (x3-x1)*(x3-x1)+(y3-y1)*(y3-y1)+(z3-z1)*(z3-z1);
-    E_Float c2 = (x3-x2)*(x3-x2)+(y3-y2)*(y3-y2)+(z3-z2)*(z3-z2);
+    E_Float b2 = (x3-x2)*(x3-x2)+(y3-y2)*(y3-y2)+(z3-z2)*(z3-z2);
+    E_Float c2 = (x3-x1)*(x3-x1)+(y3-y1)*(y3-y1)+(z3-z1)*(z3-z1);
   
     if (a2 < K_CONST::E_GEOM_CUTOFF || b2 < K_CONST::E_GEOM_CUTOFF) // security check
     { 

--- a/Cassiopee/Generator/Generator/generator.h
+++ b/Cassiopee/Generator/Generator/generator.h
@@ -432,63 +432,6 @@ namespace K_GENERATOR
                 std::vector<E_Float*>& coordz, std::vector<E_Float*>& indic,
                 std::vector<FldArrayI*>& connect);
 
-  inline E_Float computeAngle(
-    E_Float x1, E_Float y1, E_Float z1,
-    E_Float x2, E_Float y2, E_Float z2,
-    E_Float x3, E_Float y3, E_Float z3
-  )
-  {
-    E_Float a2 = (x2-x1)*(x2-x1)+(y2-y1)*(y2-y1)+(z2-z1)*(z2-z1);
-    E_Float b2 = (x3-x2)*(x3-x2)+(y3-y2)*(y3-y2)+(z3-z2)*(z3-z2);
-    E_Float c2 = (x3-x1)*(x3-x1)+(y3-y1)*(y3-y1)+(z3-z1)*(z3-z1);
-  
-    if (a2 < K_CONST::E_GEOM_CUTOFF || b2 < K_CONST::E_GEOM_CUTOFF) // security check
-    { 
-      return 0.;
-    }
-  
-    E_Float a = sqrt(a2);
-    E_Float b = sqrt(b2);
-    E_Float cosalpha = K_FUNC::E_max(K_FUNC::E_min((a2+b2-c2)/(2.*a*b),1.),-1.); // law of cosines
-  
-    return acos(cosalpha);
-  }
-  
-  inline E_Float computeSkewness(
-    E_Float x1, E_Float y1, E_Float z1,
-    E_Float x2, E_Float y2, E_Float z2,
-    E_Float x3, E_Float y3, E_Float z3,
-    E_Float refAngle, E_Int normalized=0
-  )
-  {
-    E_Float degconst = 180.0 / K_CONST::E_PI;
-    E_Float alpha = computeAngle(x1,y1,z1,x2,y2,z2,x3,y3,z3);
-
-    if (alpha < K_CONST::E_GEOM_CUTOFF) return 0.; // security check
-    
-    E_Float skewness = K_FUNC::E_abs(alpha*degconst - refAngle);
-    if (normalized) // skewness in [0,1] range
-    {  
-      if (alpha > refAngle) skewness = skewness/(180.-refAngle);
-      else skewness = skewness/refAngle;
-    }
-  
-    return skewness;
-  }
-
-  inline E_Float computeSkewness(
-    const E_Float* x, const E_Float* y, const E_Float* z,
-    E_Int ind1, E_Int ind2, E_Int ind3,
-    E_Float refAngle, E_Int normalized=0
-  )
-  {
-    E_Float x1 = x[ind1], x2 = x[ind2], x3 = x[ind3];
-    E_Float y1 = y[ind1], y2 = y[ind2], y3 = y[ind3];
-    E_Float z1 = z[ind1], z2 = z[ind2], z3 = z[ind3];
-
-    return computeSkewness(x1,y1,z1,x2,y2,z2,x3,y3,z3,refAngle,normalized);
-  }
-
 }
 # undef FldArrayF
 # undef FldArrayI

--- a/Cassiopee/Generator/Generator/generator.h
+++ b/Cassiopee/Generator/Generator/generator.h
@@ -152,7 +152,7 @@ namespace K_GENERATOR
     E_Int loop, E_Int niter, std::vector<E_Int>& constrainedPts, 
     std::vector<FldArrayF*>& constraints,
     FldArrayF& vect, E_Float toldist);
-/* Moteur enforce */
+  /* Moteur enforce */
   E_Int enforceCommon(const char* name, char* varString, 
 		      E_Int ni, E_Int nj, E_Int nk,
 		      FldArrayF& f, E_Float P0, E_Float eh,
@@ -160,10 +160,10 @@ namespace K_GENERATOR
 		      E_Int& niout, E_Int& njout, E_Int& nkout,
 		      E_Int autoAdd=1);
 
-/* Curvilinear absciss calculation */
+  /* Curvilinear absciss calculation */
   void fa(E_Float x, FldArrayF& s, E_Int* i);
 
-/* Cassiopee Kernel dependent functions 
+  /* Cassiopee Kernel dependent functions 
    Attention : si les options de gencart sont basees sur un DesNumerics
    le DesNum n'est pas detruit a la fin, ni le DesAutomesh */
   PyObject* gencart(PyObject* self, PyObject* args);
@@ -175,8 +175,8 @@ namespace K_GENERATOR
                    E_Float& snearMul, E_Int& maxLevels, E_Int& startLevel, 
                    E_Float& stepFactor, E_Int& patchedGrids);
 
-// void getListOfBlocks(PyObject* O, list<BlkBaseBlock*>& listOfBlks);
-// void getListOfMeshes(PyObject* O, list<BlkMesh*>& listOfMeshes);
+  // void getListOfBlocks(PyObject* O, list<BlkBaseBlock*>& listOfBlks);
+  // void getListOfMeshes(PyObject* O, list<BlkMesh*>& listOfMeshes);
 
   void cellPlanarityStructured(E_Int ni, E_Int nj, E_Int nk,
                                FldArrayF& f, E_Int posx, E_Int posy, E_Int posz,
@@ -185,13 +185,13 @@ namespace K_GENERATOR
   void cellPlanarityUnstructured(FldArrayF& f, FldArrayI& cn,
                                  E_Int posx, E_Int posy, E_Int posz,
                                  FldArrayF& dist);
-/* close a structured mesh */
+  /* close a structured mesh */
   void closeStructuredMesh(E_Float* xt, E_Float* yt, E_Float* zt,
                            E_Int ni, E_Int nj, E_Int nk, E_Float eps);    
-/* close an unstructured mesh */
+  /* close an unstructured mesh */
   void closeUnstructuredMesh(E_Int posx, E_Int posy,E_Int posz,E_Float eps,
                              char* eltType, FldArrayF& f, FldArrayI& cn, E_Int removeDegen=0);
-/* close a BAR mesh */
+  /* close a BAR mesh */
   void closeBARMesh(E_Int posx, E_Int posy, E_Int posz, 
                     FldArrayF& f, FldArrayI& cn);
   E_Int closeBARMeshElt(E_Int posx, E_Int posy, E_Int posz,
@@ -207,7 +207,7 @@ namespace K_GENERATOR
 
   PyObject* TFIPENTA(PyObject* arrays);
 
-/* TFI 2D structure. Retourne 0 si echec.*/
+  /* TFI 2D structure. Retourne 0 si echec.*/
   short TFIstruct2D(E_Int ni, E_Int nj, E_Int nfld, 
                     E_Int imin, E_Int imax, E_Int jmin, E_Int jmax, 
                     std::vector<FldArrayF*>& fields,
@@ -217,7 +217,7 @@ namespace K_GENERATOR
                      E_Int imin, E_Int imax, E_Int jmin, E_Int jmax,
                      std::vector<FldArrayF*>& fields,
                      FldArrayF& coords);
-/* TFI 3D structure. Retourne 0 si echec.*/
+  /* TFI 3D structure. Retourne 0 si echec.*/
   short TFIstruct3D(E_Int ni, E_Int nj, E_Int nk, E_Int nfld, 
                     E_Int imin, E_Int imax, E_Int jmin, E_Int jmax, E_Int kmin, E_Int kmax, 
                     std::vector<FldArrayF*>& fields,
@@ -240,7 +240,7 @@ namespace K_GENERATOR
                       std::vector<E_Int>& nit, 
                       std::vector<FldArrayF*>& fields, 
                       FldArrayIS& newOrder);
-/* Verifie la continuite des frontieres imin, imax, ...
+  /* Verifie la continuite des frontieres imin, imax, ...
    aux coins. Vaut 0 si pas continu, 1 sinon  */
   short checkContinuousBnds3D(E_Int ni, E_Int nj, E_Int nk,
                               E_Float* ximin, E_Float* yimin, E_Float* zimin,
@@ -269,16 +269,16 @@ namespace K_GENERATOR
     E_Float* xjmin, E_Float* yjmin, E_Float* zjmin,
     E_Float* xdiag, E_Float* ydiag, E_Float* zdiag);
 
-/* Calcul des coefficients de l 'eq. du plan ax + by + cz + d = 0*/
+  /* Calcul des coefficients de l 'eq. du plan ax + by + cz + d = 0*/
   E_Int compPlaneCoefficients(E_Int posx, E_Int posy, E_Int posz, 
                               FldArrayF& f, 
                               E_Float& a, E_Float& b, E_Float& c, E_Float& d);
 
-/* Calcul des normales a une courbe */
+  /* Calcul des normales a une courbe */
   void normals(E_Int n, E_Float* x, E_Float* y, E_Float* z,
                E_Float* nx, E_Float *ny, E_Float* nz);
 
-/* Calcul de la distance a une courbe sauf le point ind */
+  /* Calcul de la distance a une courbe sauf le point ind */
   E_Float dist2Curve(E_Int n, E_Float* x, E_Float* y, E_Float* z, E_Int* found,
                      E_Float px, E_Float py, E_Float pz, E_Int ind,
                      E_Int& nearest);
@@ -394,13 +394,13 @@ namespace K_GENERATOR
     std::vector<E_Int>& posx, std::vector<E_Int>& posy, std::vector<E_Int>& posz,
     E_Float eps);
 
-void closeAllUnstructuredMeshes(
-  std::vector<FldArrayF*>& unstructF,  std::vector<FldArrayI*>& connectsEV,
-  std::vector<E_Int>& posxt, std::vector<E_Int>& posyt, std::vector<E_Int>& poszt,
-  std::vector<FldArrayF*>& exteriorFacesF,  std::vector<FldArrayI*>& connectsEF,
-  std::vector<E_Int>& posxe, std::vector<E_Int>& posye, std::vector<E_Int>& posze,
-  E_Float eps);
-/* determination des blocs intersectants noz1 ds bboxes
+  void closeAllUnstructuredMeshes(
+    std::vector<FldArrayF*>& unstructF,  std::vector<FldArrayI*>& connectsEV,
+    std::vector<E_Int>& posxt, std::vector<E_Int>& posyt, std::vector<E_Int>& poszt,
+    std::vector<FldArrayF*>& exteriorFacesF,  std::vector<FldArrayI*>& connectsEF,
+    std::vector<E_Int>& posxe, std::vector<E_Int>& posye, std::vector<E_Int>& posze,
+    E_Float eps);
+  /* determination des blocs intersectants noz1 ds bboxes
    IN : noz1 : numero de la zone dans bboxes
    IN : minB : xmin(z1), ymin(z1), zmin(z1) 
    IN : maxB: xmin(z1), ymin(z1), zmin(z1)
@@ -431,6 +431,64 @@ void closeAllUnstructuredMeshes(
                 std::vector<E_Float*>& coordx, std::vector<E_Float*>& coordy, 
                 std::vector<E_Float*>& coordz, std::vector<E_Float*>& indic,
                 std::vector<FldArrayI*>& connect);
+
+  inline E_Float computeAngle(
+    E_Float x1, E_Float y1, E_Float z1,
+    E_Float x2, E_Float y2, E_Float z2,
+    E_Float x3, E_Float y3, E_Float z3
+  )
+  {
+    E_Float a2 = (x2-x1)*(x2-x1)+(y2-y1)*(y2-y1)+(z2-z1)*(z2-z1);
+    E_Float b2 = (x3-x1)*(x3-x1)+(y3-y1)*(y3-y1)+(z3-z1)*(z3-z1);
+    E_Float c2 = (x3-x2)*(x3-x2)+(y3-y2)*(y3-y2)+(z3-z2)*(z3-z2);
+  
+    if (a2 < K_CONST::E_GEOM_CUTOFF || b2 < K_CONST::E_GEOM_CUTOFF) // security check
+    { 
+      return 0.;
+    }
+  
+    E_Float a = sqrt(a2);
+    E_Float b = sqrt(b2);
+    E_Float cosalpha = K_FUNC::E_max(K_FUNC::E_min((a2+b2-c2)/(2.*a*b),1.),-1.); // law of cosines
+  
+    return acos(cosalpha);
+  }
+  
+  inline E_Float computeSkewness(
+    E_Float x1, E_Float y1, E_Float z1,
+    E_Float x2, E_Float y2, E_Float z2,
+    E_Float x3, E_Float y3, E_Float z3,
+    E_Float refAngle, E_Int normalized=0
+  )
+  {
+    E_Float degconst = 180.0 / K_CONST::E_PI;
+    E_Float alpha = computeAngle(x1,y1,z1,x2,y2,z2,x3,y3,z3);
+
+    if (alpha < K_CONST::E_GEOM_CUTOFF) return 0.; // security check
+    
+    E_Float skewness = K_FUNC::E_abs(alpha*degconst - refAngle);
+    if (normalized) // skewness in [0,1] range
+    {  
+      if (alpha > refAngle) skewness = skewness/(180.-refAngle);
+      else skewness = skewness/refAngle;
+    }
+  
+    return skewness;
+  }
+
+  inline E_Float computeSkewness(
+    const E_Float* x, const E_Float* y, const E_Float* z,
+    E_Int ind1, E_Int ind2, E_Int ind3,
+    E_Float refAngle, E_Int normalized=0
+  )
+  {
+    E_Float x1 = x[ind1], x2 = x[ind2], x3 = x[ind3];
+    E_Float y1 = y[ind1], y2 = y[ind2], y3 = y[ind3];
+    E_Float z1 = z[ind1], z2 = z[ind2], z3 = z[ind3];
+
+    return computeSkewness(x1,y1,z1,x2,y2,z2,x3,y3,z3,refAngle,normalized);
+  }
+
 }
 # undef FldArrayF
 # undef FldArrayI

--- a/Cassiopee/Generator/Generator/getAngleRegularityMap.cpp
+++ b/Cassiopee/Generator/Generator/getAngleRegularityMap.cpp
@@ -30,7 +30,9 @@ using namespace K_FUNC;
 PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
 {
   PyObject* array;
-  if (!PYPARSETUPLE_(args, O_, &array)) return NULL;
+  E_Int normalized;
+
+  if (!PYPARSETUPLE_(args, O_ I_, &array, &normalized)) return NULL;
   
   // Check array
   E_Int im, jm, km;
@@ -47,8 +49,6 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
                     "getAngleOrthogonalityMap: unknown type of array.");
     return NULL;
   }
-
-  E_Int normalized = 0;
 
   E_Int api = f->getApi();
   E_Int npts = f->getSize();

--- a/Cassiopee/Generator/Generator/getAngleRegularityMap.cpp
+++ b/Cassiopee/Generator/Generator/getAngleRegularityMap.cpp
@@ -75,7 +75,10 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
     return NULL;
   }
 
+  E_Int api = f->getApi();
+  E_Int npts = f->getSize();
   PyObject* tpl = NULL;
+  FldArrayF* f2;
   
   posx = K_ARRAY::isCoordinateXPresent(varString);
   posy = K_ARRAY::isCoordinateYPresent(varString);
@@ -93,9 +96,6 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
   E_Float* x = f->begin(posx);
   E_Float* y = f->begin(posy);
   E_Float* z = f->begin(posz);
-
-  E_Int api = f->getApi();
-  E_Int nvertex = f->getSize();
   
   if (res == 1) // cas structure
   {
@@ -142,7 +142,6 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
     // definissant l'orthogonalite
     tpl = K_ARRAY::buildArray3(1, "regularityAngle", im1, jm1, km1, api);
     // pointeur sur le tableau d'angle
-    FldArrayF* f2;
     K_ARRAY::getFromArray3(tpl, f2);
     E_Float* alphamax = f2->begin(1);
 
@@ -287,10 +286,101 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
   }
   else // if (res == 2)
   {
-    PyObject* tpl = K_ARRAY::buildArray3(1, "regularityAngle", nvertex, *cn, eltType, 1, api, true);
-    FldArrayF* f2;
+    PyObject* tpl = K_ARRAY::buildArray3(
+      1, "regularityAngle", npts, *cn, eltType, true, api, true
+    );
     K_ARRAY::getFromArray3(tpl, f2);
-    f2->setAllValuesAtNull();
+    E_Float* alphamax = f2->begin(1); // pointeur sur le tableau d'angle
+
+    if (strcmp(eltType, "NGON") == 0)
+    {
+      PyErr_SetString(PyExc_TypeError,
+                      "getAngleRegumarityMap: not implemented for NGON arrays.");
+      RELEASESHAREDS(tpl, f2);
+      RELEASESHAREDU(array, f, cn);
+      return NULL;
+    }
+
+    E_Int nc = cn->getNConnect();
+
+    // Number of facets per element
+    std::vector<E_Int> nfpe;
+    E_Int ierr = K_CONNECT::getNFPE(nfpe, eltType, true);
+    if (ierr != 0)
+    {
+      PyErr_SetString(PyExc_TypeError,
+                      "getAngleRegularityMap: Error computing nfpe.");
+      RELEASESHAREDS(tpl, f2);
+      RELEASESHAREDU(array, f, cn);
+      return NULL;
+    }
+
+    // Total number of elements/facets
+    E_Int ntotFacets = 0;
+    E_Int ntotElts = 0;
+    std::vector<E_Int> nepc(nc+1), nfpc(nc+1);
+    nepc[0] = 0; nfpc[0] = 0;
+    for (E_Int ic = 0; ic < nc; ic++)
+    {
+      K_FLD::FldArrayI& cm = *(cn->getConnect(ic));
+      E_Int nelts = cm.getSize();
+      nepc[ic+1] = nepc[ic] + nelts;
+      nfpc[ic+1] = nfpc[ic] + nfpe[ic]*nelts;  // number of facets per connectivity
+      ntotElts += nelts;
+      ntotFacets += nfpe[ic]*nelts;
+    }
+
+    // Compute center of facets
+    K_FLD::FldArrayF fxint(ntotFacets), fyint(ntotFacets), fzint(ntotFacets);
+    K_METRIC::compUnstructCenterInt(*cn, eltType, x, y, z,
+      fxint.begin(), fyint.begin(), fzint.begin(), true
+    );
+    E_Float* xint = fxint.begin(1);
+    E_Float* yint = fyint.begin(1);
+    E_Float* zint = fzint.begin(1);
+
+    // Compute center of elements
+    K_FLD::FldArrayF fxb(ntotElts), fyb(ntotElts), fzb(ntotElts);
+    K_METRIC::compUnstructCellCenter(*cn, x, y, z,
+      fxb.begin(), fyb.begin(), fzb.begin()
+    );
+    E_Float* xb = fxb.begin(1);
+    E_Float* yb = fyb.begin(1);
+    E_Float* zb = fzb.begin(1);
+
+    // for (E_Int j=0; j<ntotFacets; j++) printf("(facet %d): xint/yint = %2.3f/%2.3f\n", j, xint[j], yint[j]);
+    // for (E_Int j=0; j<ntotElts; j++) printf("(elt %d): xb/yb = %2.3f/%2.3f\n", j, xb[j], yb[j]);
+    // printf("ntotElts = %d, ntotFacets = %d\n", ntotElts, ntotFacets);
+
+    // calcul de la regularite
+    #pragma omp parallel
+    {
+      E_Int nelts, ind, pos;
+      E_Int elOffset, fctOffset;
+      // loop over all connectivities
+      for (E_Int ic = 0; ic < nc; ic++)
+      {
+        K_FLD::FldArrayI& cm = *(cn->getConnect(ic));
+        nelts = cm.getSize();
+        elOffset = nepc[ic];
+        fctOffset = nfpc[ic];
+        
+        // loop over all elements of connectivity cm
+        #pragma omp for
+        for (E_Int i = 0; i < nelts; i++)
+        {
+          ind = i + elOffset; // true element index
+          alphamax[ind] = 0.;
+
+          // loop over all faces of element i
+          for (E_Int f = 0; f < nfpe[ic]; f++)
+          {
+            pos = f + i*nfpe[ic] + fctOffset;
+          }
+        }
+      }
+    }
+
     RELEASESHAREDS(tpl, f2);
     return tpl;
   }

--- a/Cassiopee/Generator/Generator/getAngleRegularityMap.cpp
+++ b/Cassiopee/Generator/Generator/getAngleRegularityMap.cpp
@@ -147,8 +147,8 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
           inext2 = E_min(i+2, ni-1);
           
           alphamax[i] = 0.;
-          alphamax[i] = E_max(K_GENERATOR::computeSkewness(x, y, z, iprev, i, inext, 180., normalized), alphamax[i]);
-          alphamax[i] = E_max(K_GENERATOR::computeSkewness(x, y, z, i, inext, inext2, 180., normalized), alphamax[i]);
+          alphamax[i] = E_max(K_COMPGEOM::computeSkewness(x, y, z, iprev, i, inext, 180., normalized), alphamax[i]);
+          alphamax[i] = E_max(K_COMPGEOM::computeSkewness(x, y, z, i, inext, inext2, 180., normalized), alphamax[i]);
         }        
       }
       else if (dim == 2) // dimension = 2D
@@ -173,25 +173,25 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
           ind1 = indn;
           ind2 = j*ni+inext;
           ind3 = j*ni+inext2;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_COMPGEOM::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
           
           // angle (i-1)->i
           ind1 = j*ni+iprev;
           ind2 = indn;
           ind3 = j*ni+inext;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_COMPGEOM::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
 
           // angle j->(j+1)
           ind1 = indn;
           ind2 = jnext*ni+i;
           ind3 = jnext2*ni+i;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_COMPGEOM::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
 
           // angle (j-1)->j
           ind1 = jprev*ni+i;
           ind2 = indn;
           ind3 = jnext*ni+i;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_COMPGEOM::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
         }
       }
       else  // dimension = 3D
@@ -221,37 +221,37 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
           ind1 = indn;
           ind2 = k*ninj+j*ni+inext;
           ind3 = k*ninj+j*ni+inext2;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_COMPGEOM::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
           
           // angle (i-1)->i
           ind1 = k*ninj+j*ni+iprev;
           ind2 = indn;
           ind3 = k*ninj+j*ni+inext;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_COMPGEOM::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
 
           // angle j->(j+1)
           ind1 = indn;
           ind2 = k*ninj+jnext*ni+i;
           ind3 = k*ninj+jnext2*ni+i;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_COMPGEOM::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
 
           // angle (j-1)->j
           ind1 = k*ninj+jprev*ni+i;
           ind2 = indn;
           ind3 = k*ninj+jnext*ni+i;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_COMPGEOM::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
 
           // angle k->(k+1)
           ind1 = indn;
           ind2 = knext*ninj+j*ni+i;
           ind3 = knext2*ninj+j*ni+i;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_COMPGEOM::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
 
           // angle (k-1)->k
           ind1 = kprev*ninj+j*ni+i;
           ind2 = indn;
           ind3 = knext*ninj+j*ni+i;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_COMPGEOM::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
         }
       }
     }
@@ -371,7 +371,7 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
             x2 = xint[pos]; y2 = yint[pos]; z2 = zint[pos]; // facet center
             x3 = xb[ind2]; y3 = yb[ind2]; z3 = zb[ind2]; // neighbor element center
 
-            alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x1,y1,z1,x2,y2,z2,x3,y3,z3,180.,normalized), alphamax[ind]);
+            alphamax[ind] = E_max(K_COMPGEOM::computeSkewness(x1,y1,z1,x2,y2,z2,x3,y3,z3,180.,normalized), alphamax[ind]);
           }
         }
       }

--- a/Cassiopee/Generator/Generator/getAngleRegularityMap.cpp
+++ b/Cassiopee/Generator/Generator/getAngleRegularityMap.cpp
@@ -51,6 +51,29 @@ inline E_Float computeAngle2(
   return E_abs(acos(cosalpha)*degconst - 180.);
 }
 
+inline E_Float computeAngle3(
+  E_Float x1, E_Float y1, E_Float z1,
+  E_Float x2, E_Float y2, E_Float z2,
+  E_Float x3, E_Float y3, E_Float z3
+)
+{
+  E_Float a2 = (x2-x1)*(x2-x1)+(y2-y1)*(y2-y1)+(z2-z1)*(z2-z1);
+  E_Float b2 = (x3-x1)*(x3-x1)+(y3-y1)*(y3-y1)+(z3-z1)*(z3-z1);
+  E_Float c2 = (x3-x2)*(x3-x2)+(y3-y2)*(y3-y2)+(z3-z2)*(z3-z2);
+
+  if (a2 < E_GEOM_CUTOFF || b2 < E_GEOM_CUTOFF) // security check
+  { 
+    return 0.;
+  }
+
+  E_Float a = sqrt(a2);
+  E_Float b = sqrt(b2);
+  E_Float cosalpha = E_max(E_min((a2+b2-c2)/(2.*a*b),1.),-1.); // law of cosines
+  E_Float degconst = 180.0 / K_CONST::E_PI;
+
+  return E_abs(acos(cosalpha)*degconst - 180.);
+}
+
 // ============================================================================
 /* Return angle regularity map */
 // ============================================================================
@@ -330,6 +353,18 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
       ntotFacets += nfpe[ic]*nelts;
     }
 
+    // Calcul de la connectivite face -> elements
+    FldArrayI cFE(ntotFacets,2);
+    ierr = K_CONNECT::connectEV2FE(eltType, *cn, cFE, true);
+    if (ierr == 1)
+    {
+      PyErr_SetString(PyExc_TypeError,
+                      "getRegularityMap: Error computing cFE.");
+      RELEASESHAREDS(tpl, f2);
+      RELEASESHAREDU(array, f, cn);
+      return NULL;
+    }
+
     // Compute center of facets
     K_FLD::FldArrayF fxint(ntotFacets), fyint(ntotFacets), fzint(ntotFacets);
     K_METRIC::compUnstructCenterInt(*cn, eltType, x, y, z,
@@ -356,7 +391,12 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
     #pragma omp parallel
     {
       E_Int nelts, ind, pos;
+      E_Int ind1, ind2;
       E_Int elOffset, fctOffset;
+      E_Int nneis;
+      E_Float x1, y1, z1;
+      E_Float x2, y2, z2;
+      E_Float x3, y3, z3;
       // loop over all connectivities
       for (E_Int ic = 0; ic < nc; ic++)
       {
@@ -371,11 +411,24 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
         {
           ind = i + elOffset; // true element index
           alphamax[ind] = 0.;
+          x2 = xb[ind]; y2 = yb[ind]; z2 = zb[ind]; // cell center
 
           // loop over all faces of element i
           for (E_Int f = 0; f < nfpe[ic]; f++)
           {
             pos = f + i*nfpe[ic] + fctOffset;
+            ind1 = cFE(pos, 1) - 1;
+            ind2 = cFE(pos, 2) - 1;
+            // printf("elt %d (facet %d): ind1/ind2 = %d/%d\n", ind+1, pos+1, ind1, ind2);
+            if (ind2 < 0) continue; // facet has only one element
+            x1 = xint[pos]; y1 = yint[pos]; z1 = zint[pos]; // facet center
+            x3 = xb[ind2]; y3 = yb[ind2]; z3 = zb[ind2]; // neighbor element center
+
+            alphamax[ind] = E_max(computeAngle3(x1,y1,z1,x2,y2,z2,x3,y3,z3), alphamax[ind]);
+
+            // printf("x1/y1/z1 = %f/%f/%f\n", x1, y1, z1);
+            // printf("x2/y2/z2 = %f/%f/%f\n", x2, y2, z2);
+            // printf("x3/y3/z3 = %f/%f/%f\n", x3, y3, z3);
           }
         }
       }

--- a/Cassiopee/Generator/Generator/getAngleRegularityMap.cpp
+++ b/Cassiopee/Generator/Generator/getAngleRegularityMap.cpp
@@ -383,10 +383,6 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
     E_Float* yb = fyb.begin(1);
     E_Float* zb = fzb.begin(1);
 
-    // for (E_Int j=0; j<ntotFacets; j++) printf("(facet %d): xint/yint = %2.3f/%2.3f\n", j, xint[j], yint[j]);
-    // for (E_Int j=0; j<ntotElts; j++) printf("(elt %d): xb/yb = %2.3f/%2.3f\n", j, xb[j], yb[j]);
-    // printf("ntotElts = %d, ntotFacets = %d\n", ntotElts, ntotFacets);
-
     // calcul de la regularite
     #pragma omp parallel
     {
@@ -419,16 +415,11 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
             pos = f + i*nfpe[ic] + fctOffset;
             ind1 = cFE(pos, 1) - 1;
             ind2 = cFE(pos, 2) - 1;
-            // printf("elt %d (facet %d): ind1/ind2 = %d/%d\n", ind+1, pos+1, ind1, ind2);
             if (ind2 < 0) continue; // facet has only one element
             x1 = xint[pos]; y1 = yint[pos]; z1 = zint[pos]; // facet center
             x3 = xb[ind2]; y3 = yb[ind2]; z3 = zb[ind2]; // neighbor element center
 
             alphamax[ind] = E_max(computeAngle3(x1,y1,z1,x2,y2,z2,x3,y3,z3), alphamax[ind]);
-
-            // printf("x1/y1/z1 = %f/%f/%f\n", x1, y1, z1);
-            // printf("x2/y2/z2 = %f/%f/%f\n", x2, y2, z2);
-            // printf("x3/y3/z3 = %f/%f/%f\n", x3, y3, z3);
           }
         }
       }

--- a/Cassiopee/Generator/Generator/getAngleRegularityMap.cpp
+++ b/Cassiopee/Generator/Generator/getAngleRegularityMap.cpp
@@ -21,7 +21,6 @@
 
 # include "generator.h"
 
-using namespace K_CONST;
 using namespace K_FLD;
 using namespace K_FUNC;
 
@@ -143,13 +142,13 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
         #pragma omp for
         for (E_Int i = 0; i < ni1; i++)
         {
-          iprev = K_FUNC::E_max(i-1, 0);
+          iprev = E_max(i-1, 0);
           inext = i+1;
-          inext2 = K_FUNC::E_min(i+2, ni-1);
+          inext2 = E_min(i+2, ni-1);
           
           alphamax[i] = 0.;
-          alphamax[i] = E_max(K_GENERATOR::computeSkewness(x, y, z, i, iprev, inext, 180., normalized), alphamax[i]);
-          alphamax[i] = E_max(K_GENERATOR::computeSkewness(x, y, z, inext, i, inext2, 180., normalized), alphamax[i]);
+          alphamax[i] = E_max(K_GENERATOR::computeSkewness(x, y, z, iprev, i, inext, 180., normalized), alphamax[i]);
+          alphamax[i] = E_max(K_GENERATOR::computeSkewness(x, y, z, i, inext, inext2, 180., normalized), alphamax[i]);
         }        
       }
       else if (dim == 2) // dimension = 2D
@@ -158,41 +157,41 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
         for (E_Int j = 0; j < nj1; j++)
         for (E_Int i = 0; i < ni1; i++)
         {
-          iprev = K_FUNC::E_max(i-1, 0);
+          iprev = E_max(i-1, 0);
           inext = i+1;
-          inext2 = K_FUNC::E_min(i+2, ni-1);
+          inext2 = E_min(i+2, ni-1);
 
-          jprev = K_FUNC::E_max(j-1, 0);
+          jprev = E_max(j-1, 0);
           jnext = j+1;
-          jnext2 = K_FUNC::E_min(j+2, nj-1);
+          jnext2 = E_min(j+2, nj-1);
 
           ind  = j*ni1+i;
           indn = j*ni+i;
           alphamax[ind] = 0.;
 
-          // calcul de l'angle | i->(i+1)
+          // angle i->(i+1)
           ind1 = indn;
           ind2 = j*ni+inext;
           ind3 = j*ni+inext2;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
           
-          // calcul de l'angle | (i-1)->i
+          // angle (i-1)->i
           ind1 = j*ni+iprev;
           ind2 = indn;
           ind3 = j*ni+inext;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
 
-          // calcul de l'angle | j->(j+1)
+          // angle j->(j+1)
           ind1 = indn;
           ind2 = jnext*ni+i;
           ind3 = jnext2*ni+i;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
 
-          // calcul de l'angle | (j-1)->j
+          // angle (j-1)->j
           ind1 = jprev*ni+i;
           ind2 = indn;
           ind3 = jnext*ni+i;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
         }
       }
       else  // dimension = 3D
@@ -202,57 +201,57 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
         for (E_Int j = 0; j < nj1; j++)
         for (E_Int i = 0; i < ni1; i++)
         {
-          iprev = K_FUNC::E_max(i-1, 0);
+          iprev = E_max(i-1, 0);
           inext = i+1;
-          inext2 = K_FUNC::E_min(i+2, ni-1);
+          inext2 = E_min(i+2, ni-1);
 
-          jprev = K_FUNC::E_max(j-1, 0);
+          jprev = E_max(j-1, 0);
           jnext = j+1;
-          jnext2 = K_FUNC::E_min(j+2, nj-1);
+          jnext2 = E_min(j+2, nj-1);
 
-          kprev = K_FUNC::E_max(k-1, 0);
+          kprev = E_max(k-1, 0);
           knext = k+1;
-          knext2 = K_FUNC::E_min(k+2, nk-1);
+          knext2 = E_min(k+2, nk-1);
 
           ind  = k*ni1nj1+j*ni1+i;
           indn = k*ninj+j*ni+i;
           alphamax[ind] = 0.;
 
-          // calcul de l'angle | i->(i+1)
+          // angle i->(i+1)
           ind1 = indn;
           ind2 = k*ninj+j*ni+inext;
           ind3 = k*ninj+j*ni+inext2;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
           
-          // calcul de l'angle | (i-1)->i
+          // angle (i-1)->i
           ind1 = k*ninj+j*ni+iprev;
           ind2 = indn;
           ind3 = k*ninj+j*ni+inext;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
 
-          // calcul de l'angle | j->(j+1)
+          // angle j->(j+1)
           ind1 = indn;
           ind2 = k*ninj+jnext*ni+i;
           ind3 = k*ninj+jnext2*ni+i;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
 
-          // calcul de l'angle | (j-1)->j
+          // angle (j-1)->j
           ind1 = k*ninj+jprev*ni+i;
           ind2 = indn;
           ind3 = k*ninj+jnext*ni+i;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
 
-          // calcul de l'angle | k->(k+1)
+          // angle k->(k+1)
           ind1 = indn;
           ind2 = knext*ninj+j*ni+i;
           ind3 = knext2*ninj+j*ni+i;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
 
-          // calcul de l'angle | (k-1)->k
+          // angle (k-1)->k
           ind1 = kprev*ninj+j*ni+i;
           ind2 = indn;
           ind3 = knext*ninj+j*ni+i;
-          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 180., normalized), alphamax[ind]);
         }
       }
     }
@@ -298,7 +297,7 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
     nepc[0] = 0; nfpc[0] = 0;
     for (E_Int ic = 0; ic < nc; ic++)
     {
-      K_FLD::FldArrayI& cm = *(cn->getConnect(ic));
+      FldArrayI& cm = *(cn->getConnect(ic));
       E_Int nelts = cm.getSize();
       nepc[ic+1] = nepc[ic] + nelts;
       nfpc[ic+1] = nfpc[ic] + nfpe[ic]*nelts;  // number of facets per connectivity
@@ -319,7 +318,7 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
     }
 
     // Compute center of facets
-    K_FLD::FldArrayF fxint(ntotFacets), fyint(ntotFacets), fzint(ntotFacets);
+    FldArrayF fxint(ntotFacets), fyint(ntotFacets), fzint(ntotFacets);
     K_METRIC::compUnstructCenterInt(*cn, eltType, x, y, z,
       fxint.begin(), fyint.begin(), fzint.begin(), true
     );
@@ -328,7 +327,7 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
     E_Float* zint = fzint.begin(1);
 
     // Compute center of elements
-    K_FLD::FldArrayF fxb(ntotElts), fyb(ntotElts), fzb(ntotElts);
+    FldArrayF fxb(ntotElts), fyb(ntotElts), fzb(ntotElts);
     K_METRIC::compUnstructCellCenter(*cn, x, y, z,
       fxb.begin(), fyb.begin(), fzb.begin()
     );
@@ -349,7 +348,7 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
       // loop over all connectivities
       for (E_Int ic = 0; ic < nc; ic++)
       {
-        K_FLD::FldArrayI& cm = *(cn->getConnect(ic));
+        FldArrayI& cm = *(cn->getConnect(ic));
         nelts = cm.getSize();
         elOffset = nepc[ic];
         fctOffset = nfpc[ic];
@@ -359,8 +358,8 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
         for (E_Int i = 0; i < nelts; i++)
         {
           ind = i + elOffset; // true element index
-          alphamax[ind] = 0.;
-          x2 = xb[ind]; y2 = yb[ind]; z2 = zb[ind]; // cell center
+          x1 = xb[ind]; y1 = yb[ind]; z1 = zb[ind]; // cell center
+          alphamax[ind] = 0.; // initialization
 
           // loop over all faces of element i
           for (E_Int f = 0; f < nfpe[ic]; f++)
@@ -368,8 +367,8 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
             pos = f + i*nfpe[ic] + fctOffset;
             ind1 = cFE(pos, 1) - 1;
             ind2 = cFE(pos, 2) - 1;
-            if (ind2 < 0) continue; // facet has only one element
-            x1 = xint[pos]; y1 = yint[pos]; z1 = zint[pos]; // facet center
+            if (ind2 < 0) continue; // facet has only one neighbor element
+            x2 = xint[pos]; y2 = yint[pos]; z2 = zint[pos]; // facet center
             x3 = xb[ind2]; y3 = yb[ind2]; z3 = zb[ind2]; // neighbor element center
 
             alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x1,y1,z1,x2,y2,z2,x3,y3,z3,180.,normalized), alphamax[ind]);

--- a/Cassiopee/Generator/Generator/getAngleRegularityMap.cpp
+++ b/Cassiopee/Generator/Generator/getAngleRegularityMap.cpp
@@ -25,24 +25,30 @@ using namespace K_CONST;
 using namespace K_FLD;
 using namespace K_FUNC;
 
-inline E_Float computeAngle(E_Float x1,E_Float y1,E_Float z1,E_Float x2,E_Float y2,E_Float z2,E_Float x3,E_Float y3,E_Float z3) {
-  E_Float a2, b2, c2, a, b, d;
-  E_Float pi = 4*atan(1.);
-  E_Float degconst = 180.0 / pi;
-  a2 = (x2-x1)*(x2-x1)+(y2-y1)*(y2-y1)+(z2-z1)*(z2-z1);
-  b2 = (x3-x2)*(x3-x2)+(y3-y2)*(y3-y2)+(z3-z2)*(z3-z2);
-  c2 = (x3-x1)*(x3-x1)+(y3-y1)*(y3-y1)+(z3-z1)*(z3-z1);
-  if ((a2 == 0) || (b2==0) || (c2==0))
-  {
+inline E_Float computeAngle2(
+  const E_Float* x, const E_Float* y, const E_Float* z,
+  E_Int ind1, E_Int ind2, E_Int ind3
+)
+{
+  E_Float x1 = x[ind1], x2 = x[ind2], x3 = x[ind3];
+  E_Float y1 = y[ind1], y2 = y[ind2], y3 = y[ind3];
+  E_Float z1 = z[ind1], z2 = z[ind2], z3 = z[ind3];
+
+  E_Float a2 = (x2-x1)*(x2-x1)+(y2-y1)*(y2-y1)+(z2-z1)*(z2-z1);
+  E_Float b2 = (x3-x1)*(x3-x1)+(y3-y1)*(y3-y1)+(z3-z1)*(z3-z1);
+  E_Float c2 = (x3-x2)*(x3-x2)+(y3-y2)*(y3-y2)+(z3-z2)*(z3-z2);
+
+  if (a2 < E_GEOM_CUTOFF || b2 < E_GEOM_CUTOFF) // security check
+  { 
     return 0.;
   }
-  else
-  {
-    a = sqrt(a2);
-    b = sqrt(b2);
-    d = E_max(E_min((a2+b2-c2)/(2.*a*b),1.),-1.);       
-    return E_abs(acos(d)*degconst - 180.);
-  }
+
+  E_Float a = sqrt(a2);
+  E_Float b = sqrt(b2);
+  E_Float cosalpha = E_max(E_min((a2+b2-c2)/(2.*a*b),1.),-1.); // law of cosines
+  E_Float degconst = 180.0 / K_CONST::E_PI;
+
+  return E_abs(acos(cosalpha)*degconst - 180.);
 }
 
 // ============================================================================
@@ -101,27 +107,36 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
     if (im == 1) im1 = 1;
     if (jm == 1) jm1 = 1;
     if (km == 1) km1 = 1;
-    // Direction constante (en 2D)
-    // 0: 3D
-    // 1: 2D i constant
-    // 2: 2D j constant
-    // 3: 2D k constant
-    E_Int dir = 0;
+    E_Int ncells = im1*jm1*km1;
+
+    E_Int ni = 1, nj = 1, nk = 1;
     if (im == 1)
     {
-      dim = 2; dir=1;
-      if ((jm ==1)||(km == 1)) dim = 1;
+      if (jm == 1) {dim = 1; ni = km;}
+      else if (km == 1) {dim = 1; ni = jm;}
+      else {dim = 2; ni = jm; nj = km;}
     }
     else if (jm == 1)
     {
-      dim = 2; dir = 2;
-      if ((im ==1)||(km == 1)) dim = 1;
+      if (im == 1) {dim = 1; ni = km;}
+      else if (km == 1) {dim = 1; ni = im;}
+      else {dim = 2; ni = im; nj = km;}
     } 
     else if (km == 1)
     {
-      dim = 2; dir = 3;
-      if ((im ==1)||(jm == 1)) dim = 1;
+      if (im == 1) {dim = 1; ni = jm;}
+      else if (jm == 1) {dim = 1; ni = im;}
+      else {dim = 2; ni = im; nj = jm;}
     }
+    else
+    {
+      ni = im; nj = jm; nk = km;
+    }
+    E_Int ni1 = E_max(1, E_Int(ni)-1);
+    E_Int nj1 = E_max(1, E_Int(nj)-1);
+    E_Int nk1 = E_max(1, E_Int(nk)-1);
+    E_Int ni1nj1 = ni1*nj1;
+    E_Int ninj = ni*nj;
     
     // Construction du tableau numpy stockant les angles 
     // definissant l'orthogonalite
@@ -130,1112 +145,139 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
     FldArrayF* f2;
     K_ARRAY::getFromArray3(tpl, f2);
     E_Float* alphamax = f2->begin(1);
+
+    if (ncells == 1) // mono cell mesh -> early exit
+    {
+      alphamax[0] = 0.;
+      RELEASESHAREDS(tpl, f2);
+      RELEASESHAREDS(array, f);
+      return tpl;
+    }
     
     // calcul de l'orthogonalite globale
     #pragma omp parallel
     {
       E_Int ithread = __CURRENT_THREAD__;
+      E_Int ind, indn, ind1, ind2, ind3;
+      E_Int iprev, jprev, kprev;
+      E_Int inext, jnext, knext;
+      E_Int inext2, jnext2, knext2;
+
       if (dim == 1) // dimension = 1D
       {
-        E_Int ni = E_max(im, E_max(jm, km));
-        E_Int ni1 = ni - 1;
-
-        E_Int ind1, ind2, ind3;
-
-        // Initialisation
-        #pragma omp for schedule(static)
+        #pragma omp for
         for (E_Int i = 0; i < ni1; i++)
         {
-          alphamax[i] = -42.;
-        }
-
-        // Corners
-        if (ithread == 0)
-        {
-          // imin --------------------------------------------------
-          E_Int i = 0;
-          // calcul de l'angle | i->(i+1)
-          ind1 = i;
-          ind2 = i+1;
-          ind3 = i+2;
-          alphamax[i] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[i]);
-
-          // imax --------------------------------------------------
-          i = (ni1-1);
-          // calcul de l'angle | (i-1)->i
-          ind1 = i-1;
-          ind2 = i;
-          ind3 = i+1;
-          alphamax[i] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[i]);
-        }
-
-        // Global loop
-        #pragma omp for schedule(static)
-        for (E_Int i = 1; i < ni1-1; i++)
-        {
-          // calcul de l'angle | i->(i+1)
-          ind1 = i;
-          ind2 = i+1;
-          ind3 = i+2;
-          alphamax[i] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[i]);
+          iprev = K_FUNC::E_max(i-1, 0);
+          inext = i+1;
+          inext2 = K_FUNC::E_min(i+2, ni-1);
           
-          // calcul de l'angle | (i-1)->i
-          ind1 = i-1;
-          ind2 = i;
-          ind3 = i+1;
-          alphamax[i] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[i]);
-        }
-        
+          alphamax[i] = 0.;
+          alphamax[i] = E_max(computeAngle2(x, y, z, i, iprev, inext), alphamax[i]);
+          alphamax[i] = E_max(computeAngle2(x, y, z, inext, i, inext2), alphamax[i]);
+        }        
       }
       else if (dim == 2) // dimension = 2D
       {
-        // (ni,nj) : dimensions of 2D-grid 
-        E_Int ni=1, nj=1;
-        switch (dir)
-        {
-          case 3: // k constant
-            ni = im; nj = jm;
-            break;
-          case 2: // j constant
-            ni = im; nj = km;
-            break;
-          case 1: // i constant
-            ni = jm; nj = km;
-            break;
-        }
-
-        E_Int ni1 = ni - 1; E_Int nj1 = nj - 1;
-        if (ni == 1) ni1 = 1;
-        if (nj == 1) nj1 = 1;
-
-        E_Int ind, indn, ind1, ind2, ind3;
-
-        // Initialisation
+        #pragma omp for collapse(2)
         for (E_Int j = 0; j < nj1; j++)
+        for (E_Int i = 0; i < ni1; i++)
         {
-          #pragma omp for schedule(static)
-          for (E_Int i = 0; i < ni1; i++)
-          {
-            ind = j*ni1+i;
-            alphamax[ind] = -42.;
-          }
-        }
+          iprev = K_FUNC::E_max(i-1, 0);
+          inext = i+1;
+          inext2 = K_FUNC::E_min(i+2, ni-1);
 
-        // Corners
-        if (ithread == 0)
-        {
-          // imin, jmin --------------------------------------------------
-          ind  = 0*ni1+0;
-          indn = 0*ni+0;
-          // calcul de l'angle | i->(i+1)
-          ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-          // calcul de l'angle | j->(j+1)
-          ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
+          jprev = K_FUNC::E_max(j-1, 0);
+          jnext = j+1;
+          jnext2 = K_FUNC::E_min(j+2, nj-1);
 
-          // imax, jmin --------------------------------------------------
-          ind  = 0*ni1+(ni1-1);
-          indn = 0*ni+(ni1-1);
-          // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
-          ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-          // calcul de l'angle | j->(j+1)
-          ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // imin, jmax --------------------------------------------------
-          ind  = (nj1-1)*ni1+0;
-          indn = (nj1-1)*ni+0;
-          // calcul de l'angle | i->(i+1)
-          ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-          // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
-          ind2 = indn;
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // imax, jmax --------------------------------------------------
-          ind  = (nj1-1)*ni1+(ni1-1);
-          indn = (nj1-1)*ni+(ni1-1);
-          // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
-          ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-          // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
-          ind2 = indn; 
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-        }
-
-        // Edges
-        #pragma omp for schedule(static)
-        for (E_Int j = 1; j < nj1-1; j++) // imin | imax
-        {
-          // imin --------------------------------------------------
-          ind  = j*ni1+0;
-          indn = j*ni+0;
+          ind  = j*ni1+i;
+          indn = j*ni+i;
+          alphamax[ind] = 0.;
 
           // calcul de l'angle | i->(i+1)
           ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
+          ind2 = j*ni+inext;
+          ind3 = j*ni+inext2;
+          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
+          
+          // calcul de l'angle | (i-1)->i
+          ind1 = j*ni+iprev;
+          ind2 = indn;
+          ind3 = j*ni+inext;
+          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
 
           // calcul de l'angle | j->(j+1)
           ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
+          ind2 = jnext*ni+i;
+          ind3 = jnext2*ni+i;
+          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
 
           // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
+          ind1 = jprev*ni+i;
           ind2 = indn;
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // imax --------------------------------------------------
-          ind  = j*ni1+(ni1-1);
-          indn = j*ni+(ni1-1);
-
-          // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
-          ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | j->(j+1)
-          ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
-          ind2 = indn;
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-        }
-
-        #pragma omp for schedule(static)
-        for (E_Int i = 1; i < ni1-1; i++) // jmin | jmax
-        {
-          // jmin --------------------------------------------------
-          ind  = 0*ni1+i;
-          indn = 0*ni+i;
-
-          // calcul de l'angle | i->(i+1)
-          ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
-          ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | j->(j+1)
-          ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // jmax --------------------------------------------------
-          ind  = (nj1-1)*ni1+i;
-          indn = (nj1-1)*ni+i;
-
-          // calcul de l'angle | i->(i+1)
-          ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
-          ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
-          ind2 = indn;
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-        }
-
-        // Global loop
-        for (E_Int j = 1; j < nj1-1; j++)
-        {
-          #pragma omp for schedule(static)
-          for (E_Int i = 1; i < ni1-1; i++)
-          {
-            ind  = j*ni1+i;
-            indn = j*ni+i;
-
-            // calcul de l'angle | i->(i+1)
-            ind1 = indn;
-            ind2 = indn+1;
-            ind3 = indn+2;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-            
-            // calcul de l'angle | (i-1)->i
-            ind1 = indn-1;
-            ind2 = indn;
-            ind3 = indn+1;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | j->(j+1)
-            ind1 = indn;
-            ind2 = indn+ni;
-            ind3 = indn+2*ni;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | (j-1)->j
-            ind1 = indn-ni;
-            ind2 = indn;
-            ind3 = indn+ni;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-          }
+          ind3 = jnext*ni+i;
+          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
         }
       }
       else  // dimension = 3D
       {
-        // (ni,nj,nk) : dimensions of 3D-grid 
-        E_Int ni = im;
-        E_Int nj = jm;
-        E_Int nk = km;
-        E_Int ni1 = ni - 1; E_Int nj1 = nj - 1; E_Int nk1 = nk - 1;
-        if (ni == 1) ni1 = 1;
-        if (nj == 1) nj1 = 1;
-        if (nk == 1) nk1 = 1;
-
-        E_Int ind, indn, ind1, ind2, ind3;
-
-        // Initialisation
+        #pragma omp for collapse(3)
         for (E_Int k = 0; k < nk1; k++)
+        for (E_Int j = 0; j < nj1; j++)
+        for (E_Int i = 0; i < ni1; i++)
         {
-          for (E_Int j = 0; j < nj1; j++)
-          {
-            #pragma omp for schedule(static)
-            for (E_Int i = 0; i < ni1; i++)
-            {
-              ind = k*ni1*nj1+j*ni1+i;
-              alphamax[ind] = -42.;
-            }
-          }
-        }
+          iprev = K_FUNC::E_max(i-1, 0);
+          inext = i+1;
+          inext2 = K_FUNC::E_min(i+2, ni-1);
 
-        if (ithread == 0)
-        {
-          // Corners
-          // imin, jmin, kmin --------------------------------------------------
-          ind  = 0*ni1*nj1+0*ni1+0;
-          indn = 0*ni*nj+0*ni+0;
+          jprev = K_FUNC::E_max(j-1, 0);
+          jnext = j+1;
+          jnext2 = K_FUNC::E_min(j+2, nj-1);
+
+          kprev = K_FUNC::E_max(k-1, 0);
+          knext = k+1;
+          knext2 = K_FUNC::E_min(k+2, nk-1);
+
+          ind  = k*ni1nj1+j*ni1+i;
+          indn = k*ninj+j*ni+i;
+          alphamax[ind] = 0.;
+
           // calcul de l'angle | i->(i+1)
           ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | j->(j+1)
-          ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | k->(k+1)
-          ind1 = indn;
-          ind2 = indn+ni*nj;
-          ind3 = indn+2*ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // imin, jmin, kmax --------------------------------------------------
-          ind  = (nk1-1)*ni1*nj1+0*ni1+0;
-          indn = (nk1-1)*ni*nj+0*ni+0;
-          // calcul de l'angle | i->(i+1)
-          ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | j->(j+1)
-          ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (k-1)->k
-          ind1 = indn-ni*nj;
-          ind2 = indn;
-          ind3 = indn+ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // imin, jmax, kmin --------------------------------------------------
-          ind  = 0*ni1*nj1+(nj1-1)*ni1+0;
-          indn = 0*ni*nj+(nj1-1)*ni+0;
-          // calcul de l'angle | i->(i+1)
-          ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
-          ind2 = indn;
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | k->(k+1)
-          ind1 = indn;
-          ind2 = indn+ni*nj;
-          ind3 = indn+2*ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // imin, jmax, kmax --------------------------------------------------
-          ind  = (nk1-1)*ni1*nj1+(nj1-1)*ni1+0;
-          indn = (nk1-1)*ni*nj+(nj1-1)*ni+0;
-          // calcul de l'angle | i->(i+1)
-          ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
-          ind2 = indn;
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (k-1)->k
-          ind1 = indn-ni*nj;
-          ind2 = indn;
-          ind3 = indn+ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // imax, jmin, kmin --------------------------------------------------
-          ind  = 0*ni1*nj1+0*ni1+(ni1-1);
-          indn = 0*ni*nj+0*ni+(ni1-1);      
-          // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
-          ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | j->(j+1)
-          ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | k->(k+1)
-          ind1 = indn;
-          ind2 = indn+ni*nj;
-          ind3 = indn+2*ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // imax, jmin, kmax --------------------------------------------------
-          ind  = (nk1-1)*ni1*nj1+0*ni1+(ni1-1);
-          indn = (nk1-1)*ni*nj+0*ni+(ni1-1);      
-          // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
-          ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | j->(j+1)
-          ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (k-1)->k
-          ind1 = indn-ni*nj;
-          ind2 = indn;
-          ind3 = indn+ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // imax, jmax, kmin --------------------------------------------------
-          ind  = 0*ni1*nj1+(nj1-1)*ni1+(ni1-1);
-          indn = 0*ni*nj+(nj1-1)*ni+(ni1-1);
+          ind2 = k*ninj+j*ni+inext;
+          ind3 = k*ninj+j*ni+inext2;
+          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
           
           // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
+          ind1 = k*ninj+j*ni+iprev;
           ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
-          ind2 = indn;
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | k->(k+1)
-          ind1 = indn;
-          ind2 = indn+ni*nj;
-          ind3 = indn+2*ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // imax, jmax, kmax
-          ind  = (nk1-1)*ni1*nj1+(nj1-1)*ni1+(ni1-1);
-          indn = (nk1-1)*ni*nj+(nj1-1)*ni+(ni1-1);      
-          // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
-          ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
-          ind2 = indn;
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (k-1)->k
-          ind1 = indn-ni*nj;
-          ind2 = indn;
-          ind3 = indn+ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-        }
-
-        // Edges
-        #pragma omp for schedule(static)
-        for (E_Int k = 1; k < nk1-1; k++) // imin | imax and jmin | jmax
-        {
-          // imin and jmin --------------------------------------------------
-          ind  = k*ni1*nj1+0*ni1+0;
-          indn = k*ni*nj+0*ni+0;
-
-          // calcul de l'angle | i->(i+1)
-          ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
+          ind3 = k*ninj+j*ni+inext;
+          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
 
           // calcul de l'angle | j->(j+1)
           ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
+          ind2 = k*ninj+jnext*ni+i;
+          ind3 = k*ninj+jnext2*ni+i;
+          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
+
+          // calcul de l'angle | (j-1)->j
+          ind1 = k*ninj+jprev*ni+i;
+          ind2 = indn;
+          ind3 = k*ninj+jnext*ni+i;
+          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
 
           // calcul de l'angle | k->(k+1)
           ind1 = indn;
-          ind2 = indn+ni*nj;
-          ind3 = indn+2*ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
+          ind2 = knext*ninj+j*ni+i;
+          ind3 = knext2*ninj+j*ni+i;
+          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
 
           // calcul de l'angle | (k-1)->k
-          ind1 = indn-ni*nj;
+          ind1 = kprev*ninj+j*ni+i;
           ind2 = indn;
-          ind3 = indn+ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // imax and jmin --------------------------------------------------
-          ind  = k*ni1*nj1+0*ni1+(ni1-1);
-          indn = k*ni*nj+0*ni+(ni1-1);
-          
-          // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
-          ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | j->(j+1)
-          ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | k->(k+1)
-          ind1 = indn;
-          ind2 = indn+ni*nj;
-          ind3 = indn+2*ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (k-1)->k
-          ind1 = indn-ni*nj;
-          ind2 = indn;
-          ind3 = indn+ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // imin and jmax --------------------------------------------------
-          ind  = k*ni1*nj1+(nj1-1)*ni1+0;
-          indn = k*ni*nj+(nj1-1)*ni+0;
-
-          // calcul de l'angle | i->(i+1)
-          ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
-          ind2 = indn;
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | k->(k+1)
-          ind1 = indn;
-          ind2 = indn+ni*nj;
-          ind3 = indn+2*ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (k-1)->k
-          ind1 = indn-ni*nj;
-          ind2 = indn;
-          ind3 = indn+ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // imax and jmax --------------------------------------------------
-          ind  = k*ni1*nj1+(nj1-1)*ni1+(ni1-1);
-          indn = k*ni*nj+(nj1-1)*ni+(ni1-1);
-          
-          // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
-          ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
-          ind2 = indn;
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | k->(k+1)
-          ind1 = indn;
-          ind2 = indn+ni*nj;
-          ind3 = indn+2*ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (k-1)->k
-          ind1 = indn-ni*nj;
-          ind2 = indn;
-          ind3 = indn+ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-        }
-        
-        #pragma omp for schedule(static)
-        for (E_Int j = 1; j < nj1-1; j++) // imin | imax and kmin | kmax
-        {
-          // imin and kmin --------------------------------------------------
-          ind  = 0*ni1*nj1+j*ni1+0;
-          indn = 0*ni*nj+j*ni+0;
-
-          // calcul de l'angle | i->(i+1)
-          ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | j->(j+1)
-          ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
-          ind2 = indn;
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | k->(k+1)
-          ind1 = indn;
-          ind2 = indn+ni*nj;
-          ind3 = indn+2*ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // imax and kmin --------------------------------------------------
-          ind  = 0*ni1*nj1+j*ni1+(ni1-1);
-          indn = 0*ni*nj+j*ni+(ni1-1);
-
-          // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
-          ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | j->(j+1)
-          ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
-          ind2 = indn;
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | k->(k+1)
-          ind1 = indn;
-          ind2 = indn+ni*nj;
-          ind3 = indn+2*ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // imin and kmax --------------------------------------------------
-          ind  = (nk1-1)*ni1*nj1+j*ni1+0;
-          indn = (nk1-1)*ni*nj+j*ni+0;
-
-          // calcul de l'angle | i->(i+1)
-          ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | j->(j+1)
-          ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
-          ind2 = indn;
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (k-1)->k
-          ind1 = indn-ni*nj;
-          ind2 = indn;
-          ind3 = indn+ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // imax and kmax --------------------------------------------------
-          ind  = (nk1-1)*ni1*nj1+j*ni1+(ni1-1);
-          indn = (nk1-1)*ni*nj+j*ni+(ni1-1);
-
-          // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
-          ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | j->(j+1)
-          ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
-          ind2 = indn;
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (k-1)->k
-          ind1 = indn-ni*nj;
-          ind2 = indn;
-          ind3 = indn+ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-        }
-
-        #pragma omp for schedule(static)
-        for (E_Int i = 1; i < ni1-1; i++) // jmin | jmax and kmin | kmax
-        {
-          // jmin and kmin --------------------------------------------------
-          ind  = 0*ni1*nj1+0*ni1+i;
-          indn = 0*ni*nj+0*ni+i;
-
-          // calcul de l'angle | i->(i+1)
-          ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-          
-          // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
-          ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | j->(j+1)
-          ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | k->(k+1)
-          ind1 = indn;
-          ind2 = indn+ni*nj;
-          ind3 = indn+2*ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // jmax and kmin --------------------------------------------------
-          ind  = 0*ni1*nj1+(nj1-1)*ni1+i;
-          indn = 0*ni*nj+(nj1-1)*ni+i;
-
-          // calcul de l'angle | i->(i+1)
-          ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-          
-          // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
-          ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
-          ind2 = indn;
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | k->(k+1)
-          ind1 = indn;
-          ind2 = indn+ni*nj;
-          ind3 = indn+2*ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // jmin and kmax --------------------------------------------------
-          ind  = (nk1-1)*ni1*nj1+0*ni1+i;
-          indn = (nk1-1)*ni*nj+0*ni+i;
-
-          // calcul de l'angle | i->(i+1)
-          ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-          
-          // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
-          ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | j->(j+1)
-          ind1 = indn;
-          ind2 = indn+ni;
-          ind3 = indn+2*ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (k-1)->k
-          ind1 = indn-ni*nj;
-          ind2 = indn;
-          ind3 = indn+ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // jmax and kmax --------------------------------------------------
-          ind  = (nk1-1)*ni1*nj1+(nj1-1)*ni1+i;
-          indn = (nk1-1)*ni*nj+(nj1-1)*ni+i;
-
-          // calcul de l'angle | i->(i+1)
-          ind1 = indn;
-          ind2 = indn+1;
-          ind3 = indn+2;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-          
-          // calcul de l'angle | (i-1)->i
-          ind1 = indn-1;
-          ind2 = indn;
-          ind3 = indn+1;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (j-1)->j
-          ind1 = indn-ni;
-          ind2 = indn;
-          ind3 = indn+ni;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-          // calcul de l'angle | (k-1)->k
-          ind1 = indn-ni*nj;
-          ind2 = indn;
-          ind3 = indn+ni*nj;
-          alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-        }
-
-        // Faces
-        for (E_Int k = 1; k < nk1-1; k++) // imin | imax
-        {
-          #pragma omp for schedule(static)
-          for (E_Int j = 1; j < nj1-1; j++)
-          {
-            // imin --------------------------------------------------
-            ind  = k*ni1*nj1+j*ni1+0;
-            indn = k*ni*nj+j*ni+0;
-
-            // calcul de l'angle | i->(i+1)
-            ind1 = indn;
-            ind2 = indn+1;
-            ind3 = indn+2;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | j->(j+1)
-            ind1 = indn;
-            ind2 = indn+ni;
-            ind3 = indn+2*ni;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | (j-1)->j
-            ind1 = indn-ni;
-            ind2 = indn;
-            ind3 = indn+ni;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | k->(k+1)
-            ind1 = indn;
-            ind2 = indn+ni*nj;
-            ind3 = indn+2*ni*nj;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | (k-1)->k
-            ind1 = indn-ni*nj;
-            ind2 = indn;
-            ind3 = indn+ni*nj;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // imax --------------------------------------------------
-            ind  = k*ni1*nj1+j*ni1+(ni1-1);
-            indn = k*ni*nj+j*ni+(ni1-1);
-
-            // calcul de l'angle | (i-1)->i
-            ind1 = indn-1;
-            ind2 = indn;
-            ind3 = indn+1;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | j->(j+1)
-            ind1 = indn;
-            ind2 = indn+ni;
-            ind3 = indn+2*ni;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | (j-1)->j
-            ind1 = indn-ni;
-            ind2 = indn;
-            ind3 = indn+ni;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | k->(k+1)
-            ind1 = indn;
-            ind2 = indn+ni*nj;
-            ind3 = indn+2*ni*nj;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | (k-1)->k
-            ind1 = indn-ni*nj;
-            ind2 = indn;
-            ind3 = indn+ni*nj;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-          }
-        }
-
-        for (E_Int k = 1; k < nk1-1; k++) // jmin | jmax
-        {
-          #pragma omp for schedule(static)
-          for (E_Int i = 1; i < ni1-1; i++)
-          {
-            // jmin --------------------------------------------------
-            ind  = k*ni1*nj1+0*ni1+i;
-            indn = k*ni*nj+0*ni+i;
-
-            // calcul de l'angle | i->(i+1)
-            ind1 = indn;
-            ind2 = indn+1;
-            ind3 = indn+2;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | (i-1)->i
-            ind1 = indn-1;
-            ind2 = indn;
-            ind3 = indn+1;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | j->(j+1)
-            ind1 = indn;
-            ind2 = indn+ni;
-            ind3 = indn+2*ni;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | k->(k+1)
-            ind1 = indn;
-            ind2 = indn+ni*nj;
-            ind3 = indn+2*ni*nj;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | (k-1)->k
-            ind1 = indn-ni*nj;
-            ind2 = indn;
-            ind3 = indn+ni*nj;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // jmax --------------------------------------------------
-            ind  = k*ni1*nj1+(nj1-1)*ni1+i;
-            indn = k*ni*nj+(nj1-1)*ni+i;
-
-            // calcul de l'angle | i->(i+1)
-            ind1 = indn;
-            ind2 = indn+1;
-            ind3 = indn+2;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | (i-1)->i
-            ind1 = indn-1;
-            ind2 = indn;
-            ind3 = indn+1;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | (j-1)->j
-            ind1 = indn-ni;
-            ind2 = indn;
-            ind3 = indn+ni;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | k->(k+1)
-            ind1 = indn;
-            ind2 = indn+ni*nj;
-            ind3 = indn+2*ni*nj;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | (k-1)->k
-            ind1 = indn-ni*nj;
-            ind2 = indn;
-            ind3 = indn+ni*nj;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-          }
-        }
-
-        for (E_Int j = 1; j < nj1-1; j++) // kmin | kmax
-        {
-          #pragma omp for schedule(static)
-          for (E_Int i = 1; i < ni1-1; i++)
-          {
-            // kmin --------------------------------------------------
-            ind  = 0*ni1*nj1+j*ni1+i;
-            indn = 0*ni*nj+j*ni+i;
-
-            // calcul de l'angle | i->(i+1)
-            ind1 = indn;
-            ind2 = indn+1;
-            ind3 = indn+2;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | (i-1)->i
-            ind1 = indn-1;
-            ind2 = indn;
-            ind3 = indn+1;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | j->(j+1)
-            ind1 = indn;
-            ind2 = indn+ni;
-            ind3 = indn+2*ni;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | (j-1)->j
-            ind1 = indn-ni;
-            ind2 = indn;
-            ind3 = indn+ni;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | k->(k+1)
-            ind1 = indn;
-            ind2 = indn+ni*nj;
-            ind3 = indn+2*ni*nj;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // kmax --------------------------------------------------
-            ind  = (nk1-1)*ni1*nj1+j*ni1+i;
-            indn = (nk1-1)*ni*nj+j*ni+i;
-
-            // calcul de l'angle | i->(i+1)
-            ind1 = indn;
-            ind2 = indn+1;
-            ind3 = indn+2;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | (i-1)->i
-            ind1 = indn-1;
-            ind2 = indn;
-            ind3 = indn+1;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | j->(j+1)
-            ind1 = indn;
-            ind2 = indn+ni;
-            ind3 = indn+2*ni;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | (j-1)->j
-            ind1 = indn-ni;
-            ind2 = indn;
-            ind3 = indn+ni;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-            // calcul de l'angle | (k-1)->k
-            ind1 = indn-ni*nj;
-            ind2 = indn;
-            ind3 = indn+ni*nj;
-            alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-          }
-        }
-
-        // Global loop
-        for (E_Int k = 1; k < nk1-1; k++)
-        {
-          for (E_Int j = 1; j < nj1-1; j++)
-          {
-            #pragma omp for schedule(static)
-            for (E_Int i = 1; i < ni1-1; i++)
-            {
-              ind  = k*ni1*nj1+j*ni1+i;
-              indn = k*ni*nj+j*ni+i;
-
-              // calcul de l'angle | i->(i+1)
-              ind1 = indn;
-              ind2 = indn+1;
-              ind3 = indn+2;
-              alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-              
-              // calcul de l'angle | (i-1)->i
-              ind1 = indn-1;
-              ind2 = indn;
-              ind3 = indn+1;
-              alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-              // calcul de l'angle | j->(j+1)
-              ind1 = indn;
-              ind2 = indn+ni;
-              ind3 = indn+2*ni;
-              alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-              // calcul de l'angle | (j-1)->j
-              ind1 = indn-ni;
-              ind2 = indn;
-              ind3 = indn+ni;
-              alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-              // calcul de l'angle | k->(k+1)
-              ind1 = indn;
-              ind2 = indn+ni*nj;
-              ind3 = indn+2*ni*nj;
-              alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-
-              // calcul de l'angle | (k-1)->k
-              ind1 = indn-ni*nj;
-              ind2 = indn;
-              ind3 = indn+ni*nj;
-              alphamax[ind] = E_max(computeAngle(x[ind1],y[ind1],z[ind1],x[ind2],y[ind2],z[ind2],x[ind3],y[ind3],z[ind3]), alphamax[ind]);
-            }
-          }
+          ind3 = knext*ninj+j*ni+i;
+          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
         }
       }
     }

--- a/Cassiopee/Generator/Generator/getAngleRegularityMap.cpp
+++ b/Cassiopee/Generator/Generator/getAngleRegularityMap.cpp
@@ -25,55 +25,6 @@ using namespace K_CONST;
 using namespace K_FLD;
 using namespace K_FUNC;
 
-inline E_Float computeAngle2(
-  const E_Float* x, const E_Float* y, const E_Float* z,
-  E_Int ind1, E_Int ind2, E_Int ind3
-)
-{
-  E_Float x1 = x[ind1], x2 = x[ind2], x3 = x[ind3];
-  E_Float y1 = y[ind1], y2 = y[ind2], y3 = y[ind3];
-  E_Float z1 = z[ind1], z2 = z[ind2], z3 = z[ind3];
-
-  E_Float a2 = (x2-x1)*(x2-x1)+(y2-y1)*(y2-y1)+(z2-z1)*(z2-z1);
-  E_Float b2 = (x3-x1)*(x3-x1)+(y3-y1)*(y3-y1)+(z3-z1)*(z3-z1);
-  E_Float c2 = (x3-x2)*(x3-x2)+(y3-y2)*(y3-y2)+(z3-z2)*(z3-z2);
-
-  if (a2 < E_GEOM_CUTOFF || b2 < E_GEOM_CUTOFF) // security check
-  { 
-    return 0.;
-  }
-
-  E_Float a = sqrt(a2);
-  E_Float b = sqrt(b2);
-  E_Float cosalpha = E_max(E_min((a2+b2-c2)/(2.*a*b),1.),-1.); // law of cosines
-  E_Float degconst = 180.0 / K_CONST::E_PI;
-
-  return E_abs(acos(cosalpha)*degconst - 180.);
-}
-
-inline E_Float computeAngle3(
-  E_Float x1, E_Float y1, E_Float z1,
-  E_Float x2, E_Float y2, E_Float z2,
-  E_Float x3, E_Float y3, E_Float z3
-)
-{
-  E_Float a2 = (x2-x1)*(x2-x1)+(y2-y1)*(y2-y1)+(z2-z1)*(z2-z1);
-  E_Float b2 = (x3-x1)*(x3-x1)+(y3-y1)*(y3-y1)+(z3-z1)*(z3-z1);
-  E_Float c2 = (x3-x2)*(x3-x2)+(y3-y2)*(y3-y2)+(z3-z2)*(z3-z2);
-
-  if (a2 < E_GEOM_CUTOFF || b2 < E_GEOM_CUTOFF) // security check
-  { 
-    return 0.;
-  }
-
-  E_Float a = sqrt(a2);
-  E_Float b = sqrt(b2);
-  E_Float cosalpha = E_max(E_min((a2+b2-c2)/(2.*a*b),1.),-1.); // law of cosines
-  E_Float degconst = 180.0 / K_CONST::E_PI;
-
-  return E_abs(acos(cosalpha)*degconst - 180.);
-}
-
 // ============================================================================
 /* Return angle regularity map */
 // ============================================================================
@@ -97,6 +48,8 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
                     "getAngleOrthogonalityMap: unknown type of array.");
     return NULL;
   }
+
+  E_Int normalized = 0;
 
   E_Int api = f->getApi();
   E_Int npts = f->getSize();
@@ -195,8 +148,8 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
           inext2 = K_FUNC::E_min(i+2, ni-1);
           
           alphamax[i] = 0.;
-          alphamax[i] = E_max(computeAngle2(x, y, z, i, iprev, inext), alphamax[i]);
-          alphamax[i] = E_max(computeAngle2(x, y, z, inext, i, inext2), alphamax[i]);
+          alphamax[i] = E_max(K_GENERATOR::computeSkewness(x, y, z, i, iprev, inext, 180., normalized), alphamax[i]);
+          alphamax[i] = E_max(K_GENERATOR::computeSkewness(x, y, z, inext, i, inext2, 180., normalized), alphamax[i]);
         }        
       }
       else if (dim == 2) // dimension = 2D
@@ -221,25 +174,25 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
           ind1 = indn;
           ind2 = j*ni+inext;
           ind3 = j*ni+inext2;
-          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
           
           // calcul de l'angle | (i-1)->i
           ind1 = j*ni+iprev;
           ind2 = indn;
           ind3 = j*ni+inext;
-          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
 
           // calcul de l'angle | j->(j+1)
           ind1 = indn;
           ind2 = jnext*ni+i;
           ind3 = jnext2*ni+i;
-          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
 
           // calcul de l'angle | (j-1)->j
           ind1 = jprev*ni+i;
           ind2 = indn;
           ind3 = jnext*ni+i;
-          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
         }
       }
       else  // dimension = 3D
@@ -269,37 +222,37 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
           ind1 = indn;
           ind2 = k*ninj+j*ni+inext;
           ind3 = k*ninj+j*ni+inext2;
-          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
           
           // calcul de l'angle | (i-1)->i
           ind1 = k*ninj+j*ni+iprev;
           ind2 = indn;
           ind3 = k*ninj+j*ni+inext;
-          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
 
           // calcul de l'angle | j->(j+1)
           ind1 = indn;
           ind2 = k*ninj+jnext*ni+i;
           ind3 = k*ninj+jnext2*ni+i;
-          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
 
           // calcul de l'angle | (j-1)->j
           ind1 = k*ninj+jprev*ni+i;
           ind2 = indn;
           ind3 = k*ninj+jnext*ni+i;
-          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
 
           // calcul de l'angle | k->(k+1)
           ind1 = indn;
           ind2 = knext*ninj+j*ni+i;
           ind3 = knext2*ninj+j*ni+i;
-          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
 
           // calcul de l'angle | (k-1)->k
           ind1 = kprev*ninj+j*ni+i;
           ind2 = indn;
           ind3 = knext*ninj+j*ni+i;
-          alphamax[ind] = E_max(computeAngle2(x, y, z, ind2, ind1, ind3), alphamax[ind]);
+          alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 180., normalized), alphamax[ind]);
         }
       }
     }
@@ -419,7 +372,7 @@ PyObject* K_GENERATOR::getAngleRegularityMap(PyObject* self, PyObject* args)
             x1 = xint[pos]; y1 = yint[pos]; z1 = zint[pos]; // facet center
             x3 = xb[ind2]; y3 = yb[ind2]; z3 = zb[ind2]; // neighbor element center
 
-            alphamax[ind] = E_max(computeAngle3(x1,y1,z1,x2,y2,z2,x3,y3,z3), alphamax[ind]);
+            alphamax[ind] = E_max(K_GENERATOR::computeSkewness(x1,y1,z1,x2,y2,z2,x3,y3,z3,180.,normalized), alphamax[ind]);
           }
         }
       }

--- a/Cassiopee/Generator/Generator/getOrthogonalityMap.cpp
+++ b/Cassiopee/Generator/Generator/getOrthogonalityMap.cpp
@@ -22,7 +22,6 @@
 # include "generator.h"
 # include <math.h>
 
-using namespace K_CONST;
 using namespace K_FLD;
 using namespace K_FUNC;
 
@@ -149,13 +148,12 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
         for (E_Int j = 0; j < nj1; j++)
         for (E_Int i = 0; i < ni1; i++)
         {
-          // indices pour le calcul de l'angle definissant l'orthogonalite
           inext = i+1;
           jnext = j+1;
-          // calcul de l'angle
           ind = j*ni1+i;
-          ind1 = j*ni+i;
-          ind2 = j*ni+inext;
+          // (i,j) angle
+          ind1 = j*ni+inext;
+          ind2 = j*ni+i;
           ind3 = jnext*ni+i;
           skewness[ind] = K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
         }
@@ -167,22 +165,20 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
         for (E_Int j = 0; j < nj1; j++)
         for (E_Int i = 0; i < ni1; i++)
         {
-          // indices pour le calcul des angles definissant l'orthogonalite
           inext = i+1;
           jnext = j+1;
           knext = k+1;
-          // calcul des angles
           ind  = k*ni1*nj1+j*ni1+i;
-          ind1 = k*ni*nj+j*ni+i;
-          ind2 = k*ni*nj+j*ni+inext;
+          // (i,j) angle
+          ind1 = k*ni*nj+j*ni+inext;
+          ind2 = k*ni*nj+j*ni+i;
           ind3 = k*ni*nj+jnext*ni+i;
-          // ... angle correspondant aux indices (ij)
           skewness1 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
-          // ... angle correspondant aux indices (ik)
+          // (i,k) angle
           ind3 = knext*ni*nj+j*ni+i;
           skewness2 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
-          // ... angle correspondant aux indices (jk)
-          ind2 = k*ni*nj+jnext*ni+i;
+          // (j,k) angle
+          ind1 = k*ni*nj+jnext*ni+i;
           skewness3 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
           // max skewness
           skewness[ind] = E_max(E_max(skewness1,skewness2),skewness3);
@@ -241,7 +237,7 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
       // loop over all connectivities
       for (E_Int ic = 0; ic < nc; ic++)
       {
-        K_FLD::FldArrayI& cm = *(cn->getConnect(ic));
+        FldArrayI& cm = *(cn->getConnect(ic));
         nelts = cm.getSize();
         K_CONNECT::getEVFacets(facets, eltTypes[ic], false, false);
         
@@ -263,10 +259,10 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
               ind3 = cm(i,facets[f][2])-1;
               ind4 = cm(i,facets[f][3])-1;
 
-              skewness1 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind4, ind2, 90., normalized); // angle 412
-              skewness2 = K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 90., normalized); // angle 123
-              skewness3 = K_GENERATOR::computeSkewness(x, y, z, ind3, ind2, ind4, 90., normalized); // angle 234
-              skewness4 = K_GENERATOR::computeSkewness(x, y, z, ind4, ind3, ind1, 90., normalized); // angle 341
+              skewness1 = K_GENERATOR::computeSkewness(x, y, z, ind4, ind1, ind2, 90., normalized); // angle 412
+              skewness2 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized); // angle 123
+              skewness3 = K_GENERATOR::computeSkewness(x, y, z, ind2, ind3, ind4, 90., normalized); // angle 234
+              skewness4 = K_GENERATOR::computeSkewness(x, y, z, ind3, ind4, ind1, 90., normalized); // angle 341
 
               skewness[ind] = E_max(E_max(E_max(E_max(skewness1,skewness2),skewness3),skewness4),skewness[ind]);
             }
@@ -276,9 +272,9 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
               ind2 = cm(i,facets[f][1])-1;
               ind3 = cm(i,facets[f][2])-1;
 
-              skewness1 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind3, ind2, 60., normalized); // angle 312
-              skewness2 = K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 60., normalized); // angle 123
-              skewness3 = K_GENERATOR::computeSkewness(x, y, z, ind3, ind2, ind1, 60., normalized); // angle 231
+              skewness1 = K_GENERATOR::computeSkewness(x, y, z, ind3, ind1, ind2, 60., normalized); // angle 312
+              skewness2 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 60., normalized); // angle 123
+              skewness3 = K_GENERATOR::computeSkewness(x, y, z, ind2, ind3, ind1, 60., normalized); // angle 231
 
               skewness[ind] = E_max(E_max(E_max(skewness1,skewness2),skewness3),skewness[ind]);
             }

--- a/Cassiopee/Generator/Generator/getOrthogonalityMap.cpp
+++ b/Cassiopee/Generator/Generator/getOrthogonalityMap.cpp
@@ -155,7 +155,7 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
           ind1 = j*ni+inext;
           ind2 = j*ni+i;
           ind3 = jnext*ni+i;
-          skewness[ind] = K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
+          skewness[ind] = K_COMPGEOM::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
         }
       }
       else // dim == 3
@@ -173,13 +173,13 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
           ind1 = k*ni*nj+j*ni+inext;
           ind2 = k*ni*nj+j*ni+i;
           ind3 = k*ni*nj+jnext*ni+i;
-          skewness1 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
+          skewness1 = K_COMPGEOM::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
           // (i,k) angle
           ind3 = knext*ni*nj+j*ni+i;
-          skewness2 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
+          skewness2 = K_COMPGEOM::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
           // (j,k) angle
           ind1 = k*ni*nj+jnext*ni+i;
-          skewness3 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
+          skewness3 = K_COMPGEOM::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
           // max skewness
           skewness[ind] = E_max(E_max(skewness1,skewness2),skewness3);
         }
@@ -259,10 +259,10 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
               ind3 = cm(i,facets[f][2])-1;
               ind4 = cm(i,facets[f][3])-1;
 
-              skewness1 = K_GENERATOR::computeSkewness(x, y, z, ind4, ind1, ind2, 90., normalized); // angle 412
-              skewness2 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized); // angle 123
-              skewness3 = K_GENERATOR::computeSkewness(x, y, z, ind2, ind3, ind4, 90., normalized); // angle 234
-              skewness4 = K_GENERATOR::computeSkewness(x, y, z, ind3, ind4, ind1, 90., normalized); // angle 341
+              skewness1 = K_COMPGEOM::computeSkewness(x, y, z, ind4, ind1, ind2, 90., normalized); // angle 412
+              skewness2 = K_COMPGEOM::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized); // angle 123
+              skewness3 = K_COMPGEOM::computeSkewness(x, y, z, ind2, ind3, ind4, 90., normalized); // angle 234
+              skewness4 = K_COMPGEOM::computeSkewness(x, y, z, ind3, ind4, ind1, 90., normalized); // angle 341
 
               skewness[ind] = E_max(E_max(E_max(E_max(skewness1,skewness2),skewness3),skewness4),skewness[ind]);
             }
@@ -272,9 +272,9 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
               ind2 = cm(i,facets[f][1])-1;
               ind3 = cm(i,facets[f][2])-1;
 
-              skewness1 = K_GENERATOR::computeSkewness(x, y, z, ind3, ind1, ind2, 60., normalized); // angle 312
-              skewness2 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 60., normalized); // angle 123
-              skewness3 = K_GENERATOR::computeSkewness(x, y, z, ind2, ind3, ind1, 60., normalized); // angle 231
+              skewness1 = K_COMPGEOM::computeSkewness(x, y, z, ind3, ind1, ind2, 60., normalized); // angle 312
+              skewness2 = K_COMPGEOM::computeSkewness(x, y, z, ind1, ind2, ind3, 60., normalized); // angle 123
+              skewness3 = K_COMPGEOM::computeSkewness(x, y, z, ind2, ind3, ind1, 60., normalized); // angle 231
 
               skewness[ind] = E_max(E_max(E_max(skewness1,skewness2),skewness3),skewness[ind]);
             }

--- a/Cassiopee/Generator/Generator/getOrthogonalityMap.cpp
+++ b/Cassiopee/Generator/Generator/getOrthogonalityMap.cpp
@@ -26,50 +26,6 @@ using namespace K_CONST;
 using namespace K_FLD;
 using namespace K_FUNC;
 
-inline E_Float computeAngle(
-  const E_Float* x, const E_Float* y, const E_Float* z,
-  E_Int ind1, E_Int ind2, E_Int ind3
-)
-{
-  E_Float x1 = x[ind1], x2 = x[ind2], x3 = x[ind3];
-  E_Float y1 = y[ind1], y2 = y[ind2], y3 = y[ind3];
-  E_Float z1 = z[ind1], z2 = z[ind2], z3 = z[ind3];
-
-  E_Float a2 = (x2-x1)*(x2-x1)+(y2-y1)*(y2-y1)+(z2-z1)*(z2-z1);
-  E_Float b2 = (x3-x1)*(x3-x1)+(y3-y1)*(y3-y1)+(z3-z1)*(z3-z1);
-  E_Float c2 = (x3-x2)*(x3-x2)+(y3-y2)*(y3-y2)+(z3-z2)*(z3-z2);
-
-  if (a2 < E_GEOM_CUTOFF || b2 < E_GEOM_CUTOFF) // security check
-  { 
-    return 0.;
-  }
-
-  E_Float a = sqrt(a2);
-  E_Float b = sqrt(b2);
-  E_Float cosalpha = E_max(E_min((a2+b2-c2)/(2.*a*b),1.),-1.); // law of cosines
-
-  return acos(cosalpha);
-}
-
-inline E_Float computeSkewness(
-  const E_Float* x, const E_Float* y, const E_Float* z,
-  E_Int ind1, E_Int ind2, E_Int ind3,
-  E_Float refAngle, E_Int normalized
-)
-{
-  E_Float degconst = 180.0 / K_CONST::E_PI;
-  E_Float alpha = computeAngle(x, y, z, ind1, ind2, ind3)*degconst;
-  
-  E_Float skewness = E_abs(alpha - refAngle);
-  if (normalized) // skewness in [0,1] range
-  {  
-    if (alpha > refAngle) skewness = skewness/(180.-refAngle);
-    else skewness = skewness/refAngle;
-  }
-
-  return skewness;
-}
-
 // ============================================================================
 /* Return orthogonality map */
 /* angle is given in degree */
@@ -201,7 +157,7 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
           ind1 = j*ni+i;
           ind2 = j*ni+inext;
           ind3 = jnext*ni+i;
-          skewness[ind] = computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
+          skewness[ind] = K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
         }
       }
       else // dim == 3
@@ -221,13 +177,13 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
           ind2 = k*ni*nj+j*ni+inext;
           ind3 = k*ni*nj+jnext*ni+i;
           // ... angle correspondant aux indices (ij)
-          skewness1 = computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
+          skewness1 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
           // ... angle correspondant aux indices (ik)
           ind3 = knext*ni*nj+j*ni+i;
-          skewness2 = computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
+          skewness2 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
           // ... angle correspondant aux indices (jk)
           ind2 = k*ni*nj+jnext*ni+i;
-          skewness3 = computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
+          skewness3 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind2, ind3, 90., normalized);
           // max skewness
           skewness[ind] = E_max(E_max(skewness1,skewness2),skewness3);
         }
@@ -307,10 +263,10 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
               ind3 = cm(i,facets[f][2])-1;
               ind4 = cm(i,facets[f][3])-1;
 
-              skewness1 = computeSkewness(x, y, z, ind1, ind4, ind2, 90., normalized); // angle 412
-              skewness2 = computeSkewness(x, y, z, ind2, ind1, ind3, 90., normalized); // angle 123
-              skewness3 = computeSkewness(x, y, z, ind3, ind2, ind4, 90., normalized); // angle 234
-              skewness4 = computeSkewness(x, y, z, ind4, ind3, ind1, 90., normalized); // angle 341
+              skewness1 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind4, ind2, 90., normalized); // angle 412
+              skewness2 = K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 90., normalized); // angle 123
+              skewness3 = K_GENERATOR::computeSkewness(x, y, z, ind3, ind2, ind4, 90., normalized); // angle 234
+              skewness4 = K_GENERATOR::computeSkewness(x, y, z, ind4, ind3, ind1, 90., normalized); // angle 341
 
               skewness[ind] = E_max(E_max(E_max(E_max(skewness1,skewness2),skewness3),skewness4),skewness[ind]);
             }
@@ -320,9 +276,9 @@ PyObject* K_GENERATOR::getOrthogonalityMap(PyObject* self, PyObject* args)
               ind2 = cm(i,facets[f][1])-1;
               ind3 = cm(i,facets[f][2])-1;
 
-              skewness1 = computeSkewness(x, y, z, ind1, ind3, ind2, 60., normalized); // angle 312
-              skewness2 = computeSkewness(x, y, z, ind2, ind1, ind3, 60., normalized); // angle 123
-              skewness3 = computeSkewness(x, y, z, ind3, ind2, ind1, 60., normalized); // angle 231
+              skewness1 = K_GENERATOR::computeSkewness(x, y, z, ind1, ind3, ind2, 60., normalized); // angle 312
+              skewness2 = K_GENERATOR::computeSkewness(x, y, z, ind2, ind1, ind3, 60., normalized); // angle 123
+              skewness3 = K_GENERATOR::computeSkewness(x, y, z, ind3, ind2, ind1, 60., normalized); // angle 231
 
               skewness[ind] = E_max(E_max(E_max(skewness1,skewness2),skewness3),skewness[ind]);
             }

--- a/Cassiopee/Generator/test/getAngleRegularityMapPT_t1.py
+++ b/Cassiopee/Generator/test/getAngleRegularityMapPT_t1.py
@@ -9,6 +9,8 @@ a = T.deformPoint(a, (0,0,0), (0.1,0.1,1.), 0.5, 0.4)
 a = T.deformPoint(a, (5,0,0), (0.,1.,0.), 0.5, 0.5)
 t = G.getAngleRegularityMap(a)
 test.testT(t, 1)
+t = G.getAngleRegularityMap(t, normalized=True)
+test.testT(t, 11)
 
 # Test 2D structure
 a = G.cart((0,0,0), (1,1,1), (10,10,1))
@@ -16,6 +18,8 @@ a = T.deformPoint(a, (0,0,0), (0.1,0.1,1.), 0.5, 0.4)
 a = T.deformPoint(a, (5,5,0), (1.,1.,0.), 0.5, 0.5)
 t = G.getAngleRegularityMap(a)
 test.testT(t, 2)
+t = G.getAngleRegularityMap(t, normalized=True)
+test.testT(t, 21)
 
 # Test 3D structure
 a = G.cart((0,0,0), (1,1,1), (10,10,10))
@@ -23,3 +27,5 @@ a = T.deformPoint(a, (0,0,0), (0.1,0.1,1.), 0.5, 0.4)
 a = T.deformPoint(a, (5,5,9), (1.,1.,1.), 0.5, 0.5)
 t = G.getAngleRegularityMap(a)
 test.testT(t, 3)
+t = G.getAngleRegularityMap(t, normalized=True)
+test.testT(t, 31)

--- a/Cassiopee/Generator/test/getAngleRegularityMapPT_t3.py
+++ b/Cassiopee/Generator/test/getAngleRegularityMapPT_t3.py
@@ -1,0 +1,87 @@
+# - getAngleRegularityMap (pyTree) -
+import Generator.PyTree as G
+import Converter.PyTree as C
+import Geom.PyTree as D
+import KCore.test as test
+import Transform.PyTree as T
+
+pos = 1
+
+# --- BE ---
+# 1D unstructured bar
+a = D.line((0,0,0), (1,0,0), 11)
+a = C.convertArray2Tetra(a)
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getAngleRegularityMap(a)
+test.testT(t, 1)
+
+# 2D unstructured tri
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,1), (10,10,1))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getAngleRegularityMap(a)
+test.testT(t, 2)
+
+# 2D unstructured quad
+a = G.cartHexa((0.,0.,0.), (0.1,0.1,1), (10,10,1))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getAngleRegularityMap(a)
+test.testT(t, 3)
+
+# 3D unstructured hexa
+a = G.cartHexa((0.,0.,0.), (0.1,0.1,0.1), (10,10,10))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getAngleRegularityMap(a)
+test.testT(t, 4)
+
+# 3D unstructured tetra
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,0.1), (10,10,10))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getAngleRegularityMap(a)
+test.testT(t, 5)
+
+# 3D unstructured pyra
+a = G.cartPyra((0.,0.,0.), (0.1,0.1,0.1), (10,10,10))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getAngleRegularityMap(a)
+test.testT(t, 6)
+
+# 3D unstructured penta
+a = G.cartPenta((0.,0.,0.), (0.1,0.1,0.1), (10,10,10))
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getAngleRegularityMap(a)
+test.testT(t, 7)
+
+# --- ME ---
+# 1D unstructured ME
+a = G.cartHexa((0.,0.,0.), (0.1,0.0,0.0), (5,1,1))
+b = G.cartHexa((0.4,0.,0.), (0.0,0.1,0.0), (1,11,1))
+c = G.cartHexa((0.4,1.,0.), (0.1,0.0,0.), (4,1,1))
+d = G.cartHexa((0.7,1.,0.), (0.1,0.1,0.05), (1,1,12))
+a = C.mergeConnectivity([a, b, c, d], None)
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getAngleRegularityMap(a)
+test.testT(t, 8)
+
+# 2D unstructured ME: tri-quad-tri
+#                          |
+#                         tri
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,0.2), (5,10,1))
+b = G.cartHexa((0.4,0.,0.), (0.1,0.1,0.2), (5,10,1))
+c = G.cartTetra((0.8,0.,0.), (0.1,0.1,0.2), (5,10,1))
+d = G.cartTetra((0.4,-0.9,0.), (0.1,0.1,0.2), (5,10,1))
+a = C.mergeConnectivity([a, b, c, d], None)
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getAngleRegularityMap(a)
+test.testT(t, 9)
+
+# 3D unstructured ME: tetra   pyra
+#                              |
+#                     penta - hexa
+a = G.cartTetra((-0.05,0.45,0.05), (0.1,0.1,0.1), (5,5,5))
+b = G.cartPyra((0.4,0.4,0.), (0.1,0.1,0.1), (5,5,5))
+c = G.cartPenta((0.,0.,0.), (0.1,0.1,0.1), (5,5,5))
+d = G.cartHexa((0.4,0.,0.), (0.1,0.1,0.1), (5,5,5))
+a = C.mergeConnectivity([a, b, c, d], None)
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getAngleRegularityMap(a)
+test.testT(t, 10)

--- a/Cassiopee/Generator/test/getAngleRegularityMapPT_t4.py
+++ b/Cassiopee/Generator/test/getAngleRegularityMapPT_t4.py
@@ -1,0 +1,61 @@
+# - getAngleRegularityMap (pyTree) -
+import Generator.PyTree as G
+import Converter.Internal as Internal
+import Converter.PyTree as C
+import Geom.PyTree as D
+import KCore.test as test
+
+import numpy
+
+# check 90-degree skew grids
+
+# 1D unstructured bar
+a = D.line((0,0,0), (1,0,0), 3)
+a = C.convertArray2Tetra(a)
+x = numpy.array([0,0,1], dtype=numpy.float64)
+y = numpy.array([1,0,0], dtype=numpy.float64)
+Internal.getNodeFromName(a, 'CoordinateX')[1] = x
+Internal.getNodeFromName(a, 'CoordinateY')[1] = y
+t = G.getAngleRegularityMap(a)
+test.testT(t, 1)
+
+# 2D unstructured tri
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,1), (2,2,1))
+x = numpy.array([0,1,-1,0], dtype=numpy.float64)
+y = numpy.array([0,-0.5,-0.5,1], dtype=numpy.float64)
+Internal.getNodeFromName(a, 'CoordinateX')[1] = x
+Internal.getNodeFromName(a, 'CoordinateY')[1] = y
+t = G.getAngleRegularityMap(a)
+test.testT(t, 2)
+
+# 2D unstructured quad
+a = G.cartHexa((0.,0.,0.), (0.1,0.1,1), (3,2,1))
+x = numpy.array([0,1,2,0,1,2], dtype=numpy.float64)
+y = numpy.array([-1,0,-1,0,1,0], dtype=numpy.float64)
+Internal.getNodeFromName(a, 'CoordinateX')[1] = x
+Internal.getNodeFromName(a, 'CoordinateY')[1] = y
+a = C.initVars(a,'Density',1.); a = C.initVars(a,'centers:cellN',1.)
+t = G.getAngleRegularityMap(a)
+test.testT(t, 3)
+
+# 3D unstructured hexa
+a = G.cartHexa((0.,0.,0.), (0.1,0.1,0.1), (3,2,2))
+x = numpy.array([0,1,2,0,1,2,0,1,2,0,1,2], dtype=numpy.float64)
+y = numpy.array([0-1,0,0-1,1-1,1,1-1,0-1,0,0-1,1-1,1,1-1], dtype=numpy.float64)
+z = numpy.array([0,0,0,0,0,0,1,1,1,1,1,1], dtype=numpy.float64)
+Internal.getNodeFromName(a, 'CoordinateX')[1] = x
+Internal.getNodeFromName(a, 'CoordinateY')[1] = y
+Internal.getNodeFromName(a, 'CoordinateZ')[1] = z
+t = G.getAngleRegularityMap(a)
+test.testT(t, 4)
+
+# 3D unstructured penta
+a = G.cartPenta((0.,0.,0.), (0.1,0.1,0.1), (2,2,2))
+x = numpy.array([0,1,-1,0,0,1,-1,0], dtype=numpy.float64)
+y = numpy.array([0,-0.5,-0.5,1,0,-0.5,-0.5,1], dtype=numpy.float64)
+z = numpy.array([0,0,0,0,1,1,1,1], dtype=numpy.float64)
+Internal.getNodeFromName(a, 'CoordinateX')[1] = x
+Internal.getNodeFromName(a, 'CoordinateY')[1] = y
+Internal.getNodeFromName(a, 'CoordinateZ')[1] = z
+t = G.getAngleRegularityMap(a)
+test.testT(t, 5)

--- a/Cassiopee/KCore/KCore/CompGeom/compGeom.cpp
+++ b/Cassiopee/KCore/KCore/CompGeom/compGeom.cpp
@@ -205,7 +205,7 @@ void K_COMPGEOM::rectifyNormals(const E_Int ni1, const E_Int nj1, const E_Int in
 }
 
 // ============================================================================
-// Compute the minimum squared distance between 2 blocks and return
+// Computes the minimum squared distance between 2 blocks and return
 // the corresponding cell indices
 // ============================================================================
 void K_COMPGEOM::compMeanDist(const E_Int ni1, const E_Int nj1,
@@ -359,6 +359,73 @@ void K_COMPGEOM::compMeanDist(const E_Int ni1, const E_Int nj1,
   }
   
   return;
+}
+
+// ============================================================================
+// Computes an angle formed by three points (P1,P2,P3)
+// Returns a float between 0 and pi
+// Returns 0 if two points are superimposed
+// ============================================================================
+E_Float K_COMPGEOM::computeAngle(
+  E_Float x1, E_Float y1, E_Float z1,
+  E_Float x2, E_Float y2, E_Float z2,
+  E_Float x3, E_Float y3, E_Float z3
+)
+{
+  E_Float a2 = (x2-x1)*(x2-x1)+(y2-y1)*(y2-y1)+(z2-z1)*(z2-z1);
+  E_Float b2 = (x3-x2)*(x3-x2)+(y3-y2)*(y3-y2)+(z3-z2)*(z3-z2);
+  E_Float c2 = (x3-x1)*(x3-x1)+(y3-y1)*(y3-y1)+(z3-z1)*(z3-z1);
+
+  if (a2 < K_CONST::E_GEOM_CUTOFF || b2 < K_CONST::E_GEOM_CUTOFF) // security check
+  { 
+    return 0.;
+  }
+
+  E_Float a = sqrt(a2);
+  E_Float b = sqrt(b2);
+  E_Float cosalpha = K_FUNC::E_max(K_FUNC::E_min((a2+b2-c2)/(2.*a*b),1.),-1.); // law of cosines
+
+  return acos(cosalpha);
+}
+
+// ============================================================================
+// Computes a skewness value from three points (P1,P2,P3) and a reference angle
+// Returns a skewness angle or a float if normalized=1
+// Returns 0 if two points are superimposed
+// ============================================================================
+E_Float K_COMPGEOM::computeSkewness(
+  E_Float x1, E_Float y1, E_Float z1,
+  E_Float x2, E_Float y2, E_Float z2,
+  E_Float x3, E_Float y3, E_Float z3,
+  E_Float refAngle, E_Int normalized
+)
+{
+  E_Float degconst = 180.0 / K_CONST::E_PI;
+  E_Float alpha = K_COMPGEOM::computeAngle(x1,y1,z1,x2,y2,z2,x3,y3,z3);
+
+  if (alpha < K_CONST::E_GEOM_CUTOFF) return 0.; // security check
+  
+  E_Float skewness = K_FUNC::E_abs(alpha*degconst - refAngle);
+  if (normalized) // skewness in [0,1] range
+  {  
+    if (alpha > refAngle) skewness = skewness/(180.-refAngle);
+    else skewness = skewness/refAngle;
+  }
+
+  return skewness;
+}
+
+E_Float K_COMPGEOM::computeSkewness(
+  const E_Float* x, const E_Float* y, const E_Float* z,
+  E_Int ind1, E_Int ind2, E_Int ind3,
+  E_Float refAngle, E_Int normalized
+)
+{
+  E_Float x1 = x[ind1], x2 = x[ind2], x3 = x[ind3];
+  E_Float y1 = y[ind1], y2 = y[ind2], y3 = y[ind3];
+  E_Float z1 = z[ind1], z2 = z[ind2], z3 = z[ind3];
+
+  return K_COMPGEOM::computeSkewness(x1,y1,z1,x2,y2,z2,x3,y3,z3,refAngle,normalized);
 }
 
 //===========================================================================

--- a/Cassiopee/KCore/KCore/CompGeom/compGeom.h
+++ b/Cassiopee/KCore/KCore/CompGeom/compGeom.h
@@ -402,13 +402,34 @@ typedef struct {
      Retourne 0. si triangle degenere */
   E_Float compTriangleArea(const E_Float a, const E_Float b, const E_Float c);
 
+  /* Computes an angle formed by three points (P1,P2,P3)
+      Returns a float between 0 and pi
+      Returns 0 if two points are superimposed */
+  E_Float computeAngle(
+    E_Float x1, E_Float y1, E_Float z1,
+    E_Float x2, E_Float y2, E_Float z2,
+    E_Float x3, E_Float y3, E_Float z3);
+  
+  /* Computes a skewness value from three points (P1,P2,P3) and a reference angle
+      Returns a skewness angle or a float if normalized=1
+      Returns 0 if two points are superimposed */
+  E_Float computeSkewness(
+    E_Float x1, E_Float y1, E_Float z1,
+    E_Float x2, E_Float y2, E_Float z2,
+    E_Float x3, E_Float y3, E_Float z3,
+    E_Float refAngle, E_Int normalized=0);
+
+  E_Float computeSkewness(
+    const E_Float* x, const E_Float* y, const E_Float* z,
+    E_Int ind1, E_Int ind2, E_Int ind3,
+    E_Float refAngle, E_Int normalized=0);
+
   /* Calcul le cercle circonscrit a un triangle du plan (x,y)
      IN: p1, p2, p3: triangles coordinates (in plane x,y)
      OUT: pc, R: center and radius of circum-center
      Retourne:
      0: OK
-     -1: Failed
-  */
+     -1: Failed */
   E_Int circumCircle(E_Float* p1, E_Float* p2, E_Float* p3,
                      E_Float* pc, E_Float& R);
 

--- a/Cassiopee/KCore/KCore/Connect/connect.h
+++ b/Cassiopee/KCore/KCore/Connect/connect.h
@@ -218,7 +218,13 @@ namespace K_CONNECT
    (commencant a 0) et nof la numero local de la face 0,1,2,...
   */
   void connectEV2VF(K_FLD::FldArrayI& cEV, const char* eltType,
-                    std::vector< std::vector<E_Int> >& cVF);
+                    std::vector<std::vector<E_Int> >& cVF);
+  /* Change a Elts-Vertex connectivity to a Face-Element connectivity.
+      IN: eltType: type d'element (TRI, QUAD,...).
+      IN: cEV: Elts-Vertex connectivity.
+      IN: keepDuplicates: whether to keep duplicates of internal faces.*/
+  E_Int connectEV2FE(const char* eltType, K_FLD::FldArrayI& cEV,
+                      K_FLD::FldArrayI& cFE, E_Bool keepDuplicates=true);
   /* Change HO EV connectivity to LO EV connectivity.
      mode=0: sub-select, mode=1: tesselate */
   E_Int connectHO2LO(const char* eltTypeHO, K_FLD::FldArrayI& cEVHO,

--- a/Cassiopee/KCore/KCore/Connect/connectEV2FE.cpp
+++ b/Cassiopee/KCore/KCore/Connect/connectEV2FE.cpp
@@ -91,7 +91,7 @@ E_Int K_CONNECT::connectEV2FE(
 
       for (E_Int i = 0; i < nelts; i++)
       {
-        eidx = cumnepc[ic] + i;  // global element index
+        eidx = cumnepc[ic] + i + 1;  // global element index, 1-based
         // Loop over each facet of this element
         for (E_Int f = 0; f < nfpe[ic]; f++)
         {

--- a/Cassiopee/KCore/KCore/Connect/connectEV2FE.cpp
+++ b/Cassiopee/KCore/KCore/Connect/connectEV2FE.cpp
@@ -1,0 +1,169 @@
+/*
+    Copyright 2013-2026 ONERA.
+
+    This file is part of Cassiopee.
+
+    Cassiopee is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cassiopee is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cassiopee.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "Connect/connect.h"
+#include <unordered_map>
+
+//=============================================================================
+// Change a Elts-Vertex connectivity to a Face-Element connectivity.
+// IN: eltType: type d'element (TRI, QUAD,...).
+// IN: cEV: Elts-Vertex connectivity. For each elt, give vertices index.
+// IN: keepDuplicates: whether to keep duplicates of internal faces.
+// OUT: cFE: Face-Element connectivity. For a face, give the neighbour elements.
+//      If a face has 1 neighbour element only, the second index value is 0.
+// cFE does not need to be preallocated to the total number of faces or number
+// of unique faces.
+// Return 0 (success), 1 (fail)
+// ! Marche pour les maillages non structures BE et ME
+// ! Marche uniquement pour les maillage conformes
+//=============================================================================
+E_Int K_CONNECT::connectEV2FE(
+  const char* eltType, FldArrayI& cEV, FldArrayI& cFE, E_Bool keepDuplicates
+)
+{
+  const E_Int UNSET = 0;
+  
+  E_Int nc = cEV.getNConnect();
+  std::vector<char*> eltTypes;
+  K_ARRAY::extractVars(eltType, eltTypes);
+
+  // Compute number of faces per element, nfpe
+  std::vector<E_Int> nfpe;
+  E_Int ierr = K_CONNECT::getNFPE(nfpe, eltType, true);
+  if (ierr != 0) return 1;
+
+  // Compute cumulative number of elements and faces per connectivity
+  std::vector<E_Int> cumnepc(nc+1); cumnepc[0] = 0;
+  std::vector<E_Int> cumnfpc(nc+1); cumnfpc[0] = 0;
+
+  for (E_Int ic = 0; ic < nc; ic++)
+  {
+    K_FLD::FldArrayI& cm = *(cEV.getConnect(ic));
+    E_Int nelts = cm.getSize();
+    E_Int nfaces = nelts*nfpe[ic];
+    cumnepc[ic+1] = cumnepc[ic] + nelts;
+    cumnfpc[ic+1] = cumnfpc[ic] + nfaces;
+  }
+  E_Int ntotFaces = cumnfpc[nc];
+
+  // Hash all faces
+  E_Int nvpf, fidx, eidx;
+  E_Int face[5];
+  TopologyOpt F;
+  struct FaceAttrs
+  {
+    E_Int fidx;  // global face index
+    E_Int left;  // left element
+    E_Int right;  // right element (-1 if not set yet)
+  };
+  std::unordered_map<TopologyOpt, FaceAttrs, BernsteinHash<TopologyOpt> > faceMap;
+  faceMap.reserve(ntotFaces);
+
+  if (keepDuplicates)
+  {
+    // Pre-allocate the Face-Element connectivity
+    cFE.malloc(ntotFaces, 2);
+    E_Int* facesp1 = cFE.begin(1);
+    E_Int* facesp2 = cFE.begin(2);
+
+    // Loop over all connectivities
+    for (E_Int ic = 0; ic < nc; ic++)
+    {
+      K_FLD::FldArrayI& cm = *(cEV.getConnect(ic));
+      E_Int nelts = cm.getSize();
+      std::vector<std::vector<E_Int> > facets;
+      K_CONNECT::getEVFacets(facets, eltTypes[ic], false, true);
+
+      for (E_Int i = 0; i < nelts; i++)
+      {
+        eidx = cumnepc[ic] + i;  // global element index
+        // Loop over each facet of this element
+        for (E_Int f = 0; f < nfpe[ic]; f++)
+        {
+          fidx = cumnfpc[ic] + i*nfpe[ic] + f;  // global face index
+          nvpf = facets[f].size();  // number of vertices per facet
+          // Fill face and insert in map
+          for (E_Int j = 0; j < nvpf; j++) face[j] = cm(i, facets[f][j]);
+          F.set(face, nvpf);
+          auto resf = faceMap.emplace(F, FaceAttrs{fidx, eidx, UNSET});
+          if (resf.second)  // first time this face is visited
+          {
+            facesp1[fidx] = eidx;
+            facesp2[fidx] = UNSET;
+          }
+          else  // this face has already been visited
+          {
+            const FaceAttrs& attrs = resf.first->second;
+            facesp2[attrs.fidx] = eidx;  // amend right element of the orignal face
+            // register the duplicated face with swapped left and right elements
+            facesp1[fidx] = eidx;
+            facesp2[fidx] = attrs.left;
+          }
+        }
+      }
+    }
+  }
+  else
+  {
+    // Loop over all connectivities
+    for (E_Int ic = 0; ic < nc; ic++)
+    {
+      K_FLD::FldArrayI& cm = *(cEV.getConnect(ic));
+      E_Int nelts = cm.getSize();
+      std::vector<std::vector<E_Int> > facets;
+      K_CONNECT::getEVFacets(facets, eltTypes[ic], false, true);
+
+      for (E_Int i = 0; i < nelts; i++)
+      {
+        eidx = cumnepc[ic] + i;  // global element index
+        // Loop over each facet of this element
+        for (E_Int f = 0; f < nfpe[ic]; f++)
+        {
+          fidx = cumnfpc[ic] + i*nfpe[ic] + f;  // global face index
+          nvpf = facets[f].size();  // number of vertices per facet
+          // Fill face and insert in map
+          for (E_Int j = 0; j < nvpf; j++) face[j] = cm(i, facets[f][j]);
+          F.set(face, nvpf);
+          auto resf = faceMap.emplace(F, FaceAttrs{fidx, eidx, UNSET});
+          if (!resf.second)  // this face has already been visited
+          {
+            FaceAttrs& attrs = resf.first->second;
+            attrs.right = eidx;
+          }
+        }
+      }
+    }
+    E_Int nuniqueFaces = faceMap.size();
+
+    // Fill the Face-Element connectivity
+    cFE.malloc(nuniqueFaces, 2);
+    E_Int* facesp1 = cFE.begin(1);
+    E_Int* facesp2 = cFE.begin(2);
+
+    for (const auto& facet : faceMap)
+    {
+      const FaceAttrs& attrs = facet.second;
+      fidx = attrs.fidx;
+      facesp1[fidx] = attrs.left;
+      facesp2[fidx] = attrs.right;
+    }
+  }
+
+  for (size_t ic = 0; ic < eltTypes.size(); ic++) delete [] eltTypes[ic];
+  return 0;
+}

--- a/Cassiopee/KCore/KCore/Metric/compUnstrCellCenter.cpp
+++ b/Cassiopee/KCore/KCore/Metric/compUnstrCellCenter.cpp
@@ -56,6 +56,9 @@ void K_METRIC::compUnstructCellCenter(
       for (E_Int i = 0; i < nelts; i++)
       {
         pos = nepc[ic] + i;
+        xb[pos] = 0.;
+        yb[pos] = 0.;
+        zb[pos] = 0.;
         for (E_Int j = 1; j <= nvpe; j++)
         {
           ind = cm(i, j) - 1;

--- a/Cassiopee/KCore/KCore/Metric/compUnstrCenterInt.cpp
+++ b/Cassiopee/KCore/KCore/Metric/compUnstrCenterInt.cpp
@@ -29,7 +29,8 @@
 void K_METRIC::compUnstructCenterInt(
   K_FLD::FldArrayI& cn, const char* eltType,
   const E_Float* xt, const E_Float* yt, const E_Float* zt,
-  E_Float* xint, E_Float* yint, E_Float* zint
+  E_Float* xint, E_Float* yint, E_Float* zint,
+  E_Bool expandToLowerDim
 )
 {
   E_Int fctOffset = 0;
@@ -39,7 +40,7 @@ void K_METRIC::compUnstructCenterInt(
 
   // Number of facets per element
   std::vector<E_Int> nfpe;
-  E_Int ierr = K_CONNECT::getNFPE(nfpe, eltType, false);
+  E_Int ierr = K_CONNECT::getNFPE(nfpe, eltType, true);
   if (ierr != 0) return;
 
   for (E_Int ic = 0; ic < nc; ic++)
@@ -48,7 +49,50 @@ void K_METRIC::compUnstructCenterInt(
     E_Int nelts = cm.getSize();
     E_Int nfpc;  // number of facets per connectivity
 
-    if (strcmp(eltTypes[ic], "TRI") == 0)
+    if (strcmp(eltTypes[ic], "BAR") == 0)
+    {
+      #pragma omp parallel
+      {
+        E_Int ind1, ind2, pos;
+        E_Float x1, x2;
+        E_Float y1, y2;
+        E_Float z1, z2;
+
+        #pragma omp for
+        for (E_Int i = 0; i < nelts; i++)
+        {
+          ind1 = cm(i, 1) - 1;
+          ind2 = cm(i, 2) - 1;
+
+          x1 = xt[ind1]; x2 = xt[ind2];
+          y1 = yt[ind1]; y2 = yt[ind2];
+          z1 = zt[ind1]; z2 = zt[ind2];
+
+          if (expandToLowerDim) // two facets per elt
+          {
+            // facette 1
+            pos = fctOffset + i * nfpe[ic];
+            xint[pos] = x1;
+            yint[pos] = y1;
+            zint[pos] = z1;
+
+            // facette 2
+            pos += 1;
+            xint[pos] = x2;
+            yint[pos] = y2;
+            zint[pos] = z2;
+          }
+          else // one facet per elt
+          {
+            pos = fctOffset + i;  // fctOffset + i = fctOffset + i * nfpe[ic]
+            xint[pos] = K_CONST::ONE_HALF * (x1 + x2);
+            yint[pos] = K_CONST::ONE_HALF * (y1 + y2);
+            zint[pos] = K_CONST::ONE_HALF * (z1 + z2);
+          }
+        }
+      }
+    }
+    else if (strcmp(eltTypes[ic], "TRI") == 0)
     {
       #pragma omp parallel
       {
@@ -68,10 +112,33 @@ void K_METRIC::compUnstructCenterInt(
           y1 = yt[ind1]; y2 = yt[ind2]; y3 = yt[ind3];
           z1 = zt[ind1]; z2 = zt[ind2]; z3 = zt[ind3];
 
-          pos = fctOffset + i;  // fctOffset + i = fctOffset + i * nfpe[ic]
-          xint[pos] = K_CONST::ONE_THIRD * (x1 + x2 + x3);
-          yint[pos] = K_CONST::ONE_THIRD * (y1 + y2 + y3);
-          zint[pos] = K_CONST::ONE_THIRD * (z1 + z2 + z3);
+          if (expandToLowerDim) // three facets per elt
+          {
+            // facette 12
+            pos = fctOffset + i * nfpe[ic];
+            xint[pos] = K_CONST::ONE_HALF * (x1 + x2);
+            yint[pos] = K_CONST::ONE_HALF * (y1 + y2);
+            zint[pos] = K_CONST::ONE_HALF * (z1 + z2);
+
+            // facette 23
+            pos += 1;
+            xint[pos] = K_CONST::ONE_HALF * (x2 + x3);
+            yint[pos] = K_CONST::ONE_HALF * (y2 + y3);
+            zint[pos] = K_CONST::ONE_HALF * (z2 + z3);
+
+            // facette 31
+            pos += 1;
+            xint[pos] = K_CONST::ONE_HALF * (x3 + x1);
+            yint[pos] = K_CONST::ONE_HALF * (y3 + y1);
+            zint[pos] = K_CONST::ONE_HALF * (z3 + z1);
+          }
+          else // one facet per elt
+          {
+            pos = fctOffset + i;  // fctOffset + i = fctOffset + i * nfpe[ic]
+            xint[pos] = K_CONST::ONE_THIRD * (x1 + x2 + x3);
+            yint[pos] = K_CONST::ONE_THIRD * (y1 + y2 + y3);
+            zint[pos] = K_CONST::ONE_THIRD * (z1 + z2 + z3);
+          }
         }
       }
     }
@@ -96,10 +163,39 @@ void K_METRIC::compUnstructCenterInt(
           y1 = yt[ind1]; y2 = yt[ind2]; y3 = yt[ind3]; y4 = yt[ind4];
           z1 = zt[ind1]; z2 = zt[ind2]; z3 = zt[ind3]; z4 = zt[ind4];
 
-          pos = fctOffset + i;  // fctOffset + i = fctOffset + i * nfpe[ic]
-          xint[pos] = K_CONST::ONE_FOURTH * (x1 + x2 + x3 + x4);
-          yint[pos] = K_CONST::ONE_FOURTH * (y1 + y2 + y3 + y4);
-          zint[pos] = K_CONST::ONE_FOURTH * (z1 + z2 + z3 + z4);
+          if (expandToLowerDim) // four facets per elt
+          {
+            // facette 12
+            pos = fctOffset + i * nfpe[ic];
+            xint[pos] = K_CONST::ONE_HALF * (x1 + x2);
+            yint[pos] = K_CONST::ONE_HALF * (y1 + y2);
+            zint[pos] = K_CONST::ONE_HALF * (z1 + z2);
+
+            // facette 23
+            pos += 1;
+            xint[pos] = K_CONST::ONE_HALF * (x2 + x3);
+            yint[pos] = K_CONST::ONE_HALF * (y2 + y3);
+            zint[pos] = K_CONST::ONE_HALF * (z2 + z3);
+
+            // facette 34
+            pos += 1;
+            xint[pos] = K_CONST::ONE_HALF * (x3 + x4);
+            yint[pos] = K_CONST::ONE_HALF * (y3 + y4);
+            zint[pos] = K_CONST::ONE_HALF * (z3 + z4);
+
+            // facette 41
+            pos += 1;
+            xint[pos] = K_CONST::ONE_HALF * (x4 + x1);
+            yint[pos] = K_CONST::ONE_HALF * (y4 + y1);
+            zint[pos] = K_CONST::ONE_HALF * (z4 + z1);
+          }
+          else // one facet per elt
+          {
+            pos = fctOffset + i;  // fctOffset + i = fctOffset + i * nfpe[ic]
+            xint[pos] = K_CONST::ONE_FOURTH * (x1 + x2 + x3 + x4);
+            yint[pos] = K_CONST::ONE_FOURTH * (y1 + y2 + y3 + y4);
+            zint[pos] = K_CONST::ONE_FOURTH * (z1 + z2 + z3 + z4);
+          }
         }
       }
     }

--- a/Cassiopee/KCore/KCore/Metric/compUnstrCenterInt.cpp
+++ b/Cassiopee/KCore/KCore/Metric/compUnstrCenterInt.cpp
@@ -40,7 +40,7 @@ void K_METRIC::compUnstructCenterInt(
 
   // Number of facets per element
   std::vector<E_Int> nfpe;
-  E_Int ierr = K_CONNECT::getNFPE(nfpe, eltType, true);
+  E_Int ierr = K_CONNECT::getNFPE(nfpe, eltType, expandToLowerDim);
   if (ierr != 0) return;
 
   for (E_Int ic = 0; ic < nc; ic++)

--- a/Cassiopee/KCore/KCore/Metric/metric.h
+++ b/Cassiopee/KCore/KCore/Metric/metric.h
@@ -242,7 +242,8 @@ namespace K_METRIC
   void compUnstructCenterInt(
     K_FLD::FldArrayI& cn, const char* eltType,
     const E_Float* xt, const E_Float* yt, const E_Float* zt,
-    E_Float* xint, E_Float* yint, E_Float* zint);
+    E_Float* xint, E_Float* yint, E_Float* zint,
+    E_Bool expandToLowerDim=true);
 
   /* Calcul du volume de toutes les cellules et des surfaces des interfaces
      CAS NON STRUCTURE

--- a/Cassiopee/KCore/srcs.py
+++ b/Cassiopee/KCore/srcs.py
@@ -82,6 +82,7 @@ cpp_srcs = [
     'KCore/Connect/connectEV2EENbrs.cpp',
     'KCore/Connect/connectEV2FV.cpp',
     'KCore/Connect/connectEV2VF.cpp',
+    'KCore/Connect/connectEV2FE.cpp',
     'KCore/Connect/connectNG2FE.cpp',
     'KCore/Connect/connectNG2EV.cpp',
     'KCore/Connect/connectNG2VF.cpp',


### PR DESCRIPTION
No regression!

Updated getAngleRegularityMap (grid skewness) function with BE/ME support. 
New test-cases.
Simplified algo for structured meshes.
Add a normalized parameter, similar to the one in getOrthogonalityMap, to retrieve a float instead of an angle for the grid skewness.
Small bug fix for compUnstrCellCenter (missing array initialization).
Add expandToLowerDim boolean option in compUnstrCenterInt with similar behavior to getEVFacets. For example, QUAD elements facets can be either one facet (the quad element) or quad facets (the four edges).
New connectEV2FE connectivities from Vincent Casseau to retrieve the neighbor element(s) of each facet.
Skewness and angle inline functions have been factorized and put in generator.h.