### PR TITLE
Post/CPlot: handle empty set of exterior faces for unstr. grids

### DIFF
--- a/Cassiopee/CPlot/apps/tkBlock.py
+++ b/Cassiopee/CPlot/apps/tkBlock.py
@@ -237,7 +237,7 @@ def exteriorFaces():
     CTK.TKTREE.updateApp()
     if not fail:
         if not empty: CTK.TXT.insert('START', 'Exterior faces extracted.\n')
-        else: CTK.TXT.insert('START', 'Exterior faces: empty set (closed/watertight mesh).\n')
+        else: CTK.TXT.insert('START', 'Exterior faces: empty set.\n')
     else:
         Panels.displayErrors(errors, header='Error: exteriorFaces')
         CTK.TXT.insert('START', 'Exterior faces fails for at least one zone.\n')

--- a/Cassiopee/CPlot/apps/tkBlock.py
+++ b/Cassiopee/CPlot/apps/tkBlock.py
@@ -218,14 +218,16 @@ def exteriorFaces():
     p = Internal.getNodesFromName1(CTK.t, 'CONTOURS')
     gnob = C.getNobOfBase(p[0], CTK.t)
 
-    fail = False; errors = []
+    fail = False; empty = True; errors = []
     for nz in nzs:
         nob = CTK.Nb[nz]+1
         noz = CTK.Nz[nz]
         try:
             ext = P.exteriorFaces(CTK.t[2][nob][2][noz])
             ext = T.splitConnexity(ext)
-            for i in ext: CTK.add(CTK.t, gnob, -1, i)
+            for i in ext:
+                empty = False 
+                CTK.add(CTK.t, gnob, -1, i)
         except TypeError as e: # type d'element non reconnu
             fail = True; errors += [0,str(e)]
         except ValueError: # empty set
@@ -233,7 +235,9 @@ def exteriorFaces():
     #C._fillMissingVariables(CTK.t)
     (CTK.Nb, CTK.Nz) = CPlot.updateCPlotNumbering(CTK.t)
     CTK.TKTREE.updateApp()
-    if not fail: CTK.TXT.insert('START', 'Exterior faces done.\n')
+    if not fail: 
+        if not empty: CTK.TXT.insert('START', 'Exterior faces extracted.\n')
+        else: CTK.TXT.insert('START', 'Exterior faces: empty set (closed/watertight mesh).\n')
     else:
         Panels.displayErrors(errors, header='Error: exteriorFaces')
         CTK.TXT.insert('START', 'Exterior faces fails for at least one zone.\n')

--- a/Cassiopee/CPlot/apps/tkBlock.py
+++ b/Cassiopee/CPlot/apps/tkBlock.py
@@ -218,30 +218,17 @@ def exteriorFaces():
     p = Internal.getNodesFromName1(CTK.t, 'CONTOURS')
     gnob = C.getNobOfBase(p[0], CTK.t)
 
-    fail = False; empty = True; errors = []
     for nz in nzs:
         nob = CTK.Nb[nz]+1
         noz = CTK.Nz[nz]
-        try:
-            ext = P.exteriorFaces(CTK.t[2][nob][2][noz])
-            ext = T.splitConnexity(ext)
-            for i in ext:
-                empty = False
-                CTK.add(CTK.t, gnob, -1, i)
-        except TypeError as e: # type d'element non reconnu
-            fail = True; errors += [0,str(e)]
-        except ValueError: # empty set
-            pass
+        ext = P.exteriorFaces(CTK.t[2][nob][2][noz])
+        ext = T.splitConnexity(ext)
+        for i in ext: CTK.add(CTK.t, gnob, -1, i)
     #C._fillMissingVariables(CTK.t)
     (CTK.Nb, CTK.Nz) = CPlot.updateCPlotNumbering(CTK.t)
     CTK.TKTREE.updateApp()
-    if not fail:
-        if not empty: CTK.TXT.insert('START', 'Exterior faces extracted.\n')
-        else: CTK.TXT.insert('START', 'Exterior faces: empty set.\n')
-    else:
-        Panels.displayErrors(errors, header='Error: exteriorFaces')
-        CTK.TXT.insert('START', 'Exterior faces fails for at least one zone.\n')
-        CTK.TXT.insert('START', 'Warning: ', 'Warning')
+    if ext != []: CTK.TXT.insert('START', 'Exterior faces extracted.\n')
+    else: CTK.TXT.insert('START', 'External faces set is empty.\n')
     CPlot.render()
 
 #=========================================================================

--- a/Cassiopee/CPlot/apps/tkBlock.py
+++ b/Cassiopee/CPlot/apps/tkBlock.py
@@ -226,7 +226,7 @@ def exteriorFaces():
             ext = P.exteriorFaces(CTK.t[2][nob][2][noz])
             ext = T.splitConnexity(ext)
             for i in ext:
-                empty = False 
+                empty = False
                 CTK.add(CTK.t, gnob, -1, i)
         except TypeError as e: # type d'element non reconnu
             fail = True; errors += [0,str(e)]
@@ -235,7 +235,7 @@ def exteriorFaces():
     #C._fillMissingVariables(CTK.t)
     (CTK.Nb, CTK.Nz) = CPlot.updateCPlotNumbering(CTK.t)
     CTK.TKTREE.updateApp()
-    if not fail: 
+    if not fail:
         if not empty: CTK.TXT.insert('START', 'Exterior faces extracted.\n')
         else: CTK.TXT.insert('START', 'Exterior faces: empty set (closed/watertight mesh).\n')
     else:

--- a/Cassiopee/CPlot/apps/tkCADFix.py
+++ b/Cassiopee/CPlot/apps/tkCADFix.py
@@ -412,7 +412,7 @@ def checkWatertight(event=None):
         ext = P.exteriorFaces(f)
         ext = T.splitConnexity(ext)
         for i in ext:
-            isWatertight = False 
+            isWatertight = False
             CTK.add(CTK.t, gnob, -1, i)
     (CTK.Nb, CTK.Nz) = CPlot.updateCPlotNumbering(CTK.t)
     CTK.TKTREE.updateApp()

--- a/Cassiopee/CPlot/apps/tkCADFix.py
+++ b/Cassiopee/CPlot/apps/tkCADFix.py
@@ -407,17 +407,13 @@ def checkWatertight(event=None):
 
     VARS[6].set('Components: %d'%(len(ef)))
 
-    isWatertight = False
-    #try:
     isWatertight = True
     for f in ef:
-        try:
-            ext = P.exteriorFaces(f)
-            ext = T.splitConnexity(ext)
-            for i in ext: CTK.add(CTK.t, gnob, -1, i)
-            if len(ext) != 0: isWatertight = False; break
-        except: isWatertight = True
-
+        ext = P.exteriorFaces(f)
+        ext = T.splitConnexity(ext)
+        for i in ext:
+            isWatertight = False 
+            CTK.add(CTK.t, gnob, -1, i)
     (CTK.Nb, CTK.Nz) = CPlot.updateCPlotNumbering(CTK.t)
     CTK.TKTREE.updateApp()
     CTK.display(CTK.t)

--- a/Cassiopee/CPlot/apps/tkExtractEdges.py
+++ b/Cassiopee/CPlot/apps/tkExtractEdges.py
@@ -70,7 +70,7 @@ def exteriorFaces():
     CTK.t = C.addBase2PyTree(CTK.t, 'CONTOURS', 1)
     p = C.Internal.getNodeFromName1(CTK.t, 'CONTOURS')
 
-    fail = False; exts = []; errors = []
+    exts = []
     for nz in nzs:
         nob = CTK.Nb[nz]+1
         noz = CTK.Nz[nz]
@@ -78,30 +78,20 @@ def exteriorFaces():
         dim = Internal.getZoneDim(z)
         if dim[0] == 'Unstructured':
             z = G.close(z)
-            try:
-                ext = P.exteriorFaces(z)
-                ext = G.close(ext)
-                ext = T.splitConnexity(ext)
-                exts += ext
-            except Exception as e:
-                fail = True; errors += [0,str(e)]
+            ext = P.exteriorFaces(z)
+            ext = G.close(ext)
+            ext = T.splitConnexity(ext)
+            exts += ext
         else:
             ext = P.exteriorFacesStructured(z)
             exts += ext
-
-    if fail:
-        Panels.displayErrors(errors, header='Error: exteriorFaces')
 
     if exts == []:
         CTK.TXT.insert('START', 'External edges set is empty.\n')
     else:
         nob = C.getNobOfBase(p, CTK.t)
         for i in exts: CTK.add(CTK.t, nob, -1, i)
-        if not fail:
-            CTK.TXT.insert('START', 'External edges extracted.\n')
-        else:
-            CTK.TXT.insert('START', 'External edges fails for at least one zone.\n')
-            CTK.TXT.insert('START', 'Warning: ', 'Warning')
+        CTK.TXT.insert('START', 'External edges extracted.\n')
     (CTK.Nb, CTK.Nz) = CPlot.updateCPlotNumbering(CTK.t)
     CTK.TKTREE.updateApp()
     CPlot.render()

--- a/Cassiopee/CPlot/apps/tkFixer2.py
+++ b/Cassiopee/CPlot/apps/tkFixer2.py
@@ -365,11 +365,9 @@ def getFix(t):
     for z in zones:
         dim = Internal.getZoneDim(z)
         if dim[3] == 'TRI': zonesF.append(z)
-    try: ext = P.exteriorFaces(zonesF)
-    except: ext = []
-    if ext != []:
-        ext = T.splitManifold(ext)
-        #ext = T.splitSharpEdges(ext)
+    ext = P.exteriorFaces(zonesF)
+    ext = T.splitConnexity(ext)
+    if ext != []: ext = T.splitManifold(ext)
     return ext
 
 def displayFix(event=None):

--- a/Cassiopee/CPlot/apps/tkMMGs.py
+++ b/Cassiopee/CPlot/apps/tkMMGs.py
@@ -8,6 +8,7 @@ import CPlot.Tk as CTK
 import Generator.PyTree as G
 import Converter.Internal as Internal
 import Post.PyTree as P
+import Transform.PyTree as T
 import CPlot.iconics as iconics
 
 # local widgets list
@@ -97,10 +98,9 @@ def remesh():
             nob = CTK.Nb[nz]+1
             noz = CTK.Nz[nz]
             z = CTK.t[2][nob][2][noz]
-            try:
-                ext = P.exteriorFaces(z)
-                fixedConstraints.append(ext)
-            except: pass
+            ext = P.exteriorFaces(z)
+            ext = T.splitConnexity(ext)
+            fixedConstraints += ext
 
     # Other given constraints
     name = VARS[4].get()

--- a/Cassiopee/CPlot/apps/tkSmooth.py
+++ b/Cassiopee/CPlot/apps/tkSmooth.py
@@ -72,7 +72,7 @@ def smooth():
     strength = strength[0]
 
     # Constraints
-    fixedConstraints = []; projConstraints = []
+    fixedConstraints = []; projConstraints = []; ext = []
 
     name = VARS[1].get()
     names = name.split(';')
@@ -111,9 +111,9 @@ def smooth():
 
     # Keep external faces
     if VARS[3].get() == 1 or pbDim == 3:
-        try: ext = P.exteriorFaces(A)
-        except: ext = []
-    if VARS[3].get() == 1 and ext != []: fixedConstraints.append(ext)
+        ext = P.exteriorFaces(A)
+        ext = T.splitConnexity(ext)
+    if VARS[3].get() == 1: fixedConstraints += ext
 
     # Keep sharp edges
     if VARS[5].get() == 1:

--- a/Cassiopee/Generator/Generator/AMR.py
+++ b/Cassiopee/Generator/Generator/AMR.py
@@ -161,10 +161,8 @@ def generateListOfOffsets__(tb, snears, offsetValues=[], dim=3, opt=False, numTb
                 if Cmpi.master:
                     print('Remeshing (tb) surface mesh --> Maximum chordal deviation between final and initial mesh::%g || Maximum mesh step in final mesh::%g'%(hausd, hmax), flush=True)
                 # exteriorFaces currently crashes if the surface is closed
-                try:
-                    fixedConstraints = P.exteriorFaces(z)
-                except:
-                    fixedConstraints = []
+                fixedConstraints = P.exteriorFaces(z)
+                fixedConstraints = T.splitConnexity(fixedConstraints)
                 z = G.mmgs(z, hausd=hausd, hmax=hmax, fixedConstraints=fixedConstraints)
                 tb[2][nob][2] = Internal.getZones(z)
 
@@ -185,10 +183,8 @@ def generateListOfOffsets__(tb, snears, offsetValues=[], dim=3, opt=False, numTb
                     if Cmpi.master:
                         print('Remeshing aux. temp. (tbv2) surface mesh --> Maximum chordal deviation between final and initial mesh::%g || Maximum mesh step in final mesh::%g'%(hausd, hmax), flush=True)
                     # exteriorFaces currently crashes if the surface is closed
-                    try:
-                        fixedConstraints = P.exteriorFaces(z)
-                    except:
-                        fixedConstraints = []
+                    fixedConstraints = P.exteriorFaces(z)
+                    fixedConstraints = T.splitConnexity(fixedConstraints)
                     z = G.mmgs(z, hausd=hausd, hmax=hmax, fixedConstraints=fixedConstraints)
                     tbv2[2][nob][2] = Internal.getZones(z)
 

--- a/Cassiopee/Generator/Generator/Generator.py
+++ b/Cassiopee/Generator/Generator/Generator.py
@@ -868,11 +868,11 @@ def zip(array, tol=1e-12):
     Usage: zip(array, tol)"""
     if isinstance(array[0], list):
         extFaces = []
-        try:
-            import Post as P
-            for a in array:
-                if len(a) == 4: extFaces.append(P.exteriorFaces(a))
-        except: pass
+        import Post as P
+        for a in array:
+            if len(a) == 4:
+                ext = P.exteriorFaces(a)
+                if C.getNCells(ext) > 0: extFaces.append(ext)
         return generator.closeBorders(array, extFaces, tol)
     else:
         return generator.closeBorders([array], [], tol)[0]

--- a/Cassiopee/OCC/OCC/PyTree.py
+++ b/Cassiopee/OCC/OCC/PyTree.py
@@ -1577,9 +1577,8 @@ def isWatertight(component, leaks=[]):
     """Tell of componenent is watertight."""
     import Post.PyTree as P
     import Transform.PyTree as T
-    try:
-        leaks += P.exteriorFaces(component)
-        leaks += T.splitConnexity(leaks)
-    except: pass
-    if len(leaks) != 0: return False
+    ext = P.exteriorFaces(component)
+    ext = T.splitConnexity(ext)
+    leaks += ext
+    if leaks != []: return False
     else: return True

--- a/Cassiopee/Post/Post/selectExteriorFaces.cpp
+++ b/Cassiopee/Post/Post/selectExteriorFaces.cpp
@@ -892,7 +892,6 @@ PyObject* K_POST::selectExteriorFacesNGon3D(char* varString, FldArrayF& f,
 
   if (nptsExt == 0) // exterior face is empty -> early exit
   {
-    printf("exteriorFaces: empty set of exterior faces.\n");
     tpl = K_ARRAY::buildArray3(nfld, varString, 0, 0, 0, 
       "NGON", 0, 0,
       ngonType, center, api
@@ -1086,7 +1085,6 @@ PyObject* K_POST::selectExteriorFacesNGon2D(char* varString, FldArrayF& f,
 
   if (nptsExt == 0) // exterior face is empty -> early exit
   {
-    printf("exteriorFaces: empty set of exterior faces.\n");
     tpl = K_ARRAY::buildArray3(nfld, varString, 0, 0, 0, 
       "NGON", 0, 0,
       ngonType, center, api
@@ -1812,7 +1810,6 @@ PyObject* K_POST::selectExteriorFacesME(char* varString, FldArrayF& f,
 	  delete [] eltType2;
 	  for (size_t ic = 0; ic < eltTypes.size(); ic++) delete [] eltTypes[ic];
     
-    printf("exteriorFaces: empty set of exterior faces.\n");
     tpl = K_ARRAY::buildArray3(nfld, varString, 0, 0, "NODE", false, api); // returns empty array
     return tpl;
   }

--- a/Cassiopee/Post/Post/selectExteriorFaces.cpp
+++ b/Cassiopee/Post/Post/selectExteriorFaces.cpp
@@ -680,7 +680,7 @@ short K_POST::exteriorFacesBasic3(FldArrayF& f, FldArrayI& cn,
   E_Int* prev = new E_Int [nthreads];
   vector< vector<E_Int> > vectOfFaces(nthreads);
 
-#pragma omp parallel default(shared)
+  #pragma omp parallel default(shared)
   {
   E_Int ithread = __CURRENT_THREAD__;
   E_Int* indir = new E_Int [net];
@@ -688,7 +688,7 @@ short K_POST::exteriorFacesBasic3(FldArrayF& f, FldArrayI& cn,
 
   E_Int ne = 0;
   // nbre d'elements exterieurs + indirection
-#pragma omp for
+  #pragma omp for
   for (E_Int e = 0; e < nelts; e++)
   {
     if (cEEN[e].size() != nvoisins)
@@ -760,7 +760,7 @@ short K_POST::exteriorFacesBasic3(FldArrayF& f, FldArrayI& cn,
       sizeL += vectOfFaces[ithread].size();
     }
   }
-#pragma omp parallel default(shared)
+  #pragma omp parallel default(shared)
   {
     E_Int  ithread = __CURRENT_THREAD__;
     E_Int ne = nes[ithread];
@@ -885,18 +885,31 @@ PyObject* K_POST::selectExteriorFacesNGon3D(char* varString, FldArrayF& f,
     
   PyObject* indir = NULL;
   E_Int* indirp = NULL;
+  cFE.malloc(0);
+  // Calcul des nouvelles connectivites Elmt/Faces et Face/Noeuds
+  E_Bool center = false;
+  PyObject* tpl;
+
+  if (nptsExt == 0) // exterior face is empty -> early exit
+  {
+    printf("exteriorFaces: empty set of exterior faces.\n");
+    tpl = K_ARRAY::buildArray3(nfld, varString, 0, 0, 0, 
+      "NGON", 0, 0,
+      ngonType, center, api
+    );
+    return tpl;
+  }
+
   if (boolIndir)
   {
     indir = K_NUMPY::buildNumpyArray(nfacesExt, 1, 1, 0);
     indirp = K_NUMPY::getNumpyPtrI(indir);
   }
-  cFE.malloc(0);
   
-  // Calcul des nouvelles connectivites Elmt/Faces et Face/Noeuds
-  E_Bool center = false;
-  PyObject* tpl = K_ARRAY::buildArray3(nfld, varString, nptsExt, nfacesExt,
-                                       nedgesExt, "NGON", sizeFN2, sizeEF2,
-                                       ngonType, center, api);
+  tpl = K_ARRAY::buildArray3(nfld, varString, nptsExt, nfacesExt,
+    nedgesExt, "NGON", sizeFN2, sizeEF2,
+    ngonType, center, api
+  );
   FldArrayF* f2; FldArrayI* cn2;
   K_ARRAY::getFromArray3(tpl, f2, cn2);
   E_Int* ngon2 = cn2->getNGon();
@@ -1066,17 +1079,31 @@ PyObject* K_POST::selectExteriorFacesNGon2D(char* varString, FldArrayF& f,
 
   PyObject* indir = NULL;
   E_Int* indirp = NULL;
+  cFE.malloc(0);
+  // Calcul des nouvelles connectivites Elmt/Faces et Face/Noeuds
+  E_Bool center = false;
+  PyObject* tpl;
+
+  if (nptsExt == 0) // exterior face is empty -> early exit
+  {
+    printf("exteriorFaces: empty set of exterior faces.\n");
+    tpl = K_ARRAY::buildArray3(nfld, varString, 0, 0, 0, 
+      "NGON", 0, 0,
+      ngonType, center, api
+    );
+    return tpl;
+  }
+
   if (boolIndir)
   {
     indir = K_NUMPY::buildNumpyArray(nedgesExt, 1, 1, 0);
     indirp = K_NUMPY::getNumpyPtrI(indir);
   }
-  cFE.malloc(0);
-  // Calcul des nouvelles connectivites Elmt/Faces et Face/Noeuds
-  E_Bool center = false;
-  PyObject* tpl = K_ARRAY::buildArray3(nfld, varString, nptsExt, nedgesExt,
-                                       nptsExt, "NGON", sizeFN2, sizeEF2,
-                                       ngonType, center, api);
+
+  tpl = K_ARRAY::buildArray3(nfld, varString, nptsExt, nedgesExt,
+    nptsExt, "NGON", sizeFN2, sizeEF2,
+    ngonType, center, api
+  );
   FldArrayF* f2; FldArrayI* cn2;
   K_ARRAY::getFromArray3(tpl, f2, cn2);
   E_Int* ngon2 = cn2->getNGon();
@@ -1389,11 +1416,11 @@ short K_POST::exteriorFacesBasic2(E_Int nfaces, E_Int nvertex,
   E_Float* interfacez = interfaceCenters.begin(3);
   E_Float fvertex = 1./nvertex;
 
-#pragma omp parallel default(shared)
+  #pragma omp parallel default(shared)
   {
     E_Float xm, ym, zm;
     E_Int ind, ff;
-#pragma omp for
+    #pragma omp for
     for (E_Int et = 0; et < ne; et++)
     {
       for (E_Int j = 0; j < nfaces; j++)
@@ -1769,7 +1796,9 @@ PyObject* K_POST::selectExteriorFacesME(char* varString, FldArrayF& f,
     }
   }
 
-  if (ntotUniqueFaces == 0)  // can only happen for a closed 1D contour
+  PyObject* tpl;
+
+  if (ntotUniqueFaces == 0)  // can happen for closed 1D/2D contours
   {
 		// Free memory
 	  for (E_Int i = 0; i < nthreads; i++)
@@ -1782,7 +1811,10 @@ PyObject* K_POST::selectExteriorFacesME(char* varString, FldArrayF& f,
 	
 	  delete [] eltType2;
 	  for (size_t ic = 0; ic < eltTypes.size(); ic++) delete [] eltTypes[ic];
-		return NULL;
+    
+    printf("exteriorFaces: empty set of exterior faces.\n");
+    tpl = K_ARRAY::buildArray3(nfld, varString, 0, 0, "NODE", false, api); // returns empty array
+    return tpl;
   }
 
   if (boolIndir)
@@ -1792,8 +1824,9 @@ PyObject* K_POST::selectExteriorFacesME(char* varString, FldArrayF& f,
   }
 
   // Build new connectivity (containing a max. 2 BE conns)
-  PyObject* tpl = K_ARRAY::buildArray3(nfld, varString, npts2,
-                                       nfpc2, eltType2, false, api);
+  tpl = K_ARRAY::buildArray3(nfld, varString, npts2,
+    nfpc2, eltType2, false, api
+  );
   FldArrayF* f2; FldArrayI* cn2;
   K_ARRAY::getFromArray3(tpl, f2, cn2);
   std::vector<FldArrayI*> cms2(nc2);

--- a/Cassiopee/Post/test/exteriorFaces_t1.py
+++ b/Cassiopee/Post/test/exteriorFaces_t1.py
@@ -37,12 +37,11 @@ test.testA([b],9)
 indices = []
 b = P.exteriorFaces(a,indices)
 test.testO([b,indices],29)
+# EMPTY BAR
 a = D.circle((0,0,0),1.)
 a = C.convertArray2Tetra(a); a = G.close(a)
-indices=[]
-try:
-    b = P.exteriorFaces(a,indices)
-except: pass
+b = P.exteriorFaces(a)
+test.testA([b],39)
 
 # TRI
 a = G.cartTetra((0,0,0), (1,1,1), (20,3,1))
@@ -51,6 +50,10 @@ test.testA([b],4)
 indices = []
 b = P.exteriorFaces(a,indices)
 test.testO([b,indices],24)
+# EMPTY TRI
+a = D.sphere6( (0,0,0), 1., N=3, ntype='TRI')
+b = P.exteriorFaces(a)
+test.testA([b],34)
 
 # QUAD
 a = G.cartHexa((0,0,0), (1,1,1), (20,3,1))
@@ -59,6 +62,10 @@ test.testA([b],5)
 indices = []
 b = P.exteriorFaces(a)
 test.testO([b,indices],25)
+# EMPTY QUAD
+a = D.sphere6( (0,0,0), 1., N=3, ntype='QUAD')
+b = P.exteriorFaces(a)
+test.testA([b],35)
 
 # TETRA
 a = G.cartTetra((0,0,0), (1,1,1), (3,3,3))
@@ -83,14 +90,9 @@ test.testA([b],8)
 indices = []
 b = P.exteriorFaces(a)
 test.testO([b,indices],28)
-# EMPTY
+# EMPTY NGON
 a = D.sphere( (0,0,0), 1.)
-a = C.convertArray2Tetra(a)
+a = C.convertArray2NGon(a)
 a = G.close(a)
-try:
-    b = P.exteriorFaces(a)
-except: pass
-indices = []
-try:
-    b = P.exteriorFaces(a,indices)
-except: pass
+b = P.exteriorFaces(a)
+test.testA([b],38)


### PR DESCRIPTION
This commit introduces a new approach to handle empty sets of exterior faces.
Instead of returning a null value and raising an error, exteriorFaces now returns an empty NGON/NODE array. This eliminates the original error and aligns with the current implementation of the Python layer and the setField operation that is performed automatically.
The GUI has been modified to notify the user when the surface/contour is watertight in the event of an empty set of exterior faces.

No regression.
Updated test case (exteriorFaces_t1.py) to test empty BAR/TRI/QUAD and 2D NGON arrays.