### PR TITLE
[Connector] Added a robust extractfrontDP approach. Needed for high resolution (small snear) test cases

### DIFF
--- a/Cassiopee/Connector/Connector/AMR.py
+++ b/Cassiopee/Connector/Connector/AMR.py
@@ -159,10 +159,9 @@ def prepareAMRData(t_case, t, IBM_parameters=None, check=False, dim=3, localDir=
 
     maxDistanceFrontIP = 0.0
     turbDistanceTmp = Internal.getNodeFromName(frontIP, 'TurbulentDistance')[1]
-    print('WARNING: Rank:%d || len(turbDistanceTmp)=%d'%(Cmpi.rank, len(turbDistanceTmp)), flush=True)
     if len(turbDistanceTmp)>0: maxDistanceFrontIP = C.getMaxValue(frontIP, 'TurbulentDistance')
     maxDistanceFrontIP = Cmpi.allreduce(maxDistanceFrontIP, op=Cmpi.MAX)
-    if Cmpi.master: print('WARNING=maxDistanceFrontIP=%g'%maxDistanceFrontIP, flush=True)
+    if Cmpi.master: print('extractFrontDP Info: maxDistanceFrontIP=%g'%maxDistanceFrontIP, flush=True)
         
     Cmpi.trace(" Removing blanked cells [start]", master=True, cpu=False)
     t = P.selectCells(t, "{cellN}==1.", strict=1)
@@ -374,7 +373,7 @@ def localOffset__(tbLocal, dim, dir_sym, minSnear, distIP):
     minLen = min(minLen, lenZ)
     factorX = int(lenX/minLen); factorY = int(lenY/minLen); factorZ = 1
     factorZ = int(lenZ/minLen)
-    factorX = min(factorX, 2); factorY = min(factorY, 2); factorZ = min(factorZ, 2)
+    factorX = min(factorX, 2); factorY = min(factorY, 2); factorZ = min(factorZ, 2) # can cause some wrinkles on the surface
     
     ni_core = 61; nj_core = 61; nk_core = 61
     hi_core = (xmax_core-xmin_core)/(ni_core-1)
@@ -418,10 +417,10 @@ def extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP, localDir='
     import Geom.IBM as D_IBM
     if dim == 2 and not isFastApproach:
         isFastApproach = True
-        if Cmpi.master: print("WARNING: extractFrontDP based on the Robust approach is incomptabile with 2D test cases. Forcing Fast Approach...", flush=True)
+        if Cmpi.master: print("extractFrontDP: for 2D test cases... Robust approach == Fast approach.", flush=True)
     if isFastApproach:
         startTimeExtract = time.perf_counter()
-        if Cmpi.master: print("WARNING: extractFrontDP - using Fast approach based on the integration points. This approach may yield unsatisfactory results for small resolutions", flush=True)
+        if Cmpi.master: print("extractFrontDP - using Fast approach based on the integration points. This approach may yield unsatisfactory results for small resolutions", flush=True)
         ##Orig Approach - Based on Integration points front (frontIP_gath)
         ##                fast approach but can lead to errors in the IBM points - encountered when running CODA
         if Cmpi.master:
@@ -431,7 +430,7 @@ def extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP, localDir='
             frontIP_gath = G.close(frontIP_gath)
             frontIP_gath[0] = "frontIP_gath"
             if dim == 3 and dir_sym > 0:           
-                print("Symmetry of frontIP gathered:%d"%Cmpi.rank)
+                print("Symmetry of frontIP: Sym. Plane: %d"%dir_sym)
                 frontIP_gath = C.newPyTree(["Base", frontIP_gath])
                 frontIP_gath= Internal.getNodeFromName(frontIP_gath, 'Base')
                 minval = C.getMinValue(frontIP_gath, ['CoordinateX', 'CoordinateY','CoordinateZ'])
@@ -452,7 +451,9 @@ def extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP, localDir='
         outputTime(startTimeExtract,functionName='extractFrontDP - Fast Approach')
     else:
         startTimeExtract = time.perf_counter()
-        if Cmpi.master: print("WARNING: extractFrontDP - using Robust approach based on the offsets & dist2wall. This approach can take some time.", flush=True)
+        if Cmpi.master:
+            print("extractFrontDP - using Robust approach based on the offsets & dist2wall. This approach can take some time.", flush=True)
+            if dir_sym > 0: print("Symmetry of frontIP: Sym. Plane: %d"%dir_sym, flush=True)
         ## Robust - based on tb (input geomtery), offset, selectcells, & dist2wall approach
         ##          more expensive but proven to be more robust
 
@@ -460,7 +461,7 @@ def extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP, localDir='
         G._getVolumeMap(t)
         hminTmp = (C.getMinValue(t,"centers:vol"))**(1/dim)
         hminTmp = Cmpi.allreduce(hminTmp, op=Cmpi.MIN)
-        
+        if Cmpi.master: print('extractFrontDP Info: Smallest cell size (snear): %g'%hminTmp, flush=True)
         # Generate Offset - scaled tb
         frontIP_gathScale = localOffset__(tb2, dim=dim, dir_sym=dir_sym, minSnear=hminTmp, distIP=distIP)
         Cmpi.convertPyTree2File(frontIP_gathScale, 'check_frontIP_gathScale.cgns')
@@ -1165,7 +1166,7 @@ def _computeTurbulentDistanceForDG__(t, tb, IBM_parameters):
 def prepareAMRIBM(tb, vmins, dim, IBM_parameters, levelMax=0, toffset=None, check=False, opt=False, octreeMode=1,
                   snears=0.01, dfars=10, loadBalancing=False, OutputAMRMesh=False,
                   localDir='./', fileName=None, tbox=None, vminsTbox=None, tbv2=None, forceAlignment=False,
-                  tIn=None):
+                  tIn=None, isFastApproach=True):
     """Generate AMR IBM mesh and prepare AMR IBM data for CODA simulation. 
     Usage: prepareAMRIBM(tb, levelMax, vmins, dim, IBM_parameters, toffset, check, opt, octreeMode,
                          snears, dfars, loadBalancing, OutputAMRMesh, localDir, fileName, tbox, vminsTbox, tbv2, forceAlignment)"""
@@ -1202,7 +1203,8 @@ def prepareAMRIBM(tb, vmins, dim, IBM_parameters, levelMax=0, toffset=None, chec
     ## ==================
     ## ==== IBM Prep ====
     ## ==================
-    t_AMR = prepareAMRData(tb, t_AMR, IBM_parameters=IBM_parameters, dim=dim, check=check, localDir=localDir, forceAlignment=forceAlignment)
+    t_AMR = prepareAMRData(tb, t_AMR, IBM_parameters=IBM_parameters, dim=dim, check=check, localDir=localDir,
+                           forceAlignment=forceAlignment, isFastApproach=isFastApproach)
     ## Ncells output
     Ncells = C.getNCells(t_AMR)
     Ncells = Cmpi.allreduce(Ncells, op=Cmpi.SUM)

--- a/Cassiopee/Connector/Connector/AMR.py
+++ b/Cassiopee/Connector/Connector/AMR.py
@@ -420,6 +420,7 @@ def extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP, localDir='
         isFastApproach = True
         if Cmpi.master: print("WARNING: extractFrontDP based on the Robust approach is incomptabile with 2D test cases. Forcing Fast Approach...", flush=True)
     if isFastApproach:
+        startTimeExtract = time.perf_counter()
         if Cmpi.master: print("WARNING: extractFrontDP - using Fast approach based on the integration points. This approach may yield unsatisfactory results for small resolutions", flush=True)
         ##Orig Approach - Based on Integration points front (frontIP_gath)
         ##                fast approach but can lead to errors in the IBM points - encountered when running CODA
@@ -429,9 +430,9 @@ def extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP, localDir='
             frontIP_gath = C.convertArray2Tetra(frontIP_gath)
             frontIP_gath = G.close(frontIP_gath)
             frontIP_gath[0] = "frontIP_gath"
-            frontIP_gath = C.newPyTree(["Base", frontIP_gath])     
             if dim == 3 and dir_sym > 0:           
                 print("Symmetry of frontIP gathered:%d"%Cmpi.rank)
+                frontIP_gath = C.newPyTree(["Base", frontIP_gath])
                 frontIP_gath= Internal.getNodeFromName(frontIP_gath, 'Base')
                 minval = C.getMinValue(frontIP_gath, ['CoordinateX', 'CoordinateY','CoordinateZ'])
                 minval = minval[dir_sym-1]
@@ -448,7 +449,9 @@ def extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP, localDir='
         del frontIP_gath
         frontDP = P.frontFaces(t, 'cellNFront')
         del t
+        outputTime(startTimeExtract,functionName='extractFrontDP - Fast Approach')
     else:
+        startTimeExtract = time.perf_counter()
         if Cmpi.master: print("WARNING: extractFrontDP - using Robust approach based on the offsets & dist2wall. This approach can take some time.", flush=True)
         ## Robust - based on tb (input geomtery), offset, selectcells, & dist2wall approach
         ##          more expensive but proven to be more robust
@@ -494,7 +497,7 @@ def extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP, localDir='
             Internal.newDataArray('CoordinateX', value=numpy.empty(0), parent=gc)
             Internal.newDataArray('CoordinateY', value=numpy.empty(0), parent=gc)
             Internal.newDataArray('CoordinateZ', value=numpy.empty(0), parent=gc)
-
+        outputTime(startTimeExtract,functionName='extractFrontDP - Robust Approach')
     ## Continue - same as orig.
     frontDP_gath = Cmpi.allgatherZones(frontDP)
     C._deleteEmptyZones(frontDP_gath)

--- a/Cassiopee/Connector/Connector/AMR.py
+++ b/Cassiopee/Connector/Connector/AMR.py
@@ -162,7 +162,7 @@ def prepareAMRData(t_case, t, IBM_parameters=None, check=False, dim=3, localDir=
     if len(turbDistanceTmp)>0: maxDistanceFrontIP = C.getMaxValue(frontIP, 'TurbulentDistance')
     maxDistanceFrontIP = Cmpi.allreduce(maxDistanceFrontIP, op=Cmpi.MAX)
     if Cmpi.master: print('extractFrontDP Info: maxDistanceFrontIP=%g'%maxDistanceFrontIP, flush=True)
-        
+
     Cmpi.trace(" Removing blanked cells [start]", master=True, cpu=False)
     t = P.selectCells(t, "{cellN}==1.", strict=1)
     Internal._rmNodesFromName(t,"FlowSolution")
@@ -313,7 +313,7 @@ def computationDistancesNormals(t, tb, dim=3):
 def localOffset__(tbLocal, dim, dir_sym, minSnear, distIP):
     # A lot of redundancies with Generator/AMR.py - TODO: can some parts be generalized
     import Geom.IBM as D_IBM
-    
+
     distOffset = distIP + 7*minSnear # 5 (real) & 2 for security
 
     # [Connector/AMR.py specific]
@@ -348,7 +348,7 @@ def localOffset__(tbLocal, dim, dir_sym, minSnear, distIP):
                 fixedConstraints = []
             z = G.mmgs(z, hausd=hausd, hmax=hmax, fixedConstraints=fixedConstraints)
             tbSym[2][nob][2] = Internal.getZones(z)
-    
+
     # Background mesh for offset - only around orig. tb & not its symmetry one
     BB = G.bbox(tbLocal)
     ni = 150; nj = 150; nk = 150
@@ -368,13 +368,13 @@ def localOffset__(tbLocal, dim, dir_sym, minSnear, distIP):
     xmax = BB[3]+2*delta2; ymax = BB[4]+2*delta2; zmax = BB[5]+2*delta2
 
     ## Get factor of lengths - cartRX core is rectilinear [Connector/AMR.py specific]
-    lenX = xmax_core-xmin_core; lenY = ymax_core-ymin_core; lenZ = zmax_core-zmin_core   
+    lenX = xmax_core-xmin_core; lenY = ymax_core-ymin_core; lenZ = zmax_core-zmin_core
     minLen = min(lenX, lenY)
     minLen = min(minLen, lenZ)
     factorX = int(lenX/minLen); factorY = int(lenY/minLen); factorZ = 1
     factorZ = int(lenZ/minLen)
     factorX = min(factorX, 2); factorY = min(factorY, 2); factorZ = min(factorZ, 2) # can cause some wrinkles on the surface
-    
+
     ni_core = 61; nj_core = 61; nk_core = 61
     hi_core = (xmax_core-xmin_core)/(ni_core-1)
     hj_core = (ymax_core-ymin_core)/(nj_core-1)
@@ -429,7 +429,7 @@ def extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP, localDir='
             frontIP_gath = C.convertArray2Tetra(frontIP_gath)
             frontIP_gath = G.close(frontIP_gath)
             frontIP_gath[0] = "frontIP_gath"
-            if dim == 3 and dir_sym > 0:           
+            if dim == 3 and dir_sym > 0:
                 print("Symmetry of frontIP: Sym. Plane: %d"%dir_sym)
                 frontIP_gath = C.newPyTree(["Base", frontIP_gath])
                 frontIP_gath= Internal.getNodeFromName(frontIP_gath, 'Base')
@@ -475,11 +475,11 @@ def extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP, localDir='
         BM = numpy.ones((nbases,nbodies),dtype=Internal.E_NpyInt)
         t = X.blankCells(t, bodiesTmp, BM, blankingType='node_in', XRaydim1=XRAYDIM1, XRaydim2=XRAYDIM1,
                          dim=dim, cellNName='cellNTmp')
-        
+
         # select cells - small region to do dist2wall
         tTmp = P.selectCells(t, "{cellNTmp}<1", strict=0)
         C._rmVars(t,['cellNTmp','vol'])
-        
+
         # dist2wall on region of select cells
         if len(Internal.getZones(tTmp))>0:
             DTW._distance2Walls(tTmp, frontIP_gath, type='ortho', signed=0, dim=dim, loc='nodes')

--- a/Cassiopee/Connector/Connector/AMR.py
+++ b/Cassiopee/Connector/Connector/AMR.py
@@ -148,6 +148,10 @@ def prepareAMRData(t_case, t, IBM_parameters=None, check=False, dim=3, localDir=
     frontIP = computeCellNForIBMFronts(t, dim, IBM_parameters, VPM=VPM)
     Cmpi.trace("Extract front faces of IBM target points [end]   ", master=True, cpu=False)
 
+    maxDistanceFrontIP = C.getMaxValue(frontIP, 'TurbulentDistance')
+    maxDistanceFrontIP = Cmpi.allreduce(maxDistanceFrontIP, op=Cmpi.MAX)
+    if Cmpi.master: print('WARNING=maxDistanceFrontIP=%g'%maxDistanceFrontIP, flush=True)
+        
     Cmpi.trace(" Removing blanked cells [start]", master=True, cpu=False)
     t = P.selectCells(t, "{cellN}==1.", strict=1)
     Internal._rmNodesFromName(t,"FlowSolution")
@@ -173,6 +177,12 @@ def prepareAMRData(t_case, t, IBM_parameters=None, check=False, dim=3, localDir=
         C.convertPyTree2File(frontIP_gath, localDir+"frontIP_gath.plt")
         C.convertPyTree2File(frontIP_gath, localDir+"frontIP_gath.cgns")
 
+    ### for debugging - keep here for now
+    #frontDP_gath = extractFrontDP(t, tb2, frontIP_gath, dim, sym3D, check, distIP=maxDistanceFrontIP, localDir=localDir, isNewApproach=True)
+    #frontDP_gath = extractFrontDP(t, tb2, frontIP_gath, dim, sym3D, check, distIP=maxDistanceFrontIP, localDir=localDir, isNewApproach=False)
+    #Cmpi.barrier()
+    #Cmpi.abort()
+
     Cmpi.trace(" Recovering Boundary Conditions [start]", master=True, cpu=False)
     f_pytree = P.exteriorFaces(t)
     for elt_t in Internal.getNodesFromType(f_pytree, "Elements_t"):
@@ -180,6 +190,7 @@ def prepareAMRData(t_case, t, IBM_parameters=None, check=False, dim=3, localDir=
             Internal._rmNode(f_pytree, elt_t)
     _recoverBoundaryConditions__(t, f_pytree, zbcs, bctypes, bcnames)
     Cmpi.trace(" Recovering Boundary Conditions [end]  ", master=True, cpu=False)
+    Cmpi.convertPyTree2File(t,'check_t_afterBC.cgns')
 
     Cmpi.trace(" Cleaning frontIP (IBMWall) per processor [start]", master=True, cpu=False)
     if Cmpi.master: print("Performing the 'identifyElements' function (it can be long.)", flush=True)
@@ -208,7 +219,7 @@ def prepareAMRData(t_case, t, IBM_parameters=None, check=False, dim=3, localDir=
     if VPM == False:
         Cmpi.trace(" Extracting front of the donor points [start]", master=True, cpu=False)
         if frontTypeDP == "1":
-            frontDP_gath = extractFrontDP(t, frontIP_gath, dim, sym3D, check, localDir=localDir)
+            frontDP_gath = extractFrontDP(t, tb2, frontIP_gath, dim, sym3D, check, distIP=maxDistanceFrontIP, localDir=localDir, isNewApproach=True)
         else:
             frontDP_gath = None
         del frontIP_gath
@@ -288,14 +299,123 @@ def computationDistancesNormals(t, tb, dim=3):
     if not OPT: t = C.center2Node(t, 'centers:TurbulentDistance')
     return t
 
-def extractFrontDP(t, frontIP_gath, dim, sym3D, check, localDir='./'):
-    if Cmpi.master:
-        C._deleteEmptyZones(frontIP_gath)
-        frontIP_gath = T.join(frontIP_gath)
-        frontIP_gath = C.convertArray2Tetra(frontIP_gath)
-        frontIP_gath = G.close(frontIP_gath)
-        frontIP_gath[0] = "frontIP_gath"
-        if dim == 3 and sym3D:
+def localOffset__(tbLocal, dim, dir_sym, minSnear, distIP):
+    # A lot of redundancies with Generator/AMR.py - TODO: can some parts be generalized
+    import Geom.IBM as D_IBM
+    
+    distOffset = distIP + 7*minSnear # 5 (real) & 2 for security
+
+    # [Connector/AMR.py specific]
+    # Copy tb about the symmetry plane
+    tbSym = Internal.copyTree(tbLocal)
+    D_IBM._setSnear(tbSym, minSnear)
+    D_IBM._setDfar(tbSym, 10)
+    D_IBM._symmetrizePb(tbSym, 'Base', snear_sym=minSnear, dir_sym=dir_sym)
+    baseSYM = Internal.getNodesFromName1(tbSym, "SYM")
+    if baseSYM is not None: tbSym=Internal.rmNodesByNameAndType(tbSym, 'SYM', 'CGNSBase_t')
+
+    # [Connector/AMR.py specific]
+    # coarsening the tb offset - like in Generator/AMR.py
+    if dim == 3:
+        for nob in range(len(tbSym[2])):
+            if Internal.getType(tbSym[2][nob]) == 'CGNSBase_t':
+                z = Internal.getZones(tbSym[2][nob])
+                z = C.convertArray2Tetra(z)
+                z = T.join(z)
+                bbz = G.bbox(z)
+                # [TODO] this needs to be related to the hmin
+                # hausd is a length and must be adapted to the dimensions of each case
+                hausd = max(bbz[3]-bbz[0], bbz[4]-bbz[1], bbz[5]-bbz[2])/10000.
+                hmax = hausd*1000
+                if Cmpi.master:
+                    print('Remeshing (tbSym) surface mesh --> Maximum chordal deviation between final and initial mesh::%g || Maximum mesh step in final mesh::%g'%(hausd, hmax), flush=True)
+                # exteriorFaces currently crashes if the surface is closed
+                try:
+                    fixedConstraints = P.exteriorFaces(z)
+                except:
+                    fixedConstraints = []
+                z = G.mmgs(z, hausd=hausd, hmax=hmax, fixedConstraints=fixedConstraints)
+                tbSym[2][nob][2] = Internal.getZones(z)
+
+    # Background mesh for offset - only around orig. tb & not its symmetry one
+    BB = G.bbox(tbLocal)
+    ni = 150; nj = 150; nk = 150
+    XRAYDIM1 = 3*ni; XRAYDIM2 = 3*nj
+
+    # CARTRX
+    delta2 = max(BB[3]-BB[0], BB[4]-BB[1], BB[5]-BB[2])*0.02 # 2% seems enough for the external cases already tested
+    xmin_core = BB[0]-delta2
+    ymin_core = BB[1]-delta2
+    zmin_core = BB[2]-delta2
+    xmax_core = BB[3]+delta2
+    ymax_core = BB[4]+delta2
+    zmax_core = BB[5]+delta2
+
+    # [Connector/AMR.py specific]
+    xmin = BB[0]-2*delta2; ymin = BB[1]-2*delta2; zmin = BB[2]-2*delta2
+    xmax = BB[3]+2*delta2; ymax = BB[4]+2*delta2; zmax = BB[5]+2*delta2
+
+    ## Get factor of lengths - cartRX core is rectilinear [Connector/AMR.py specific]
+    lenX = xmax_core-xmin_core; lenY = ymax_core-ymin_core; lenZ = zmax_core-zmin_core   
+    minLen = min(lenX, lenY)
+    if dim == 3: minLen = min(minLen, lenZ)
+    factorX = int(lenX/minLen); factorY = int(lenY/minLen); factorZ = 1
+    if dim == 3: factorZ = int(lenZ/minLen)
+
+    if dim == 2: ni_core = 101; nj_core = 101; nk_core = 101
+    else: ni_core = 61; nj_core = 61; nk_core = 61
+    hi_core = (xmax_core-xmin_core)/(ni_core-1)
+    hj_core = (ymax_core-ymin_core)/(nj_core-1)
+    hk_core = (zmax_core-zmin_core)/(nk_core-1)
+    h_core = min(hi_core, hj_core)
+    if dim == 3: h_core = min(h_core, hk_core)
+    if dim == 2:
+        zmin = 0; zmax = 0
+        zmin_core = 0.; zmax_core = 0.
+        hk_core = 0.
+    h_core = min(h_core, 4.*minSnear)
+
+    # Do not extend the CartCore beyond the symmetry plane (symClose)
+    if dir_sym > 0:
+        if   dir_sym == 1: xmin_core += delta2
+        elif dir_sym == 2: ymin_core += delta2
+        elif dir_sym == 3: zmin_core += delta2
+    # smaller and finer Cartesian core, bigger geometric factor
+    XC0 = (xmin_core, ymin_core, zmin_core); XF0 = (xmin, ymin, zmin)
+    XC1 = (xmax_core, ymax_core, zmax_core); XF1 = (xmax, ymax, zmax)
+    b = G.cartRx3(XC0, XC1, (factorX*h_core, factorY* h_core, factorZ*h_core), XF0, XF1, (1.3, 1.3, 1.3), dim=dim, rank=Cmpi.rank, size=Cmpi.size)
+
+    t0 = time.perf_counter()
+    DTW._distance2Walls(b, tbSym, type='ortho', loc='nodes', signed=0)
+    tElapse = time.perf_counter()-t0
+    tElapse = Cmpi.allreduce(tElapse, op=Cmpi.MAX)
+    if Cmpi.master: print("Generate offset frontDP: dist2wall: %.2fs"%tElapse, flush=True)
+
+    C._initVars(b,"cellN",1.)
+    # merging of symmetrical bodies in the original blanking bodies
+    # required for blankCells as a closed set of surfaces
+    bodies = [Internal.getZones(tbSym)]; nbodies = len(bodies)
+    BM = numpy.ones((1, nbodies), dtype=numpy.int32)
+    t = C.newPyTree(["BASE", Internal.getZones(b)])
+    X._blankCells(t, bodies, BM, blankingType='node_in', dim=dim, XRaydim1=XRAYDIM1, XRaydim2=XRAYDIM1)
+    C._initVars(t, '{TurbulentDistance}={TurbulentDistance}*({cellN}>0.)-{TurbulentDistance}*({cellN}<1.)')
+    iso = P.isoSurfMC(t, 'TurbulentDistance', distOffset)
+    iso = Cmpi.allgatherZones(iso)
+    iso = C.convertArray2Tetra(iso)
+    iso = T.join(iso)
+    return iso
+
+def extractFrontDP(t, tb2, frontIP_gath, dim, sym3D, check, distIP, localDir='./', isNewApproach=True):
+    if not isNewApproach:
+        ##Orig Approach - Based on Integration points front (frontIP_gath)
+        frontIP_gathSave = Internal.copyTree(frontIP_gath)
+        if Cmpi.master:
+            C._deleteEmptyZones(frontIP_gath)
+            frontIP_gath = T.join(frontIP_gath)
+            frontIP_gath = C.convertArray2Tetra(frontIP_gath)
+            frontIP_gath = G.close(frontIP_gath)
+            frontIP_gath[0] = "frontIP_gath"
+            #if dim == 3 and sym3D:
             print("Symmetry of frontIP gathered:%d"%Cmpi.rank)
             # symmetry plane xz
             point = (0.0, 0.0, 0.0)
@@ -307,27 +427,75 @@ def extractFrontDP(t, frontIP_gath, dim, sym3D, check, localDir='./'):
             z_sym = Internal.getZones(z_sym)[0]
             frontIP_gath = T.join(frontIP_gath, z_sym)
             frontIP_gath = G.close(frontIP_gath)
+        else:
+            frontIP_gath = Internal.newZone(name="front", zsize=[[0,0]], ztype="Unstructured")
+            gc = Internal.newGridCoordinates(parent=frontIP_gath)
+            Internal.newDataArray('CoordinateX', value=numpy.empty(0), parent=gc)
+            Internal.newDataArray('CoordinateY', value=numpy.empty(0), parent=gc)
+            Internal.newDataArray('CoordinateZ', value=numpy.empty(0), parent=gc)
+        frontIP_gath = Cmpi.bcastZone(frontIP_gath, root=0, coord=True)
+        frontIP_gath = C.newPyTree(["body", frontIP_gath])
+        C._initVars(t, 'cellNFront', 1.)
+        X_IBM._blankByIBCBodies(t, frontIP_gath, 'nodes', 3, cellNName="cellNFront")
+        del frontIP_gath
+        frontDP = P.frontFaces(t, 'cellNFront')
+        del t
     else:
-        frontIP_gath = Internal.newZone(name="front", zsize=[[0,0]], ztype="Unstructured")
-        gc = Internal.newGridCoordinates(parent=frontIP_gath)
-        Internal.newDataArray('CoordinateX', value=numpy.empty(0), parent=gc)
-        Internal.newDataArray('CoordinateY', value=numpy.empty(0), parent=gc)
-        Internal.newDataArray('CoordinateZ', value=numpy.empty(0), parent=gc)
-    frontIP_gath = Cmpi.bcastZone(frontIP_gath, root=0, coord=True)
-    frontIP_gath = C.newPyTree(["body", frontIP_gath])
-    C._initVars(t, 'cellNFront', 1.)
-    X_IBM._blankByIBCBodies(t, frontIP_gath, 'nodes', 3, cellNName="cellNFront")
-    del frontIP_gath
-    frontDP = P.frontFaces(t, 'cellNFront')
-    del t
+        ## Proposed - based on tb (input geomtery) & dist2wall approach
+        # Get snear
+        G._getVolumeMap(t)
+        hminTmp = (C.getMinValue(t,"centers:vol"))**(1/dim)
+        
+        # Generate Offset - scaled tb
+        frontIP_gathScale = localOffset__(tb2, dim=dim, dir_sym=2, minSnear=hminTmp, distIP=distIP)
+        Cmpi.convertPyTree2File(frontIP_gath, 'check_frontIP_gathScale.cgns')
+        
+        # blankcells - what is inside the offset
+        C._initVars(t, 'cellNTmp', 1.)
+        bodiesTmp = [Internal.getZones(frontIP_gathScale)]
+        nbodies = len(bodiesTmp)
+        nbases = len(Internal.getBases(t))
+        XRAYDIM1 = 2500
+        BM = numpy.ones((nbases,nbodies),dtype=Internal.E_NpyInt)
+        t = X.blankCells(t, bodiesTmp, BM, blankingType='node_in', XRaydim1=XRAYDIM1, XRaydim2=XRAYDIM1,
+                         dim=dim, cellNName='cellNTmp')
+        
+        # select cells - small region to do dist2wall
+        tTmp = P.selectCells(t, "{cellNTmp}<1", strict=0)
+        C._rmVars(t,['cellNTmp','vol'])
+        
+        # dist2wall on region of select cells
+        if len(Internal.getZones(tTmp))>0:
+            DTW._distance2Walls(tTmp, frontIP_gath, type='ortho', signed=0, dim=dim, loc='nodes')
+            # new cellNFront
+            C._initVars(tTmp, '{cellNFront}=({TurbulentDistance}>0.9*%g)'%hminTmp)
+            C.convertPyTree2File(tTmp, 'check_tTmp_final_proc%d.cgns'%Cmpi.rank)
+            del frontIP_gath
+            del t
+            frontDP = P.frontFaces(tTmp, 'cellNFront')
+            del frontIP_gathScale
+            del tTmp
+        else:
+            frontDP = Internal.newZone(name="front", zsize=[[0,0]], ztype="Unstructured")
+            gc = Internal.newGridCoordinates(parent=frontDP)
+            Internal.newDataArray('CoordinateX', value=numpy.empty(0), parent=gc)
+            Internal.newDataArray('CoordinateY', value=numpy.empty(0), parent=gc)
+            Internal.newDataArray('CoordinateZ', value=numpy.empty(0), parent=gc)
+
+    ## Continue - same as orig.
+
     frontDP_gath = Cmpi.allgatherZones(frontDP)
     frontDP_gath = T.join(frontDP_gath)
     frontDP_gath = C.newPyTree(["frontDP", frontDP_gath])
 
     if Cmpi.master and check:
         print("Exporting front DP...", flush=True)
-        C.convertPyTree2File(frontDP_gath, localDir+"frontDP_gath.cgns")
-        C.convertPyTree2File(frontDP_gath, localDir+"frontDP_gath.plt")
+        if isNewApproach:
+            C.convertPyTree2File(frontDP_gath, localDir+"frontDP_gath.cgns")
+            C.convertPyTree2File(frontDP_gath, localDir+"frontDP_gath.plt")
+        else:
+            C.convertPyTree2File(frontDP_gath, localDir+"frontDP_gathOrig.cgns")
+            C.convertPyTree2File(frontDP_gath, localDir+"frontDP_gathOrig.plt")
 
     return frontDP_gath
 

--- a/Cassiopee/Connector/Connector/AMR.py
+++ b/Cassiopee/Connector/Connector/AMR.py
@@ -32,8 +32,8 @@ def outputTime(startTime,functionName='FunctionName'):
     if Cmpi.rank==0: print('Elapsed Time: %s: %g [s] | %g [min] | %g [hr]'%(functionName,elapsedTime,elapsedTime/60,elapsedTime/3600),flush=True)
     return None
 
-def prepareAMRData(t_case, t, IBM_parameters=None, check=False, dim=3, localDir='./', forceAlignment=False):
-    sym3D=False; VPM = False
+def prepareAMRData(t_case, t, IBM_parameters=None, check=False, dim=3, localDir='./', forceAlignment=False, isFastApproach=True):
+    VPM = False
     Cmpi.trace('AMR prepare IBM...start', master=True)
 
     frontTypeIP = IBM_parameters["integration points"]["front type"]
@@ -64,6 +64,15 @@ def prepareAMRData(t_case, t, IBM_parameters=None, check=False, dim=3, localDir=
     if "method" in IBM_parameters["IBM type"].keys():
         if IBM_parameters["IBM type"]["method"] == "VPM":
             VPM = True
+
+    # symmetry & direction
+    dir_sym = 0
+    if "symmetryPlane" in IBM_parameters["IBM type"].keys():
+        dir_sym = int(IBM_parameters["IBM type"]["symmetryPlane"])
+        if IBM_parameters["IBM type"]["symmetryPlane"] < 1 or IBM_parameters["IBM type"]["symmetryPlane"] > 3:
+            if Cmpi.master: print("Warning: Symmetry plane direction can only be : 1 (x-direction), 2 (y-direction) or 3 (z-direction)... exiting", flush=True)
+            raise ValueError("Choose a valid symmetry plane direction. Exiting..")
+            Cmpi.abort(errorcode=1)
 
     different_front_flag = True
     if "use different front for different BCs" in IBM_parameters["integration points"]:
@@ -178,8 +187,8 @@ def prepareAMRData(t_case, t, IBM_parameters=None, check=False, dim=3, localDir=
         C.convertPyTree2File(frontIP_gath, localDir+"frontIP_gath.cgns")
 
     ### for debugging - keep here for now
-    #frontDP_gath = extractFrontDP(t, tb2, frontIP_gath, dim, sym3D, check, distIP=maxDistanceFrontIP, localDir=localDir, isNewApproach=True)
-    #frontDP_gath = extractFrontDP(t, tb2, frontIP_gath, dim, sym3D, check, distIP=maxDistanceFrontIP, localDir=localDir, isNewApproach=False)
+    #frontDP_gath = extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP=maxDistanceFrontIP, localDir=localDir, isFastApproach=False)
+    #frontDP_gath = extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP=maxDistanceFrontIP, localDir=localDir, isFastApproach=True)
     #Cmpi.barrier()
     #Cmpi.abort()
 
@@ -219,7 +228,7 @@ def prepareAMRData(t_case, t, IBM_parameters=None, check=False, dim=3, localDir=
     if VPM == False:
         Cmpi.trace(" Extracting front of the donor points [start]", master=True, cpu=False)
         if frontTypeDP == "1":
-            frontDP_gath = extractFrontDP(t, tb2, frontIP_gath, dim, sym3D, check, distIP=maxDistanceFrontIP, localDir=localDir, isNewApproach=True)
+            frontDP_gath = extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP=maxDistanceFrontIP, localDir=localDir, isFastApproach=isFastApproach)
         else:
             frontDP_gath = None
         del frontIP_gath
@@ -405,9 +414,10 @@ def localOffset__(tbLocal, dim, dir_sym, minSnear, distIP):
     iso = T.join(iso)
     return iso
 
-def extractFrontDP(t, tb2, frontIP_gath, dim, sym3D, check, distIP, localDir='./', isNewApproach=True):
-    if not isNewApproach:
+def extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP, localDir='./', isFastApproach=True):
+    if isFastApproach:
         ##Orig Approach - Based on Integration points front (frontIP_gath)
+        ##                fast approach but can lead to errors in the IBM points - encountered when running CODA
         frontIP_gathSave = Internal.copyTree(frontIP_gath)
         if Cmpi.master:
             C._deleteEmptyZones(frontIP_gath)
@@ -415,18 +425,17 @@ def extractFrontDP(t, tb2, frontIP_gath, dim, sym3D, check, distIP, localDir='./
             frontIP_gath = C.convertArray2Tetra(frontIP_gath)
             frontIP_gath = G.close(frontIP_gath)
             frontIP_gath[0] = "frontIP_gath"
-            #if dim == 3 and sym3D:
-            print("Symmetry of frontIP gathered:%d"%Cmpi.rank)
-            # symmetry plane xz
-            point = (0.0, 0.0, 0.0)
-            vector1 = (1.0, 0.0, 0.0)
-            vector2 = (0.0, 0.0, 1.0)
-            z_sym = T.symmetrize(frontIP_gath, point, vector1, vector2)
-            z_sym[0] = "sym"
-            frontIP_gath = Internal.getZones(frontIP_gath)[0]
-            z_sym = Internal.getZones(z_sym)[0]
-            frontIP_gath = T.join(frontIP_gath, z_sym)
-            frontIP_gath = G.close(frontIP_gath)
+            if dim == 3 and dir_sym > 0:
+                print("Symmetry of frontIP gathered:%d"%Cmpi.rank)
+                # Copy tb about the symmetry plane
+                z_sym = Internal.copyTree(frontIP_gath)
+                D_IBM._setSnear(z_sym, 1e-06) # dummy  snear value
+                D_IBM._setDfar(z_sym, 10) # dummy dfar value
+                D_IBM._symmetrizePb(z_sym, 'Base', snear_sym=1e-06, dir_sym=dir_sym)
+                baseSYM = Internal.getNodesFromName1(z_sym, "SYM")
+                if baseSYM is not None: z_sym = Internal.rmNodesByNameAndType(z_sym, 'SYM', 'CGNSBase_t')
+                frontIP_gath = G.close(z_sym)
+                del z_sym
         else:
             frontIP_gath = Internal.newZone(name="front", zsize=[[0,0]], ztype="Unstructured")
             gc = Internal.newGridCoordinates(parent=frontIP_gath)
@@ -441,13 +450,15 @@ def extractFrontDP(t, tb2, frontIP_gath, dim, sym3D, check, distIP, localDir='./
         frontDP = P.frontFaces(t, 'cellNFront')
         del t
     else:
-        ## Proposed - based on tb (input geomtery) & dist2wall approach
+        ## Robust - based on tb (input geomtery), offset, selectcells, & dist2wall approach
+        ##          more expensive but proven to be more robust
+
         # Get snear
         G._getVolumeMap(t)
         hminTmp = (C.getMinValue(t,"centers:vol"))**(1/dim)
         
         # Generate Offset - scaled tb
-        frontIP_gathScale = localOffset__(tb2, dim=dim, dir_sym=2, minSnear=hminTmp, distIP=distIP)
+        frontIP_gathScale = localOffset__(tb2, dim=dim, dir_sym=dir_sym, minSnear=hminTmp, distIP=distIP)
         Cmpi.convertPyTree2File(frontIP_gath, 'check_frontIP_gathScale.cgns')
         
         # blankcells - what is inside the offset

--- a/Cassiopee/Connector/Connector/AMR.py
+++ b/Cassiopee/Connector/Connector/AMR.py
@@ -464,7 +464,7 @@ def extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP, localDir='
         if Cmpi.master: print('extractFrontDP Info: Smallest cell size (snear): %g'%hminTmp, flush=True)
         # Generate Offset - scaled tb
         frontIP_gathScale = localOffset__(tb2, dim=dim, dir_sym=dir_sym, minSnear=hminTmp, distIP=distIP)
-        Cmpi.convertPyTree2File(frontIP_gathScale, 'check_frontIP_gathScale.cgns')
+        #Cmpi.convertPyTree2File(frontIP_gathScale, 'check_frontIP_gathScale.cgns') # Keep for now - debugging
 
         # blankcells - what is inside the offset
         C._initVars(t, 'cellNTmp', 1.)

--- a/Cassiopee/Connector/Connector/AMR.py
+++ b/Cassiopee/Connector/Connector/AMR.py
@@ -157,7 +157,10 @@ def prepareAMRData(t_case, t, IBM_parameters=None, check=False, dim=3, localDir=
     frontIP = computeCellNForIBMFronts(t, dim, IBM_parameters, VPM=VPM)
     Cmpi.trace("Extract front faces of IBM target points [end]   ", master=True, cpu=False)
 
-    maxDistanceFrontIP = C.getMaxValue(frontIP, 'TurbulentDistance')
+    maxDistanceFrontIP = 0.0
+    turbDistanceTmp = Internal.getNodeFromName(frontIP, 'TurbulentDistance')[1]
+    print('WARNING: Rank:%d || len(turbDistanceTmp)=%d'%(Cmpi.rank, len(turbDistanceTmp)), flush=True)
+    if len(turbDistanceTmp)>0: maxDistanceFrontIP = C.getMaxValue(frontIP, 'TurbulentDistance')
     maxDistanceFrontIP = Cmpi.allreduce(maxDistanceFrontIP, op=Cmpi.MAX)
     if Cmpi.master: print('WARNING=maxDistanceFrontIP=%g'%maxDistanceFrontIP, flush=True)
         
@@ -187,8 +190,8 @@ def prepareAMRData(t_case, t, IBM_parameters=None, check=False, dim=3, localDir=
         C.convertPyTree2File(frontIP_gath, localDir+"frontIP_gath.cgns")
 
     ### for debugging - keep here for now
-    #frontDP_gath = extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP=maxDistanceFrontIP, localDir=localDir, isFastApproach=False)
     #frontDP_gath = extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP=maxDistanceFrontIP, localDir=localDir, isFastApproach=True)
+    #frontDP_gath = extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP=maxDistanceFrontIP, localDir=localDir, isFastApproach=False)
     #Cmpi.barrier()
     #Cmpi.abort()
 
@@ -199,7 +202,7 @@ def prepareAMRData(t_case, t, IBM_parameters=None, check=False, dim=3, localDir=
             Internal._rmNode(f_pytree, elt_t)
     _recoverBoundaryConditions__(t, f_pytree, zbcs, bctypes, bcnames)
     Cmpi.trace(" Recovering Boundary Conditions [end]  ", master=True, cpu=False)
-    Cmpi.convertPyTree2File(t,'check_t_afterBC.cgns')
+    #Cmpi.convertPyTree2File(t,'check_t_afterBC.cgns')
 
     Cmpi.trace(" Cleaning frontIP (IBMWall) per processor [start]", master=True, cpu=False)
     if Cmpi.master: print("Performing the 'identifyElements' function (it can be long.)", flush=True)
@@ -317,35 +320,36 @@ def localOffset__(tbLocal, dim, dir_sym, minSnear, distIP):
     # [Connector/AMR.py specific]
     # Copy tb about the symmetry plane
     tbSym = Internal.copyTree(tbLocal)
-    D_IBM._setSnear(tbSym, minSnear)
-    D_IBM._setDfar(tbSym, 10)
-    D_IBM._symmetrizePb(tbSym, 'Base', snear_sym=minSnear, dir_sym=dir_sym)
-    baseSYM = Internal.getNodesFromName1(tbSym, "SYM")
-    if baseSYM is not None: tbSym=Internal.rmNodesByNameAndType(tbSym, 'SYM', 'CGNSBase_t')
+    if dir_sym > 0:
+        D_IBM._setSnear(tbSym, minSnear)
+        D_IBM._setDfar(tbSym, 10)
+        D_IBM._symmetrizePb(tbSym, 'Base', snear_sym=minSnear, dir_sym=dir_sym)
+        baseSYM = Internal.getNodesFromName1(tbSym, "SYM")
+        if baseSYM is not None: tbSym=Internal.rmNodesByNameAndType(tbSym, 'SYM', 'CGNSBase_t')
+        C._rmVars(tbSym,['centers:cellN'])
 
     # [Connector/AMR.py specific]
     # coarsening the tb offset - like in Generator/AMR.py
-    if dim == 3:
-        for nob in range(len(tbSym[2])):
-            if Internal.getType(tbSym[2][nob]) == 'CGNSBase_t':
-                z = Internal.getZones(tbSym[2][nob])
-                z = C.convertArray2Tetra(z)
-                z = T.join(z)
-                bbz = G.bbox(z)
-                # [TODO] this needs to be related to the hmin
-                # hausd is a length and must be adapted to the dimensions of each case
-                hausd = max(bbz[3]-bbz[0], bbz[4]-bbz[1], bbz[5]-bbz[2])/10000.
-                hmax = hausd*1000
-                if Cmpi.master:
-                    print('Remeshing (tbSym) surface mesh --> Maximum chordal deviation between final and initial mesh::%g || Maximum mesh step in final mesh::%g'%(hausd, hmax), flush=True)
-                # exteriorFaces currently crashes if the surface is closed
-                try:
-                    fixedConstraints = P.exteriorFaces(z)
-                except:
-                    fixedConstraints = []
-                z = G.mmgs(z, hausd=hausd, hmax=hmax, fixedConstraints=fixedConstraints)
-                tbSym[2][nob][2] = Internal.getZones(z)
-
+    for nob in range(len(tbSym[2])):
+        if Internal.getType(tbSym[2][nob]) == 'CGNSBase_t':
+            z = Internal.getZones(tbSym[2][nob])
+            z = C.convertArray2Tetra(z)
+            z = T.join(z)
+            bbz = G.bbox(z)
+            # [TODO] this needs to be related to the hmin
+            # hausd is a length and must be adapted to the dimensions of each case
+            hausd = max(bbz[3]-bbz[0], bbz[4]-bbz[1], bbz[5]-bbz[2])/10000.
+            hmax = hausd*1000
+            if Cmpi.master:
+                print('Remeshing (tbSym) surface mesh --> Maximum chordal deviation between final and initial mesh::%g || Maximum mesh step in final mesh::%g'%(hausd, hmax), flush=True)
+            # exteriorFaces currently crashes if the surface is closed
+            try:
+                fixedConstraints = P.exteriorFaces(z)
+            except:
+                fixedConstraints = []
+            z = G.mmgs(z, hausd=hausd, hmax=hmax, fixedConstraints=fixedConstraints)
+            tbSym[2][nob][2] = Internal.getZones(z)
+    
     # Background mesh for offset - only around orig. tb & not its symmetry one
     BB = G.bbox(tbLocal)
     ni = 150; nj = 150; nk = 150
@@ -367,21 +371,17 @@ def localOffset__(tbLocal, dim, dir_sym, minSnear, distIP):
     ## Get factor of lengths - cartRX core is rectilinear [Connector/AMR.py specific]
     lenX = xmax_core-xmin_core; lenY = ymax_core-ymin_core; lenZ = zmax_core-zmin_core   
     minLen = min(lenX, lenY)
-    if dim == 3: minLen = min(minLen, lenZ)
+    minLen = min(minLen, lenZ)
     factorX = int(lenX/minLen); factorY = int(lenY/minLen); factorZ = 1
-    if dim == 3: factorZ = int(lenZ/minLen)
-
-    if dim == 2: ni_core = 101; nj_core = 101; nk_core = 101
-    else: ni_core = 61; nj_core = 61; nk_core = 61
+    factorZ = int(lenZ/minLen)
+    factorX = min(factorX, 2); factorY = min(factorY, 2); factorZ = min(factorZ, 2)
+    
+    ni_core = 61; nj_core = 61; nk_core = 61
     hi_core = (xmax_core-xmin_core)/(ni_core-1)
     hj_core = (ymax_core-ymin_core)/(nj_core-1)
     hk_core = (zmax_core-zmin_core)/(nk_core-1)
     h_core = min(hi_core, hj_core)
-    if dim == 3: h_core = min(h_core, hk_core)
-    if dim == 2:
-        zmin = 0; zmax = 0
-        zmin_core = 0.; zmax_core = 0.
-        hk_core = 0.
+    h_core = min(h_core, hk_core)
     h_core = min(h_core, 4.*minSnear)
 
     # Do not extend the CartCore beyond the symmetry plane (symClose)
@@ -415,52 +415,53 @@ def localOffset__(tbLocal, dim, dir_sym, minSnear, distIP):
     return iso
 
 def extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP, localDir='./', isFastApproach=True):
+    import Geom.IBM as D_IBM
+    if dim == 2 and not isFastApproach:
+        isFastApproach = True
+        if Cmpi.master: print("WARNING: extractFrontDP based on the Robust approach is incomptabile with 2D test cases. Forcing Fast Approach...", flush=True)
     if isFastApproach:
+        if Cmpi.master: print("WARNING: extractFrontDP - using Fast approach based on the integration points. This approach may yield unsatisfactory results for small resolutions", flush=True)
         ##Orig Approach - Based on Integration points front (frontIP_gath)
         ##                fast approach but can lead to errors in the IBM points - encountered when running CODA
-        frontIP_gathSave = Internal.copyTree(frontIP_gath)
         if Cmpi.master:
             C._deleteEmptyZones(frontIP_gath)
             frontIP_gath = T.join(frontIP_gath)
             frontIP_gath = C.convertArray2Tetra(frontIP_gath)
             frontIP_gath = G.close(frontIP_gath)
             frontIP_gath[0] = "frontIP_gath"
-            if dim == 3 and dir_sym > 0:
+            frontIP_gath = C.newPyTree(["Base", frontIP_gath])     
+            if dim == 3 and dir_sym > 0:           
                 print("Symmetry of frontIP gathered:%d"%Cmpi.rank)
-                # Copy tb about the symmetry plane
-                z_sym = Internal.copyTree(frontIP_gath)
-                D_IBM._setSnear(z_sym, 1e-06) # dummy  snear value
-                D_IBM._setDfar(z_sym, 10) # dummy dfar value
-                D_IBM._symmetrizePb(z_sym, 'Base', snear_sym=1e-06, dir_sym=dir_sym)
-                baseSYM = Internal.getNodesFromName1(z_sym, "SYM")
-                if baseSYM is not None: z_sym = Internal.rmNodesByNameAndType(z_sym, 'SYM', 'CGNSBase_t')
-                frontIP_gath = G.close(z_sym)
-                del z_sym
-        else:
-            frontIP_gath = Internal.newZone(name="front", zsize=[[0,0]], ztype="Unstructured")
-            gc = Internal.newGridCoordinates(parent=frontIP_gath)
-            Internal.newDataArray('CoordinateX', value=numpy.empty(0), parent=gc)
-            Internal.newDataArray('CoordinateY', value=numpy.empty(0), parent=gc)
-            Internal.newDataArray('CoordinateZ', value=numpy.empty(0), parent=gc)
-        frontIP_gath = Cmpi.bcastZone(frontIP_gath, root=0, coord=True)
-        frontIP_gath = C.newPyTree(["body", frontIP_gath])
+                frontIP_gath= Internal.getNodeFromName(frontIP_gath, 'Base')
+                minval = C.getMinValue(frontIP_gath, ['CoordinateX', 'CoordinateY','CoordinateZ'])
+                minval = minval[dir_sym-1]
+                if dir_sym == 1: symPlane=(minval,0,0)
+                elif dir_sym == 2: symPlane=(0,minval,0)
+                else: symPlane=(0,0,minval)
+                D_IBM._symmetrizeBody(frontIP_gath, dir_sym=dir_sym, symPlane=symPlane) # expect base input
+                frontIP_gath = G.close(frontIP_gath)
+                frontIP_gath = T.join(frontIP_gath)
+        frontIP_gath = Cmpi.bcastZone(frontIP_gath)
+        frontIP_gath = C.newPyTree(["Base", frontIP_gath])
         C._initVars(t, 'cellNFront', 1.)
         X_IBM._blankByIBCBodies(t, frontIP_gath, 'nodes', 3, cellNName="cellNFront")
         del frontIP_gath
         frontDP = P.frontFaces(t, 'cellNFront')
         del t
     else:
+        if Cmpi.master: print("WARNING: extractFrontDP - using Robust approach based on the offsets & dist2wall. This approach can take some time.", flush=True)
         ## Robust - based on tb (input geomtery), offset, selectcells, & dist2wall approach
         ##          more expensive but proven to be more robust
 
         # Get snear
         G._getVolumeMap(t)
         hminTmp = (C.getMinValue(t,"centers:vol"))**(1/dim)
+        hminTmp = Cmpi.allreduce(hminTmp, op=Cmpi.MIN)
         
         # Generate Offset - scaled tb
         frontIP_gathScale = localOffset__(tb2, dim=dim, dir_sym=dir_sym, minSnear=hminTmp, distIP=distIP)
-        Cmpi.convertPyTree2File(frontIP_gath, 'check_frontIP_gathScale.cgns')
-        
+        Cmpi.convertPyTree2File(frontIP_gathScale, 'check_frontIP_gathScale.cgns')
+
         # blankcells - what is inside the offset
         C._initVars(t, 'cellNTmp', 1.)
         bodiesTmp = [Internal.getZones(frontIP_gathScale)]
@@ -480,10 +481,11 @@ def extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP, localDir='
             DTW._distance2Walls(tTmp, frontIP_gath, type='ortho', signed=0, dim=dim, loc='nodes')
             # new cellNFront
             C._initVars(tTmp, '{cellNFront}=({TurbulentDistance}>0.9*%g)'%hminTmp)
-            C.convertPyTree2File(tTmp, 'check_tTmp_final_proc%d.cgns'%Cmpi.rank)
+            #C.convertPyTree2File(tTmp, 'check_tTmp_final_proc%d.cgns'%Cmpi.rank)
             del frontIP_gath
             del t
             frontDP = P.frontFaces(tTmp, 'cellNFront')
+            #C.convertPyTree2File(frontDP, 'check_frontDP_proc%d.cgns'%Cmpi.rank)
             del frontIP_gathScale
             del tTmp
         else:
@@ -494,19 +496,18 @@ def extractFrontDP(t, tb2, frontIP_gath, dim, dir_sym, check, distIP, localDir='
             Internal.newDataArray('CoordinateZ', value=numpy.empty(0), parent=gc)
 
     ## Continue - same as orig.
-
     frontDP_gath = Cmpi.allgatherZones(frontDP)
+    C._deleteEmptyZones(frontDP_gath)
     frontDP_gath = T.join(frontDP_gath)
     frontDP_gath = C.newPyTree(["frontDP", frontDP_gath])
-
     if Cmpi.master and check:
         print("Exporting front DP...", flush=True)
-        if isNewApproach:
-            C.convertPyTree2File(frontDP_gath, localDir+"frontDP_gath.cgns")
-            C.convertPyTree2File(frontDP_gath, localDir+"frontDP_gath.plt")
+        if isFastApproach:
+            C.convertPyTree2File(frontDP_gath, localDir+"frontDP_gath_FastApproach.cgns")
+            C.convertPyTree2File(frontDP_gath, localDir+"frontDP_gath_FastApproach.plt")
         else:
-            C.convertPyTree2File(frontDP_gath, localDir+"frontDP_gathOrig.cgns")
-            C.convertPyTree2File(frontDP_gath, localDir+"frontDP_gathOrig.plt")
+            C.convertPyTree2File(frontDP_gath, localDir+"frontDP_gath_RobustApproach.cgns")
+            C.convertPyTree2File(frontDP_gath, localDir+"frontDP_gath_RobustApproach.plt")
 
     return frontDP_gath
 


### PR DESCRIPTION
For a large test case with a small snear, the default extractFrontDP did not yield the expected results and was not 100% robust. This approach is henceforth denoted as the fast approach. The proposed approach, hereby called robust, is slower but more robust and solves the issues found in the aforementioned test case. 
Robust approach:
1) offset generation from tb
2) blankcells to tag cells inside the offset
3) selectcells of the blanked cells
4) dist2wall to the tb for the selected cells
5) extract front
