### PR TITLE
Post: selectExteriorVertices: return a copy when the input array is NODE

### DIFF
--- a/Cassiopee/Post/Post/selectExteriorVertices.cpp
+++ b/Cassiopee/Post/Post/selectExteriorVertices.cpp
@@ -46,8 +46,11 @@ PyObject* K_POST::selectExteriorVertices(PyObject* self, PyObject* args)
   {
     if (K_STRING::cmp(eltType, "NODE") == 0)
     {
+      FldArrayI* cnn = new FldArrayI();
+      tpl = K_ARRAY::buildArray3(*f, varString, *cnn, eltType, f->getApi());
+      delete cnn;
       RELEASESHAREDU(array, f, cn);
-      return array;
+      return tpl;
     }
     else if (strcmp(eltType, "NGON") == 0)
     {


### PR DESCRIPTION
Solution taken from convertArray2Node.cpp

Regressions: exteriorVerticesPT_t1

In current, the number of cells is 0. This is consistent with the output of Geom/cloudPT_t1 for a point cloud of type NODE.

```txt
Reading Data_ld/exteriorVerticesPT_t1.ref9 (bin_pickle)...done.
DIFF: valeurs differentes pour le noeud: cartTetra.2.
DIFF: reference: [[125   1   0]]
DIFF: courant: [[125   0   0]]
DIFF: valeurs differentes pour le noeud: ElementRange.
DIFF: reference: [1 1]
DIFF: courant: [1 0]
```
