### PR TITLE
Post: change gradient variable names in computeGradLSQ - 2/2

### DIFF
--- a/Cassiopee/Post/Post/Mpi.py
+++ b/Cassiopee/Post/Post/Mpi.py
@@ -15,6 +15,10 @@ import Generator.PyTree as G
 def computeGradLSQ(t, fldNames):
     if Cmpi.size == 1: return P.computeGradLSQ(t, fldNames)
 
+    if isinstance(fldNames, str):
+        fldNames = [fldNames]
+    fldNames = [fldName.split(':')[-1] for fldName in fldNames]
+
     fcenters, fareas = G.getFaceCentersAndAreas(t)
     centers = G.getCellCenters(t, fcenters, fareas)
     zones = Internal.getZones(t)
@@ -22,22 +26,20 @@ def computeGradLSQ(t, fldNames):
         cc = centers[i]
         if cc is None: continue
         fsolc = Internal.getNodeFromName(zone, Internal.__FlowSolutionCenters__)
-        Internal.createNode('CCx', 'DataArray_t', cc[0], None, fsolc)
-        Internal.createNode('CCy', 'DataArray_t', cc[1], None, fsolc)
-        Internal.createNode('CCz', 'DataArray_t', cc[2], None, fsolc)
+        if fsolc is None: raise ValueError("computeGradLSQ: FlowSolutionCenters not found.")
+        Internal.newDataArray('CCx', cc[0], fsolc)
+        Internal.newDataArray('CCy', cc[1], fsolc)
+        Internal.newDataArray('CCz', cc[2], fsolc)
 
     # exchange fields and cell centers
-    allNames = fldNames
-    allNames.append('CCx')
-    allNames.append('CCy')
-    allNames.append('CCz')
-    rfields = X.exchangeFields(t, fldNames)
+    allFldNames = fldNames + ['CCx', 'CCy', 'CCz']
+    rfields = X.exchangeFields(t, allFldNames)
 
     # get comm list
     zgc = Internal.getNodeFromType1(zone, 'ZoneGridConnectivity_t')
-    if zgc is None: raise ValueError('ZoneGridConnectivity not found.')
+    if zgc is None: raise ValueError('computeGradLSQ: ZoneGridConnectivity not found.')
     comms = Internal.getNodesFromType1(zgc, 'GridConnectivity1to1_t')
-    if comms is None: raise ValueError('GridConnectivity1to1 not found.')
+    if comms is None: raise ValueError('computeGradLSQ: GridConnectivity1to1 not found.')
     ptlists = []
     for comm in comms:
         ptlist = Internal.getNodeFromName(comm, 'PointList')[1]
@@ -46,7 +48,6 @@ def computeGradLSQ(t, fldNames):
     # compute lsq gradients
     parRun = 1
     t = P.computeGradLSQ(t, fldNames, parRun, fcenters, ptlists, rfields)
-    # TODO(Imad): delete cell centers from tree
     return t
 
 #==============================================================================

--- a/Cassiopee/Post/Post/PyTree.py
+++ b/Cassiopee/Post/Post/PyTree.py
@@ -1507,9 +1507,9 @@ def _computeGradLSQ(t, fldNames, parRun=0, fcenters=None, ptlists=None,
                                         ptlists, rflds)
 
         for j, fldName in enumerate(fldNames):
-            Internal.newDataArray(f"grad{fldName}x", grads[j][0], fsolc)
-            Internal.newDataArray(f"grad{fldName}y", grads[j][1], fsolc)
-            Internal.newDataArray(f"grad{fldName}z", grads[j][2], fsolc)
+            Internal.newDataArray(f"gradx{fldName}", grads[j][0], fsolc)
+            Internal.newDataArray(f"grady{fldName}", grads[j][1], fsolc)
+            Internal.newDataArray(f"gradz{fldName}", grads[j][2], fsolc)
     return None
 
 def computeGrad2(t, var, ghostCells=False, withCellN=True, withTNC=False):

--- a/Cassiopee/Post/Post/PyTree.py
+++ b/Cassiopee/Post/Post/PyTree.py
@@ -1466,6 +1466,10 @@ def computeGradLSQ(t, fldNames, parRun=0, fcenters=None, ptlists=None,
 
 def _computeGradLSQ(t, fldNames, parRun=0, fcenters=None, ptlists=None,
                     rfields=None):
+    if isinstance(fldNames, str):
+        fldNames = [fldNames]
+    fldNames = [fldName.split(':')[-1] for fldName in fldNames]
+
     fc = None
     if parRun == 0:
         fc, fa = G.getFaceCentersAndAreas(t)
@@ -1473,45 +1477,39 @@ def _computeGradLSQ(t, fldNames, parRun=0, fcenters=None, ptlists=None,
 
     zones = Internal.getZones(t)
     for i, zone in enumerate(zones):
-
         arr = C.getFields(Internal.__GridCoordinates__, zone, api=3)[0]
         if arr is None: continue
-
-        fsolc = Internal.getNodeFromName1(zone,
-                                          Internal.__FlowSolutionCenters__)
-        if fsolc is None: raise ValueError("FlowSolutionCenters not found.")
+        fsolc = Internal.getNodeFromName1(zone, Internal.__FlowSolutionCenters__)
+        if fsolc is None: raise ValueError("_computeGradLSQ: FlowSolutionCenters not found.")
+        pe = Internal.getNodeFromName2(zone, 'ParentElements')
+        if pe is None: raise ValueError("_computeGradLSQ: ParentElements not found.")
+        pe = pe[1]
 
         flds = []
         for fldName in fldNames:
             fsol = Internal.getNodeFromName1(fsolc, fldName)
             if fsol is None:
-                raise ValueError('Field ' + fldName + ' not found.')
+                raise ValueError(f"_computeGradLSQ: Field centers:{fldName} not found.")
             flds.append(fsol[1])
-
-        pe = Internal.getNodeFromName(zone, 'ParentElements')[1]
 
         rflds = None
         if parRun == 0:
             cc = centers[i]
-            Grads = post.computeGradLSQ(arr, flds, pe, cc[0], cc[1], cc[2], fc[i],
+            grads = post.computeGradLSQ(arr, flds, pe, cc[0], cc[1], cc[2], fc[i],
                                         None, rflds)
         else:
             rflds = rfields[i]
             cx = Internal.getNodeFromName1(fsolc, 'CCx')[1]
             cy = Internal.getNodeFromName1(fsolc, 'CCy')[1]
             cz = Internal.getNodeFromName1(fsolc, 'CCz')[1]
-            Grads = post.computeGradLSQ(arr, flds, pe, cx, cy, cz, fcenters[0],
+            flds.extend([cx, cy, cz])
+            grads = post.computeGradLSQ(arr, flds, pe, cx, cy, cz, fcenters[0],
                                         ptlists, rflds)
 
-        for j in range(len(fldNames)-3):
-            Grad = Grads[j]
-            Internal.createNode('grad' + fldNames[j] + 'x', 'DataArray_t',
-                                Grad[0], None, fsolc)
-            Internal.createNode('grad' + fldNames[j] + 'y', 'DataArray_t',
-                                Grad[1], None, fsolc)
-            Internal.createNode('grad' + fldNames[j] + 'z', 'DataArray_t',
-                                Grad[2], None, fsolc)
-
+        for j, fldName in enumerate(fldNames):
+            Internal.newDataArray(f"grad{fldName}x", grads[j][0], fsolc)
+            Internal.newDataArray(f"grad{fldName}y", grads[j][1], fsolc)
+            Internal.newDataArray(f"grad{fldName}z", grads[j][2], fsolc)
     return None
 
 def computeGrad2(t, var, ghostCells=False, withCellN=True, withTNC=False):
@@ -1522,8 +1520,7 @@ def computeGrad2(t, var, ghostCells=False, withCellN=True, withTNC=False):
 
 def _computeGrad2(t, var, ghostCells=False, withCellN=True, withTNC=False):
     """Compute the gradient of a variable defined in array."""
-
-    if type(var) == list:
+    if isinstance(var, list):
         raise ValueError("computeGrad2: not available for lists of variables.")
     vare = var.split(':')
     if len(vare) > 1: vare = vare[1]


### PR DESCRIPTION
Please *SQUASH*

Changing gradient variable names in in P.computeGradLSQ from
`gradPressurex, gradPressurey, gradPressurez`
to
`gradxPressure, gradyPressure, gradzPressure`
for consistency with P.computeGrad and P.computeGrad2

Regressions:
- Post/computeGradLSQPT_m1
- Post/computeGradLSQPT_t1

```
Running computeGradLSQPT_m1.py with Nprocs=2 and Nthreads=12
Writing ./LSQcase.cgns (bin_cgns)...done.
Reading ./LSQcase.cgns (bin_hdf, skeleton)...done.
Reading ./LSQcase.cgns (bin_hdf, partial)...done.
Reading ./LSQcase.cgns (bin_hdf, partial)...done.
Reading ./LSQcase.cgns (bin_hdf, partial)...done.
Reading ./LSQcase.cgns (bin_hdf, partial)...done.
Total number of cells: 100
Total number of faces: 420
Total number of points: 242
ParentElements OK
Dual graph OK
Graph map OK
NFACE OK
NGON OK
Coordinates OK
Comm patches OK
Export OK
Partitioned mesh in 0.01 s
Reading Data_ubuntu/computeGradLSQPT_m1.ref1 (bin_pickle)...done.
DIFF: node Base/cartHexa_0/FlowSolution#Centers/gradgx exists in reference but not in current.
DIFF: node Base/cartHexa_0/FlowSolution#Centers/gradgy exists in reference but not in current.
DIFF: node Base/cartHexa_0/FlowSolution#Centers/gradgz exists in reference but not in current.
DIFF: node Base/cartHexa_0/FlowSolution#Centers/gradfx exists in reference but not in current.
DIFF: node Base/cartHexa_0/FlowSolution#Centers/gradfy exists in reference but not in current.
DIFF: node Base/cartHexa_0/FlowSolution#Centers/gradfz exists in reference but not in current.
DIFF: node Base/cartHexa_0/FlowSolution#Centers/gradxg exists in current but not in reference.
DIFF: node Base/cartHexa_0/FlowSolution#Centers/gradyg exists in current but not in reference.
DIFF: node Base/cartHexa_0/FlowSolution#Centers/gradzg exists in current but not in reference.
DIFF: node Base/cartHexa_0/FlowSolution#Centers/gradxf exists in current but not in reference.
DIFF: node Base/cartHexa_0/FlowSolution#Centers/gradyf exists in current but not in reference.
DIFF: node Base/cartHexa_0/FlowSolution#Centers/gradzf exists in current but not in reference.
Warning: diff2: some variables are different in both arguments in array 0. Only common fields are compared.

Elapsed CPU time: 0m1.67s
Running computeGradLSQPT_t1.py with Nprocs=0 and Nthreads=24
Reading Data_ubuntu/computeGradLSQPT_t1.ref1 (bin_pickle)...done.
DIFF: node Base/cartHexa/FlowSolution#Centers/gradgx exists in reference but not in current.
DIFF: node Base/cartHexa/FlowSolution#Centers/gradgy exists in reference but not in current.
DIFF: node Base/cartHexa/FlowSolution#Centers/gradgz exists in reference but not in current.
DIFF: node Base/cartHexa/FlowSolution#Centers/gradfx exists in reference but not in current.
DIFF: node Base/cartHexa/FlowSolution#Centers/gradfy exists in reference but not in current.
DIFF: node Base/cartHexa/FlowSolution#Centers/gradfz exists in reference but not in current.
DIFF: node Base/cartHexa/FlowSolution#Centers/gradxg exists in current but not in reference.
DIFF: node Base/cartHexa/FlowSolution#Centers/gradyg exists in current but not in reference.
DIFF: node Base/cartHexa/FlowSolution#Centers/gradzg exists in current but not in reference.
DIFF: node Base/cartHexa/FlowSolution#Centers/gradxf exists in current but not in reference.
DIFF: node Base/cartHexa/FlowSolution#Centers/gradyf exists in current but not in reference.
DIFF: node Base/cartHexa/FlowSolution#Centers/gradzf exists in current but not in reference.
Warning: diff2: some variables are different in both arguments in array 0. Only common fields are compared.

Elapsed CPU time: 0m0.27s
```