### PR TITLE
Post: fix clean up of partial derivatives in computeDiv2

### DIFF
--- a/Cassiopee/Post/Post/PyTree.py
+++ b/Cassiopee/Post/Post/PyTree.py
@@ -1773,14 +1773,10 @@ def _computeDiv2(t, var, ghostCells=False, withTNC=False, rmVar=False,
             C.setFields([divFld], z, 'centers')
 
     # Conditional clean up of partial derivatives
-    # if rmVar:  # TODO - CORRECT VERSION
-    #     varWLocList = " ".join(f"{v}X {v}Y {v}Z" for v in var).split()
-    #     C._rmVars(t, varWLocList)
-    #     C._rmBCDataVars(t, varList)
     if rmVar:
-        for i in range(0, 3*nvars, 3): # WRONG - does not delete all compos in 2D
-            C._rmVars(t, ['{}:{}'.format('centers', v) for v in varList[i:i+dim]])
-            C._rmBCDataVars(t, varList[i:i+dim])
+        varWLocList = " ".join(f"{v}X {v}Y {v}Z" for v in var).split()
+        C._rmVars(t, varWLocList)
+        C._rmBCDataVars(t, varList)
 
     return None
 


### PR DESCRIPTION
Fix clean up of partial derivatives in computeDiv2:
In 2D, the z-component was not discarded.

Regressions:
- Post/computeDiv2PT_t4

```
Running computeDiv2PT_t4.py with Nprocs=0 and Nthreads=24
Reading Data_ubuntu/computeDiv2PT_t4.ref1 (bin_pickle)...done.
Reading Data_ubuntu/computeDiv2PT_t4.ref2 (bin_pickle)...done.
DIFF: longueur des fils differente pour le noeud: Base/cart.14/ZoneBC/wall1.2/BCDataSet/BCData.
DIFF: node Base/cart.14/ZoneBC/wall1.2/BCDataSet/BCData/fld1Z exists in reference but not in current.
DIFF: node Base/cart.14/ZoneBC/wall1.2/BCDataSet/BCData/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.14/ZoneBC/wall2.2/BCDataSet/BCData.
DIFF: node Base/cart.14/ZoneBC/wall2.2/BCDataSet/BCData/fld1Z exists in reference but not in current.
DIFF: node Base/cart.14/ZoneBC/wall2.2/BCDataSet/BCData/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.14/FlowSolution#Centers.
DIFF: node Base/cart.14/FlowSolution#Centers/fld1Z exists in reference but not in current.
DIFF: node Base/cart.14/FlowSolution#Centers/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.15/ZoneBC/wall1.3/BCDataSet/BCData.
DIFF: node Base/cart.15/ZoneBC/wall1.3/BCDataSet/BCData/fld1Z exists in reference but not in current.
DIFF: node Base/cart.15/ZoneBC/wall1.3/BCDataSet/BCData/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.15/ZoneBC/wall2.3/BCDataSet/BCData.
DIFF: node Base/cart.15/ZoneBC/wall2.3/BCDataSet/BCData/fld1Z exists in reference but not in current.
DIFF: node Base/cart.15/ZoneBC/wall2.3/BCDataSet/BCData/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.15/ZoneBC/wall3.1/BCDataSet/BCData.
DIFF: node Base/cart.15/ZoneBC/wall3.1/BCDataSet/BCData/fld1Z exists in reference but not in current.
DIFF: node Base/cart.15/ZoneBC/wall3.1/BCDataSet/BCData/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.15/FlowSolution#Centers.
DIFF: node Base/cart.15/FlowSolution#Centers/fld1Z exists in reference but not in current.
DIFF: node Base/cart.15/FlowSolution#Centers/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.16/ZoneBC/wall1.4/BCDataSet/BCData.
DIFF: node Base/cart.16/ZoneBC/wall1.4/BCDataSet/BCData/fld1Z exists in reference but not in current.
DIFF: node Base/cart.16/ZoneBC/wall1.4/BCDataSet/BCData/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.16/ZoneBC/wall2.4/BCDataSet/BCData.
DIFF: node Base/cart.16/ZoneBC/wall2.4/BCDataSet/BCData/fld1Z exists in reference but not in current.
DIFF: node Base/cart.16/ZoneBC/wall2.4/BCDataSet/BCData/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.16/ZoneBC/wall3.2/BCDataSet/BCData.
DIFF: node Base/cart.16/ZoneBC/wall3.2/BCDataSet/BCData/fld1Z exists in reference but not in current.
DIFF: node Base/cart.16/ZoneBC/wall3.2/BCDataSet/BCData/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.16/FlowSolution#Centers.
DIFF: node Base/cart.16/FlowSolution#Centers/fld1Z exists in reference but not in current.
DIFF: node Base/cart.16/FlowSolution#Centers/fld2Z exists in reference but not in current.
Reading Data_ubuntu/computeDiv2PT_t4.ref3 (bin_pickle)...done.
DIFF: longueur des fils differente pour le noeud: Base/cart.29/ZoneBC/wall1.5/BCDataSet/BCData.
DIFF: node Base/cart.29/ZoneBC/wall1.5/BCDataSet/BCData/fld1Z exists in reference but not in current.
DIFF: node Base/cart.29/ZoneBC/wall1.5/BCDataSet/BCData/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.29/ZoneBC/wall2.5/BCDataSet/BCData.
DIFF: node Base/cart.29/ZoneBC/wall2.5/BCDataSet/BCData/fld1Z exists in reference but not in current.
DIFF: node Base/cart.29/ZoneBC/wall2.5/BCDataSet/BCData/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.29/FlowSolution#Centers.
DIFF: node Base/cart.29/FlowSolution#Centers/fld1Z exists in reference but not in current.
DIFF: node Base/cart.29/FlowSolution#Centers/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.30/ZoneBC/wall1.6/BCDataSet/BCData.
DIFF: node Base/cart.30/ZoneBC/wall1.6/BCDataSet/BCData/fld1Z exists in reference but not in current.
DIFF: node Base/cart.30/ZoneBC/wall1.6/BCDataSet/BCData/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.30/ZoneBC/wall2.6/BCDataSet/BCData.
DIFF: node Base/cart.30/ZoneBC/wall2.6/BCDataSet/BCData/fld1Z exists in reference but not in current.
DIFF: node Base/cart.30/ZoneBC/wall2.6/BCDataSet/BCData/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.30/ZoneBC/wall3.3/BCDataSet/BCData.
DIFF: node Base/cart.30/ZoneBC/wall3.3/BCDataSet/BCData/fld1Z exists in reference but not in current.
DIFF: node Base/cart.30/ZoneBC/wall3.3/BCDataSet/BCData/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.30/FlowSolution#Centers.
DIFF: node Base/cart.30/FlowSolution#Centers/fld1Z exists in reference but not in current.
DIFF: node Base/cart.30/FlowSolution#Centers/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.31/ZoneBC/wall1.7/BCDataSet/BCData.
DIFF: node Base/cart.31/ZoneBC/wall1.7/BCDataSet/BCData/fld1Z exists in reference but not in current.
DIFF: node Base/cart.31/ZoneBC/wall1.7/BCDataSet/BCData/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.31/ZoneBC/wall2.7/BCDataSet/BCData.
DIFF: node Base/cart.31/ZoneBC/wall2.7/BCDataSet/BCData/fld1Z exists in reference but not in current.
DIFF: node Base/cart.31/ZoneBC/wall2.7/BCDataSet/BCData/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.31/ZoneBC/wall3.4/BCDataSet/BCData.
DIFF: node Base/cart.31/ZoneBC/wall3.4/BCDataSet/BCData/fld1Z exists in reference but not in current.
DIFF: node Base/cart.31/ZoneBC/wall3.4/BCDataSet/BCData/fld2Z exists in reference but not in current.
DIFF: longueur des fils differente pour le noeud: Base/cart.31/FlowSolution#Centers.
DIFF: node Base/cart.31/FlowSolution#Centers/fld1Z exists in reference but not in current.
DIFF: node Base/cart.31/FlowSolution#Centers/fld2Z exists in reference but not in current.
Reading Data_ubuntu/computeDiv2PT_t4.ref4 (bin_pickle)...done.
Reading Data_ubuntu/computeDiv2PT_t4.ref5 (bin_pickle)...done.
Warning: diff2: number of fields are different. Only common fields are compared.
Warning: diff2: number of fields are different. Only common fields are compared.
Warning: diff2: number of fields are different. Only common fields are compared.
Warning: diff2: number of fields are different. Only common fields are compared.
Warning: diff2: number of fields are different. Only common fields are compared.
Warning: diff2: number of fields are different. Only common fields are compared.

Elapsed CPU time: 0m0.59s
```