### PR TITLE
KCore: fix installBaseUser

### DIFF
--- a/Cassiopee/KCore/Dist.py
+++ b/Cassiopee/KCore/Dist.py
@@ -22,8 +22,17 @@ def setConfigDict(installDict=None):
     prod = os.getenv("ELSAPROD")
     if installDict is None:
         try: import KCore.installBase as installBase
-        except: import installBase
-        installDict = installBase.installDict
+        except ModuleNotFoundError: import installBase
+        try:
+            import KCore.installBaseUser as installBaseUser
+            installDictUser = installBaseUser.installDict
+        except ModuleNotFoundError:
+            try:
+                import installBaseUser as installBaseUser
+                installDictUser = installBaseUser.installDict
+            except ModuleNotFoundError:
+                installDictUser = {}
+        installDict = {**installDictUser, **installBase.installDict}
 
     cassProd = None
     # prod est tout d'abord cherche dans le dictionnaire
@@ -45,9 +54,10 @@ def setConfigDict(installDict=None):
             if prod in installDict: cassProd = prod
 
     if cassProd is None:  # not found in installDict
-        print(f"Warning: {prod} not found in KCore/installBase.py.")
-        print("Warning: using default compilers and options.")
-        print("Warning: to change that, add a block in KCore/installBase.py.")
+        print(f"Warning: {prod} not found in KCore/installBase.py nor "
+              "KCore/installBaseUser.py.\n"
+              "Warning: using default compilers and options.\n"
+              "Warning: to change that, add a block in KCore/installBase.py.")
         cassProd = 'default'
 
     CONFIGDICT = installDict[cassProd]

--- a/Cassiopee/KCore/installBase.py
+++ b/Cassiopee/KCore/installBase.py
@@ -5,18 +5,8 @@
 # additionalIncludePaths, additionalLibs, additionalLibPaths].
 # Paths are list of strings. useOMP, static, useCuda are booleans.
 # Others are strings.
-try:
-    from installBaseUser import installDict as installDictUser
-except ImportError:
-    try:
-        from . import installBaseUser
-        installDictUser = installBaseUser.installDict
-    except:
-        installDictUser = {}
 
 installDict = {
-    **installDictUser,
-
     'WDAAA728Z': {
         'description': 'Windows win64+msys2 (XJ-ONERA)',
         'f77compiler': 'gfortran',

--- a/Cassiopee/KCore/installer.py
+++ b/Cassiopee/KCore/installer.py
@@ -84,7 +84,7 @@ def saveConfigFile(event=None):
     try: additionalLibPaths = parseList(VadditionalLibPaths.get())
     except: additionalLibPaths = []
 
-    dict[machine] = [
+    installDict[machine] = [
         Vdescription.get(),
         Vf77compiler.get(),
         Vf90compiler.get(),
@@ -99,7 +99,7 @@ def saveConfigFile(event=None):
         False,
         []
     ]
-    userDict = {machine: dict[machine]}
+    userDict = {machine: installDict[machine]}
     Dist.writeInstallBase(userDict)
     return
 
@@ -128,12 +128,12 @@ def changeMachineName(event=None):
             entry.config(foreground=entry.master.cget('fg'))
 
     key = ''
-    for i in dict:
+    for i in installDict:
         if re.compile(i).search(machine) is not None:
             key = i; break
 
-    if key in dict: # already defined in install base
-        setVars(dict[key])
+    if key in installDict: # already defined in install base
+        setVars(installDict[key])
     else: setDefaultVars()
 
 #==============================================================================
@@ -292,8 +292,14 @@ def checkMpeg(event=None):
 
 #==============================================================================
 # Load install base
+try:
+    import installBaseUser
+    installDictUser = installBaseUser.installDict
+except ModuleNotFoundError:
+    installDictUser = {}
 import installBase
-dict = installBase.installDict
+installDict = {**installDictUser, **installBase.installDict}
+
 
 #==============================================================================
 # Get machine
@@ -323,7 +329,7 @@ WIDGETS = {}
 
 # Init
 key = ''
-for i in dict:
+for i in installDict:
     if (re.compile(i).search(host) is not None or
             re.compile(i).search(prod) is not None):
         key = i; break
@@ -331,8 +337,8 @@ for i in dict:
 if (re.compile(key).search(host) is not None): setMachineName(host)
 if (re.compile(key).search(prod) is not None): setMachineName(prod)
 
-if key in dict: # already defined in install base
-    setVars(dict[key])
+if key in installDict: # already defined in install base
+    setVars(installDict[key])
 
 #==============================================================================
 def instructions():
@@ -404,7 +410,7 @@ file.add_command(label='Save installBase', command=saveConfigFile)
 file.add_command(label='Quit', command=quit)
 machines = TK.Menu(menu, tearoff=0)
 menu.add_cascade(label='Machines', menu=machines)
-for i in dict:
+for i in installDict:
     machines.add_command(label=i, command=lambda i=i : setMachineName(i))
 master.config(menu=menu)
 help = TK.Menu(menu, tearoff=0)

--- a/Cassiopee/KCore/setup.py
+++ b/Cassiopee/KCore/setup.py
@@ -20,7 +20,15 @@ def loadModuleFromPath(modname):
 # Compiler settings must be set in installBase.py / installBaseUser.py
 Dist = loadModuleFromPath('Dist')
 installBase = loadModuleFromPath('installBase')
-Dist.setConfigDict(installBase.installDict)
+try:
+    installBaseUser = loadModuleFromPath("installBaseUser")
+    installDict = {
+        **installBaseUser.installDict,
+        **installBase.installDict,
+    }
+except ModuleNotFoundError:
+    installDict = installBase.installDict
+Dist.setConfigDict(installDict)
 additionalLibPaths = Dist.getAdditionalLibPaths()
 additionalIncludePaths = Dist.getAdditionalIncludePaths()
 additionalLibs = Dist.getAdditionalLibs()


### PR DESCRIPTION
This isn't too much work to import both installBase and installBaseUser in KCore/Dist and KCore/setup.py such that there is no longer a need to do

```
try:
    from installBaseUser import installDict as installDictUser
except ImportError:
    try:
        from . import installBaseUser
        installDictUser = installBaseUser.installDict
    except:
        installDictUser = {}
```

in KCore/installBase.py