### PR TITLE
Transform: add <array> include for gcc compiler

### DIFF
--- a/Cassiopee/Transform/Transform/consSmooth.cpp
+++ b/Cassiopee/Transform/Transform/consSmooth.cpp
@@ -20,6 +20,7 @@
 # include "transform.h"
 # include <algorithm>
 # include <random>
+# include <array>
 using namespace K_FLD;
 using namespace K_SEARCH;
 
@@ -175,7 +176,7 @@ bool buildRingAroundP(E_Int p, E_Int pStart, const std::vector<E_Int>& eltsOfP, 
     if (!found) return false; // boundary node
   }
 
-  if (ring.size() != nNbrs) return false;
+  if (ring.size() != static_cast<std::size_t>(nNbrs)) return false;
 
   // Check: ensure the last node properly closes the loop at pStart.
   E_Int last = ring.back();


### PR DESCRIPTION
No regression.

Small bug fix in consSmooth.cpp for gcc by adding `# include <array>`.
The juno_coda prod. wouldn't compile because of the way pNbrs was accessed on lines 129 to 131:

```cpp
  std::vector<std::array<E_Int,2>> pNbrs(nNbrs);

  // Extract the 2 nodes != p for each triangle.
  E_Int k = 0;
  for (E_Int elt : eltsOfP)
  {
    E_Int n0 = (*cn)(elt, 1) - 1;
    E_Int n1 = (*cn)(elt, 2) - 1;
    E_Int n2 = (*cn)(elt, 3) - 1;
    E_Int idx = 0;
    if (n0 != p) pNbrs[k][idx++] = n0;
    if (n1 != p) pNbrs[k][idx++] = n1;
    if (n2 != p) pNbrs[k][idx++] = n2;
    k++;
  }
```
I don't know if there is a better solution than adding an include at the beginning of the file...

I've also removed a warning by adding a static_cast to compare a .size() and an E_Int on line 179.