### PR TITLE
Converter: fix _updateElementRange: vol then surf, update BC ER

### DIFF
--- a/Cassiopee/Converter/Converter/Internal.py
+++ b/Cassiopee/Converter/Converter/Internal.py
@@ -3684,8 +3684,8 @@ def groupByFamily(t, familyChilds=None, unique=False):
 
 # -- retourne la dimension d'une grille NGON
 # Retourne -1 si la grille n'est pas NGON
-def getZoneDimNGon(zone):
-  def getCellDimNGon(ngon):
+def getCellDimNGon(zone):
+  def getCellDimNGon__(ngon):
     # NGON4
     data = getNodeFromName1(ngon, 'ElementStartOffset')
     if data is not None:
@@ -3708,10 +3708,10 @@ def getZoneDimNGon(zone):
   if not c: return 3
   elif len(c) == 1:
     if c[0][1][0] not in [22, 23]: return -1
-    return getCellDimNGon(c[0])
+    return getCellDimNGon__(c[0])
   eltNames = [eltNo2EltName(e[1][0])[0] for e in c]
   if "NGON" in eltNames and "NFACE" in eltNames:
-    return getCellDimNGon(c[eltNames.index("NGON")])
+    return getCellDimNGon__(c[eltNames.index("NGON")])
   return -1
 
 # -- retourne les dimensions et le type de la grille
@@ -3752,14 +3752,14 @@ def getZoneDim(zone):
           eltName, _, cellDim = eltNo2EltInfo(elt)
           if elt in [22, 23]: # NGON or NFACE
             eltName = 'NGON'
-            cellDim = getZoneDimNGon(zone)
+            cellDim = getCellDimNGon(zone)
           return [gtype, np, ne, eltName, cellDim]
         else: # lc >= 2:
           # Y a t-il NGON et NFACE? Si oui, renvoie NGON meme si il
           # y a des BEs
           eltNames = [eltNo2EltName(i[1][0])[0] for i in c]
           if "NGON" in eltNames and "NFACE" in eltNames:
-            cellDim = getZoneDimNGon(zone)
+            cellDim = getCellDimNGon(zone)
             return [gtype, np, ne, 'NGON', cellDim]
           else: # BE/ME
             cellDim = 0

--- a/Cassiopee/Converter/Converter/Internal.py
+++ b/Cassiopee/Converter/Converter/Internal.py
@@ -3682,6 +3682,38 @@ def groupByFamily(t, familyChilds=None, unique=False):
 # -- Get zone dims --
 #==============================================================================
 
+# -- retourne la dimension d'une grille NGON
+# Retourne -1 si la grille n'est pas NGON
+def getZoneDimNGon(zone):
+  def getCellDimNGon(ngon):
+    # NGON4
+    data = getNodeFromName1(ngon, 'ElementStartOffset')
+    if data is not None:
+      offsets = data[1]
+      if offsets is not None and offsets.size > 1:
+        if offsets[1] == 1: return 1
+        if offsets[1] == 2: return 2
+      return 3
+    # NGON3
+    data = getNodeFromName1(ngon, 'ElementConnectivity')
+    if data is not None:
+      conn = data[1]
+      if conn is not None and conn.size > 0:
+        if conn[0] == 1: return 1
+        if conn[0] == 2: return 2
+      return 3
+    return 3
+
+  c = getElementNodes(zone)
+  if not c: return 3
+  elif len(c) == 1:
+    if c[0][1][0] not in [22, 23]: return -1
+    return getCellDimNGon(c[0])
+  eltNames = [eltNo2EltName(e[1][0])[0] for e in c]
+  if "NGON" in eltNames and "NFACE" in eltNames:
+    return getCellDimNGon(c[eltNames.index("NGON")])
+  return -1
+
 # -- retourne les dimensions et le type de la grille
 # pour un noeud de Zone donne --
 # Retourne ['Structured', ni, nj, nk, celldim] pour une grille structuree
@@ -3718,40 +3750,16 @@ def getZoneDim(zone):
         elif lc == 1:
           elt = c[0][1][0]
           eltName, _, cellDim = eltNo2EltInfo(elt)
-          if elt == 22 or elt == 23: # NGON or NFACE
+          if elt in [22, 23]: # NGON or NFACE
             eltName = 'NGON'
-            data = getNodeFromName1(c[0], 'ElementStartOffset')
-            if data is not None: # NGON4
-              datar = data[1]
-              if datar is not None and len(datar)>1:
-                if datar[1] == 1: cellDim = 1
-                elif datar[1] == 2: cellDim = 2
-            else: # NGON3
-              data = getNodeFromName1(c[0], 'ElementConnectivity')
-              if data is not None and len(data)>0: datar = data[1]
-              if datar is not None and datar.size>0:
-                if datar[0] == 1: cellDim = 1
-                elif datar[0] == 2: cellDim = 2
+            cellDim = getZoneDimNGon(zone)
           return [gtype, np, ne, eltName, cellDim]
         else: # lc >= 2:
           # Y a t-il NGON et NFACE? Si oui, renvoie NGON meme si il
           # y a des BEs
           eltNames = [eltNo2EltName(i[1][0])[0] for i in c]
           if "NGON" in eltNames and "NFACE" in eltNames:
-            NGONp = c[eltNames.index("NGON")]
-            data = getNodeFromName1(NGONp, 'ElementStartOffset')
-            if data is not None and len(data)>0: datar = data[1]
-            else: datar = None
-            if datar is not None and datar.size>1:
-              if datar[1] == 1: cellDim = 1
-              elif datar[1] == 2: cellDim = 2
-              return [gtype, np, ne, 'NGON', cellDim]
-            data = getNodeFromName1(NGONp, 'ElementConnectivity')
-            if data is not None and len(data)>0: datar = data[1]
-            else: datar = None
-            if datar is not None and datar.size>0:
-              if datar[0] == 1: cellDim = 1
-              elif datar[0] == 2: cellDim = 2
+            cellDim = getZoneDimNGon(zone)
             return [gtype, np, ne, 'NGON', cellDim]
           else: # BE/ME
             cellDim = 0
@@ -4416,12 +4424,13 @@ def setElementConnectivity2(z, array):
 # Sert de reference a Cassiopee pour savoir si un Elements_t est volumique ou non
 def _setElementDim(z):
   GEl = getNodesFromType1(z, 'Elements_t')
-  if GEl == []: return []
-  dimElt = [eltNo2Dim(i[1][0]) for i in GEl]
+  if GEl == []: return
+  dimElt = [-1 if i[1][0] in [22, 23] else eltNo2Dim(i[1][0]) for i in GEl]
   maxdim = max(dimElt)
   for c, GE in enumerate(GEl):
-    if dimElt[c] == maxdim: GE[1][1] = 0
-    else: GE[1][1] = 1
+    if dimElt[c] == -1: continue  # skip NGon
+    elif dimElt[c] == maxdim: GE[1][1] = 0  # volumic
+    elif GE[1][1] == 0: GE[1][1] = 1  # surfacic, was yet unset
 
 # -- Retourne une liste des noeuds Elements_t volumiques d'une zone
 # Retourne [] si il n'y en a pas.
@@ -4469,14 +4478,34 @@ def getNFaceNode(z):
     if GE[1][0] == 23: return GE
   return None
 
-# -- Update la numerotation des ElementRanges dans l'ordre des connectivites
+# -- Update la numerotation des ElementRanges :
+#     - connectivites volumiques puis connectivites surfaciques
+#     - update les ElementRanges des BCs correspondantes
 def _updateElementRange(z):
+  _setElementDim(z)
   GEl = getNodesFromType1(z, 'Elements_t')
+  BCs = getNodesFromType2(z, 'BC_t')
+
+  iGEv = []; iGEs = []
+  for i, GE in enumerate(GEl):
+    if GE[1][1] == 0: iGEv.append(i)
+    else: iGEs.append(i)
+
   c = 0
-  for GE in GEl:
-    r = getNodeFromName1(GE, 'ElementRange')
+  for i in iGEv + iGEs:
+    r = getNodeFromName1(GEl[i], 'ElementRange')
     r[1] = numpy.copy(r[1]); a = r[1]
     size = a[1]-a[0]+1
+
+    for b in BCs:
+      rbc = getNodeFromType1(b, 'IndexRange_t')
+      if rbc is not None:
+        rbc[1] = numpy.copy(rbc[1]); abc = rbc[1]
+        abc = abc.ravel('k')
+        if abc[0] == a[0] and abc[1] == a[1]:
+          abc[0] = c+1; abc[1] = c+1+size
+          break
+
     a[0] = c+1; c += size; a[1] = c
   return None
 
@@ -4935,7 +4964,7 @@ def _adaptZoneBCEltRange2EltList(t):
   return None
 
 # input dict, t
-def getElementRangeDict(t, d):
+def _getElementRangeDict(t, d):
   zones = getZones(t)
   for z in zones:
     if z[0] not in d: d[z[0]] = {}
@@ -4944,6 +4973,7 @@ def getElementRangeDict(t, d):
       n = getNodeFromName1(e, 'ElementRange')
       if n is not None and n[1] is not None: d[z[0]][e[0]] = (n[1][0],n[1][1])
       else: d[z[0]][e[0]] = (1,1)
+  return None
 
 # input dict, index of a Elements of z
 # trouve la connectivite de zname referencee par ind
@@ -4979,7 +5009,7 @@ def _fixNGon(t, remove=False, breakBE=True, convertMIXED=True, addNFace=True, ap
     dictOfZTypes[z[0]] = stype
 
   shift0 = {}
-  getElementRangeDict(t, shift0)
+  _getElementRangeDict(t, shift0)
   for z in zones:
     stype = dictOfZTypes[z[0]]
     if stype == 2: # Unstructured
@@ -5075,7 +5105,7 @@ def _fixNGon(t, remove=False, breakBE=True, convertMIXED=True, addNFace=True, ap
 
   # Remet les BCs d'aplomb (en fonction de la renumerotation shift0->shift1)
   shift1 = {}
-  getElementRangeDict(t, shift1)
+  _getElementRangeDict(t, shift1)
   for z in zones:
     stype = dictOfZTypes[z[0]]
     if stype == 2: # Unstructured


### PR DESCRIPTION
Internal._updateElementRange updates the ER of volumic and surfacic BE conns.
It did not enforce volumic conns to be listed before any surfacic conns.
It did not update ERs in BC_t nodes

This patch does just that but isn't as thorough as: Internal._sortNodesInZone(z)

Regressions:
- Connector/prepAMRFull_m1.py   
- Connector/prepAMRFull_t1.py

```
Running prepAMRFull_m1.py with Nprocs=2 and Nthreads=12
Warning: naca: number of points must be odd.
Warning: naca: number of points set to 501.
Warning: naca: number of points must be odd.
Warning: naca: number of points set to 501.
0: AMR Mesh Generation...start [0 hr 0 min 0 sec][79.516000 MB]

[...]

Reading ./tIBM.cgns (bin_hdf)...Reading Data_ubuntu/prepAMRFull_m1.ref1 (bin_pickle)...done.
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/QuadNQuad/ElementRange.
DIFF: reference: [37851 45249]
DIFF: courant: [113567 120965]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/QuadNQuad/ElementRange.
DIFF: reference: [[37851 45249]]
DIFF: courant: [[113567 120966]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCFarfield.3/ElementRange.
DIFF: reference: [[45250 45253]]
DIFF: courant: [[37851 37855]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCFarfield.4/ElementRange.
DIFF: reference: [[45254 45257]]
DIFF: courant: [[37855 37859]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCFarfield.5/ElementRange.
DIFF: reference: [[45258 45265]]
DIFF: courant: [[37859 37867]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCSymmetryPlane.1/ElementRange.
DIFF: reference: [[45266 83115]]
DIFF: courant: [[37867 75717]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCSymmetryPlane.2/ElementRange.
DIFF: reference: [[ 83116 120965]]
DIFF: courant: [[ 75717 113567]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/BCFarfield/ElementRange.
DIFF: reference: [45250 45253]
DIFF: courant: [37851 37854]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/BCFarfield.0/ElementRange.
DIFF: reference: [45254 45257]
DIFF: courant: [37855 37858]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/BCFarfield.2/ElementRange.
DIFF: reference: [45258 45265]
DIFF: courant: [37859 37866]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/BCSymmetryPlane/ElementRange.
DIFF: reference: [45266 83115]
DIFF: courant: [37867 75716]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/BCSymmetryPlane.0/ElementRange.
DIFF: reference: [ 83116 120965]
DIFF: courant: [ 75717 113566]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/QuadNQuad/ElementRange.
DIFF: reference: [37857 45259]
DIFF: courant: [113585 120987]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/ZoneBC/QuadNQuad/ElementRange.
DIFF: reference: [[37857 45259]]
DIFF: courant: [[113585 120988]]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/ZoneBC/BCFarfield.3/ElementRange.
DIFF: reference: [[45260 45263]]
DIFF: courant: [[37857 37861]]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/ZoneBC/BCFarfield.4/ElementRange.
DIFF: reference: [[45264 45267]]
DIFF: courant: [[37861 37865]]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/ZoneBC/BCFarfield.5/ElementRange.
DIFF: reference: [[45268 45275]]
DIFF: courant: [[37865 37873]]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/ZoneBC/BCSymmetryPlane.1/ElementRange.
DIFF: reference: [[45276 83131]]
DIFF: courant: [[37873 75729]]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/ZoneBC/BCSymmetryPlane.2/ElementRange.
DIFF: reference: [[ 83132 120987]]
DIFF: courant: [[ 75729 113585]]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/BCFarfield/ElementRange.
DIFF: reference: [45260 45263]
DIFF: courant: [37857 37860]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/BCFarfield.0/ElementRange.
DIFF: reference: [45264 45267]
DIFF: courant: [37861 37864]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/BCFarfield.1/ElementRange.
DIFF: reference: [45268 45275]
DIFF: courant: [37865 37872]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/BCSymmetryPlane/ElementRange.
DIFF: reference: [45276 83131]
DIFF: courant: [37873 75728]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/BCSymmetryPlane.0/ElementRange.
DIFF: reference: [ 83132 120987]
DIFF: courant: [ 75729 113584]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/BCFarfield.
DIFF: reference: [7 0]
DIFF: courant: [7 1]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/BCFarfield.0.
DIFF: reference: [7 0]
DIFF: courant: [7 1]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/BCFarfield.1.
DIFF: reference: [7 0]
DIFF: courant: [7 1]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/BCSymmetryPlane.
DIFF: reference: [7 0]
DIFF: courant: [7 1]
DIFF: valeurs differentes pour le noeud: Proc1/Proc1/BCSymmetryPlane.0.
DIFF: reference: [7 0]
DIFF: courant: [7 1]
done.
Reading ./tIBM.cgns (bin_hdf)...done.
Reading Data_ubuntu/prepAMRFull_m1.ref2 (bin_pickle)...done.

Elapsed CPU time: 0m9.11s


Running prepAMRFull_t1.py with Nprocs=0 and Nthreads=24
0: AMR Mesh Generation...start [0 hr 0 min 0 sec][58.648000 MB]
[...]
Writing ./tIBM.cgns (bin_cgns)...done.
Reading ./tAMRMesh.cgns (bin_hdf)...done.
Reading ./tIBM.cgns (bin_hdf)...Reading Data_ubuntu/prepAMRFull_t1.ref1 (bin_pickle)...done.
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/QuadNQuad/ElementRange.
DIFF: reference: [[75707 90508]]
DIFF: courant: [[75707 90509]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCFarfield.3/ElementRange.
DIFF: reference: [[90509 90516]]
DIFF: courant: [[90509 90517]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCFarfield.4/ElementRange.
DIFF: reference: [[90517 90524]]
DIFF: courant: [[90517 90525]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCFarfield.5/ElementRange.
DIFF: reference: [[90525 90532]]
DIFF: courant: [[90525 90533]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCFarfield.6/ElementRange.
DIFF: reference: [[90533 90540]]
DIFF: courant: [[90533 90541]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCSymmetryPlane.1/ElementRange.
DIFF: reference: [[ 90541 166246]]
DIFF: courant: [[ 90541 166247]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCSymmetryPlane.2/ElementRange.
DIFF: reference: [[166247 241952]]
DIFF: courant: [[166247 241953]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/BCFarfield.
DIFF: reference: [7 0]
DIFF: courant: [7 1]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/BCFarfield.0.
DIFF: reference: [7 0]
DIFF: courant: [7 1]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/BCFarfield.1.
DIFF: reference: [7 0]
DIFF: courant: [7 1]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/BCFarfield.2.
DIFF: reference: [7 0]
DIFF: courant: [7 1]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/BCSymmetryPlane.
DIFF: reference: [7 0]
DIFF: courant: [7 1]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/BCSymmetryPlane.0.
DIFF: reference: [7 0]
DIFF: courant: [7 1]
Reading Data_ld/prepAMRFull_t1.ref2 (bin_pickle)...done.
done.

Elapsed CPU time: 0m10.06s
```