### PR TITLE
CPlot: validCassiopee: cleaning

### DIFF
--- a/Cassiopee/CPlot/apps/validCassiopee.py
+++ b/Cassiopee/CPlot/apps/validCassiopee.py
@@ -353,15 +353,14 @@ def setPaths():
         loc = kwargs.get('loc', 'LOCAL')
         if loc not in ['LOCAL', 'GLOBAL']: loc = 'LOCAL'
         if PREFS["validType"] == "regression":
-            notTested = ['Upmost', 'FastP']
             paths = list(args)[1:]
             for path in paths:
                 if path is None: continue
-                print('Info: getting {} module tests in: {}.'.format(loc.lower(), path))
+                print(f'Info: getting {loc.lower()} module tests in: {path}.')
                 try: mods = [entry.name for entry in os.scandir(path) if entry.is_dir()]
                 except: mods = []
                 for mod in mods:
-                    if mod not in notTested and mod not in MODULESDIR[loc]:
+                    if mod not in MODULESDIR[loc]:
                         if loc == 'GLOBAL' and mod not in MODULESDIR['LOCAL']:
                             # Skip modules which aren't found locally - would hang
                             continue
@@ -540,7 +539,7 @@ def runSingleTest(no, module, test, update=False):
     testName = module+'/'+test
     testr = os.path.splitext(test)
     if PREFS["validType"] == "validation":
-        path = os.path.join(modulesDir, testr[0]) # TODO
+        path = os.path.join(modulesDir, testr[0])
         test = "test.py"
         ncpus, nthreads = getCPUAndThreadFromUsageLine(os.path.join(path, test), 1)
         seq = True if ncpus == 1 else False
@@ -619,7 +618,7 @@ def runSingleTest(no, module, test, update=False):
         fileTime = os.path.join(
             MODULESDIR['LOCAL'][module], testr[0], DATA,
             testr[0] + ".time"
-        ) # TODO
+        )
     else:
         fileTime = os.path.join(
             MODULESDIR['LOCAL'][module], module, 'test', DATA,
@@ -1132,7 +1131,7 @@ def viewTest(event=None):
         module = splits[0].strip()
         test = splits[1].strip()
         modulesDir = MODULESDIR[BASE4COMPARE][module]
-        if PREFS["validType"] == "validation": #TODO
+        if PREFS["validType"] == "validation":
             pathl = os.path.join(modulesDir, test)
             testFile = 'test.py'
         else:

--- a/Cassiopee/CPlot/apps/validCassiopee.py
+++ b/Cassiopee/CPlot/apps/validCassiopee.py
@@ -460,15 +460,10 @@ def getCFDBaseTests(module):
     except: reps = []
     tests = []
     for r in reps:
-        if not os.access(os.path.join(path, r, ".validignore"), os.F_OK):
-            tests.append(r)
-        """if r == 'NACA': tests.append(r) # MB 2D Euler
-        elif r == 'NACA_IBC': tests.append(r) # IBC 2D Euler
-        elif r == 'DAUPHIN': tests.append(r) # MB 3D Euler
-        elif r == 'FLATPLATE': tests.append(r) # MB 3D SA
-        elif r == 'RAE2822': tests.append(r) # MB 2D SA
-        elif r == 'RAE2822_IBC': tests.append(r) # IBC 2D SA
-        elif r == 'CUBE_IBC': tests.append(r) # IBC 3D SA"""
+        if (
+            os.access(os.path.join(path, r, "test.py"), os.F_OK)
+            and not os.access(os.path.join(path, r, ".validignore"), os.F_OK)
+        ): tests.append(r)
     return sorted(tests)
 
 #==============================================================================
@@ -502,7 +497,7 @@ def writeFinal(filename, gitInfo="", logTxt=None, append=False):
         if logTxt is not None: f.write(logTxt+'\n')
 
 #==============================================================================
-# Read un fichier star
+# Read a star file
 #==============================================================================
 def readStar(fileStar):
     star = ' '
@@ -513,122 +508,50 @@ def readStar(fileStar):
     return star
 
 #==============================================================================
+# Read the first line of a test case: if 'kpython -n . -t .' is found, use that
+# as the number of procs and threads
+#==============================================================================
+def getCPUAndThreadFromUsageLine(fileName, ncpus=2):
+    nsysThreads = KCore.kcore.getOmpMaxThreads()
+    nsysThreads = int(Threads.get())
+    nthreads = nsysThreads
+    with open(fileName, "r") as f: firstLine = f.readline().strip()
+    if "Usage: kpython" in firstLine:
+        try:
+            ncpus = int(firstLine.split("-n")[1].split()[0])
+            ncpus = min(max(ncpus, 1), nsysThreads)
+        except (IndexError, ValueError): pass
+        try: nthreads = int(firstLine.split("-t")[1].split()[0])
+        except (IndexError, ValueError): pass
+    nmaxThreads = nsysThreads//ncpus
+    nthreads = max(min(nthreads, nmaxThreads), 1)
+    return str(ncpus), str(nthreads)
+
+#==============================================================================
 # Lance un seul test unitaire ou un cas de la base de validation
 #==============================================================================
 def runSingleTest(no, module, test, update=False):
-    if PREFS["validType"] == "validation":
-        return runSingleCFDTest(no, module, test, update)
-    return runSingleUnitaryTest(no, module, test, update)
-
-#==============================================================================
-# extrait le temps CPU d'un chaine output (utile sur windows)
-# retourne le temps CPU comme une chaine
-# moyenne si plusieurs repetitions d'un meme cas unitaire
-#==============================================================================
-def extractCPUTimeWindows(output1, output2):
-    CPUtime = 'Unknown'
-    try:
-        split1 = output1.split(':')
-        h1 = int(split1[0])
-        m1 = int(split1[1])
-        s1 = split1[2]; s1 = s1.split(',')
-        ms1 = int(s1[1])
-        s1 = int(s1[0])
-        t1 = h1*3600. + m1*60. + s1 + 0.01*ms1
-        split2 = output2.split(':')
-        h2 = int(split2[0])
-        m2 = int(split2[1])
-        s2 = split2[2]; s2 = s2.split(',')
-        ms2 = int(s2[1])
-        s2 = int(s2[0])
-        t2 = h2*3600. + m2*60. + s2 + 0.01*ms2
-        tf = (t2-t1)
-        hf = int(tf/3600.)
-        tf = tf - 3600*hf
-        mf = int(tf/60.)
-        tf = tf - 60*mf
-        sf = int(tf*100)/100.
-        if hf > 0: CPUtime = '%dh%dm%gs'%(hf,mf,sf)
-        else: CPUtime = '%dm%gs'%(mf,sf)
-    except: pass
-    return CPUtime
-
-#=============================================================================
-# Extrait le temps CPU d'une sortie time -p (unix)
-#=============================================================================
-def extractCPUTimeUnix(output):
-    CPUtime = 'Unknown'
-    try:
-        i1 = output.find('real')
-        if i1 == -1: # external time command
-            i1 = output.find('elapsed')
-            output = output[:i1+7].strip().replace(',', '.')
-            output = re.split('\n| ', output)
-            output = [s for s in output if s.endswith('elapsed')][0]
-            output = re.sub('[a-z]', "", output)
-        else: # shell built-in time command (shell keyword)
-            output = output[i1+4:].strip()
-            output = output.replace(',', '.').replace('s', '')
-            output = re.sub('[h,m]', ':', output)
-            output = re.split('\n|\t| ', output)[0]
-        output = output.split(':')
-        output = output[::-1]
-        dt = [1., 60., 3600.]
-        tf = 0.
-        for i in range(len(output)):
-            tf += dt[i]*float(output[i])
-        hf = tf//3600
-        tf = tf%3600
-        output = [int(hf), int(tf//60), float(tf%60)]
-        if hf > 0.: CPUtime = '{:d}h{:d}m{:.2f}'.format(*output)
-        elif output[1] > 0.: CPUtime = '{:d}m{:.2f}'.format(*output[1:])
-        else: CPUtime = '0m{:.2f}'.format(output[-1])
-        CPUtime = CPUtime.rstrip('0').rstrip('.') + 's'
-    except: pass
-    return CPUtime
-
-#=============================================================================
-# Format the CPU time
-#=============================================================================
-def formatCPUTime(cpuTime):
-    hf = cpuTime//3600
-    tf = cpuTime%3600
-    output = [int(hf), int(tf//60), float(tf%60)]
-    if hf > 0.: cpuTimeStr = '{:d}h{:d}m{:.2f}'.format(*output)
-    elif output[1] > 0.: cpuTimeStr = '{:d}m{:.2f}'.format(*output[1:])
-    else: cpuTimeStr = '0m{:.2f}'.format(output[-1])
-    cpuTimeStr = cpuTimeStr.rstrip('0').rstrip('.') + 's'
-    return cpuTimeStr
-
-#==============================================================================
-# Lance un seul test unitaire de module
-#==============================================================================
-def runSingleUnitaryTest(no, module, test, update=False):
     global TESTS
-    testr = os.path.splitext(test)
-    modulesDir = MODULESDIR[BASE4COMPARE][module]
-    path = os.path.join(modulesDir, module, 'test')
-    testName = os.path.join(module, test)
-
-    seq = expTest1.search(test) # seq (True) ou distribue (False)
-    nthreads = KCore.kcore.getOmpMaxThreads()
-    nthreads = int(Threads.get())
     env = os.environ.copy()
-
+    modulesDir = MODULESDIR[BASE4COMPARE][module]
     if mySystem == 'mingw' or mySystem == 'windows':
-        path = path.replace('/', '\\')
-    if not seq:
-        # Read the first line of the test. If 'kpython -n...' is found, use that
-        # number of procs
-        ncpus = 2
-        with open(os.path.join(path, test), "r") as f:
-            firstLine = f.readline().strip()
-        if "Usage: kpython -n" in firstLine:
-            try: ncpus = int(firstLine.split("kpython -n")[1].split()[0])
-            except (IndexError, ValueError): pass
-        nthreads = nthreads//ncpus
-        ncpus = str(ncpus)
-    nthreads = str(nthreads)
+        modulesDir = modulesDir.replace('/', '\\')
+
+    testName = module+'/'+test
+    testr = os.path.splitext(test)
+    if PREFS["validType"] == "validation":
+        path = os.path.join(modulesDir, testr[0]) # TODO
+        test = "test.py"
+        ncpus, nthreads = getCPUAndThreadFromUsageLine(os.path.join(path, test), 1)
+        seq = True if ncpus == 1 else False
+    else:
+        path = os.path.join(modulesDir, module, 'test')
+        seq = expTest1.search(test)  # seq (True) ou distribue (False)
+        if seq:
+            nthreads = KCore.kcore.getOmpMaxThreads()
+            nthreads = str(Threads.get())
+        else:
+            ncpus, nthreads = getCPUAndThreadFromUsageLine(os.path.join(path, test), 2)
 
     env["OMP_NUM_THREADS"] = nthreads
     if mySystem == 'mingw' or mySystem == 'windows':
@@ -692,123 +615,21 @@ def runSingleUnitaryTest(no, module, test, update=False):
         success = 1; CPUtime = 'Unknown'; coverage='0%' # Core dump/error
 
     # update le fichier .time (si non present)
-    fileTime = os.path.join(
-        MODULESDIR['LOCAL'][module], module, 'test', DATA,
-        testr[0] + ".time"
-    )
-    if not os.access(fileTime, os.F_OK):
-        writeTime(fileTime, CPUtime, coverage)
-
-    if update or (testName not in TESTMETA) or (not TESTMETA[testName]['ref']):  # Update test metadata
-        updateTestMetadata(module, test, CPUtime)
-
-    # Recupere le tag local
-    tag = TESTMETA[testName]['tag']
-
-    # update status
-    if success == 0: status = 'OK'
-    elif success == 2: status = 'MEMLEAK'
-    elif success == 3: status = 'TIMEOUT'
-    else: status = 'FAILED'
-    s = buildString(module, test, CPUtime, coverage, status, tag)
-    regTest = re.compile(' '+test+' ')
-    regModule = re.compile(module+' ')
-    for c, tt in enumerate(TESTS):
-        if regModule.search(tt) is not None:
-            if regTest.search(tt) is not None: TESTS[c] = s; break
-    Listbox.delete(no, no)
-    Listbox.insert(no, s)
-    Listbox.update()
-    CPUtime = string2Time(CPUtime)
-    return CPUtime
-
-#==============================================================================
-# Lance un seul test de la base CFD
-# test = nom du repertoire du cas CFD
-#==============================================================================
-def runSingleCFDTest(no, module, test, update=False):
-    global TESTS
-    path = os.path.join(MODULESDIR[BASE4COMPARE][module], test)
-    testName = os.path.join(module, test)
-    print(f'Info: Running CFD test {testName}.')
-
-    seq = True
-    # force mpi test pour certains cas
-    if test == 'RAE2822_IBC': seq = False
-
-    if not seq:
-        try: import mpi4py
-        except: seq = True
-
-    nthreads = KCore.kcore.getOmpMaxThreads()
-    nthreads = int(Threads.get())
-    env = os.environ.copy()
-
-    if mySystem == 'mingw' or mySystem == 'windows':
-        path = path.replace('/', '\\')
-    if not seq:
-        # Read the first line of the test. If 'kpython -n...' is found, use that
-        # number of procs
-        ncpus = 2
-        with open(os.path.join(path, test), "r") as f:
-            firstLine = f.readline().strip()
-        if "Usage: kpython -n" in firstLine:
-            try: ncpus = int(firstLine.split("kpython -n")[1].split()[0])
-            except (IndexError, ValueError): pass
-        nthreads = nthreads//ncpus
-        ncpus = str(ncpus)
-    nthreads = str(nthreads)
-
-    env["OMP_NUM_THREADS"] = nthreads
-    if seq:
-        cmd = ["./valid", "check"]
+    if PREFS["validType"] == "validation":
+        fileTime = os.path.join(
+            MODULESDIR['LOCAL'][module], testr[0], DATA,
+            testr[0] + ".time"
+        ) # TODO
     else:
-        cmd = ["./valid", "check", "0", "0", "0", ncpus, nthreads]
-    try:
-        t0 = time.perf_counter()
-        output = checkOutput(cmd, path=path, env=env, stderr=subprocess.STDOUT)
-        t1 = time.perf_counter()
-        output = output.decode()
-        print(output)
-
-        # Format the CPU time
-        CPUtime = formatCPUTime(t1-t0)
-        print(f"Elapsed CPU time: {CPUtime}")
-
-        # Recupere success/failed
-        success = 0
-        if regLeakError.search(output) is not None: success = 2 # always check first
-        if regDiff.search(output) is not None: success = 1
-        if regFailed.search(output) is not None: success = 1
-        if regError.search(output) is not None: success = 1
-
-        # Recupere le coverage
-        coverage = '100%'
-
-    except subprocess.TimeoutExpired:
-        # killed here because timeout of communicate doesnt kill child processes
-        if mySystem == 'mingw' or mySystem == 'windows':
-            subprocess.call(['taskkill', '/F', '/T', '/PID', str(PROCESS.pid)])
-        else: # unix
-            # try soft, then hard
-            os.killpg(os.getpgid(PROCESS.pid), signal.SIGTERM)
-            os.kill(PROCESS.pid, signal.SIGTERM)
-            os.killpg(os.getpgid(PROCESS.pid), signal.SIGKILL)
-            os.kill(PROCESS.pid, signal.SIGKILL)
-        print('\nError: process TIMED OUT (killed).')
-        success = 3; CPUtime = 'Unknown'; coverage='0%'
-
-    except Exception as e:
-        print(e)
-        success = 1; CPUtime = 'Unknown'; coverage='0%' # Core dump/error
-
-    # update le fichier .time (si non present)
-    fileTime = os.path.join(path, DATA, test + ".time")
+        fileTime = os.path.join(
+            MODULESDIR['LOCAL'][module], module, 'test', DATA,
+            testr[0] + ".time"
+        )
     if not os.access(fileTime, os.F_OK):
         writeTime(fileTime, CPUtime, coverage)
 
     if update or (testName not in TESTMETA) or (not TESTMETA[testName]['ref']):  # Update test metadata
-        updateTestMetadata(module, test, CPUtime)
+        updateTestMetadata(*testName.split("/"), CPUtime)
 
     # Recupere le tag local
     tag = TESTMETA[testName]['tag']
@@ -818,8 +639,8 @@ def runSingleCFDTest(no, module, test, update=False):
     elif success == 2: status = 'MEMLEAK'
     elif success == 3: status = 'TIMEOUT'
     else: status = 'FAILED'
-    s = buildString(module, test, CPUtime, coverage, status, tag)
-    regTest = re.compile(' '+test+' ')
+    s = buildString(*testName.split("/"), CPUtime, coverage, status, tag)
+    regTest = re.compile(f" {testName.split('/')[1]} ")
     regModule = re.compile(module+' ')
     for c, tt in enumerate(TESTS):
         if regModule.search(tt) is not None:
@@ -829,6 +650,19 @@ def runSingleCFDTest(no, module, test, update=False):
     Listbox.update()
     CPUtime = string2Time(CPUtime)
     return CPUtime
+
+#=============================================================================
+# Format the CPU time
+#=============================================================================
+def formatCPUTime(cpuTime):
+    hf = cpuTime//3600
+    tf = cpuTime%3600
+    output = [int(hf), int(tf//60), float(tf%60)]
+    if hf > 0.: cpuTimeStr = '{:d}h{:d}m{:.2f}'.format(*output)
+    elif output[1] > 0.: cpuTimeStr = '{:d}m{:.2f}'.format(*output[1:])
+    else: cpuTimeStr = '0m{:.2f}'.format(output[-1])
+    cpuTimeStr = cpuTimeStr.rstrip('0').rstrip('.') + 's'
+    return cpuTimeStr
 
 #==============================================================================
 # Recupere le nbre de tests selectionnes et le temps total correspondant
@@ -923,8 +757,8 @@ def fillTestMetadata():
             modulesDirCmp = MODULESDIR[BASE4COMPARE][module]
             modulesDirLoc = MODULESDIR['LOCAL'][module]
             if PREFS["validType"] == "validation":
-                fileTime = os.path.join(modulesDirCmp, test, DATA, test+'.time')
-                fileStar = os.path.join(modulesDirLoc, test, DATA, test+'.star')
+                fileTime = os.path.join(modulesDirCmp, test, DATA, testr[0]+'.time')
+                fileStar = os.path.join(modulesDirLoc, test, DATA, testr[0]+'.star')
             else:
                 testr = os.path.splitext(test)
                 fileTime = os.path.join(modulesDirCmp, module, 'test', DATA, testr[0]+'.time')
@@ -1298,9 +1132,9 @@ def viewTest(event=None):
         module = splits[0].strip()
         test = splits[1].strip()
         modulesDir = MODULESDIR[BASE4COMPARE][module]
-        if PREFS["validType"] == "validation":
+        if PREFS["validType"] == "validation": #TODO
             pathl = os.path.join(modulesDir, test)
-            testFile = 'compute.py'
+            testFile = 'test.py'
         else:
             pathl = os.path.join(modulesDir, module, 'test')
             testFile = test
@@ -1444,6 +1278,7 @@ def showFaster():
     Scrollbar.config(command=Listbox.yview)
     Filter.set(''); TextFilter.update()
     return True
+
 def showFasterP():
     Listbox.delete(0, 'end')
     for s in TESTS:
@@ -1474,6 +1309,7 @@ def showSlower():
     Scrollbar.config(command=Listbox.yview)
     Filter.set(''); TextFilter.update()
     return True
+
 def showSlowerP():
     Listbox.delete(0, 'end')
     for s in TESTS:


### PR DESCRIPTION
Please **SQUASH**

- Clean / simplify
- Fix a few paths
- Create function to read nprocs and nthreads from usage line

Points of discussion:
- Test case script name: currently test.py and the parent folder is the the test case name. For example: Validation/CFDBase/IBM/airfoil/test.py: IBM is the module name and airfoil is the test name

Drawbacks:
output from kpython 
`Running chunk2partPT_m2.py with Nprocs=2 and Nthreads=24`
becomes 
`Running  test.py with Nprocs=2 and Nthreads=24`

Can't filter parallel tests: the number of procs is in the usage line (default: seq). Should we keep _t.py, _m.py?