### PR TITLE
KCore: remove recursive calls in KdTree __getInBox and __seek_closest

### DIFF
--- a/Cassiopee/KCore/KCore/Nuga/include/KdTree.cxx
+++ b/Cassiopee/KCore/KCore/Nuga/include/KdTree.cxx
@@ -627,32 +627,88 @@ void K_SEARCH::KdTree<CoordArrayType>::__getClosest_through_path(size_type n, co
   }
 }
 
-template <typename CoordArrayType>
-void K_SEARCH::KdTree<CoordArrayType>::__seek_closest
-(size_type n, const E_Float *Xn, size_type ci, size_type axis, E_Float& d2, size_type& m) const
-{
-  if (ci == IDX_NONE) return;
-  const size_type* Ni = _tree.begin() + 3 * ci;// pointer to the ith _tree's node.
+// template <typename CoordArrayType>
+// void K_SEARCH::KdTree<CoordArrayType>::__seek_closest
+// (size_type n, const E_Float *Xn, size_type ci, size_type axis, E_Float& d2, size_type& m) const
+// {
+//   if (ci == IDX_NONE) return;
+//   const size_type* Ni = _tree.begin() + 3 * ci;// pointer to the ith _tree's node.
   
-  E_Float D = (Xn[axis] - _posAcc.getVal(*Ni, axis));
+//   E_Float D = (Xn[axis] - _posAcc.getVal(*Ni, axis));
 
-  if ((D*D) >= d2)
+//   if ((D*D) >= d2)
+//   {
+//     if (D < 0)
+//       __seek_closest(n, Xn, *(Ni+1), (axis+1)%_dim, d2, m); //left traversal
+//     else
+//       __seek_closest(n, Xn, *(Ni+2), (axis+1)%_dim, d2, m); //right traversal
+//   }
+//   else
+//   {
+//     E_Float di2 = _posAcc.dist2(n, *Ni);
+//     if ((di2 < d2) && ( n != *Ni))
+//     {
+// 		  d2 = di2;
+// 		  m = *Ni;
+// 	  }
+//     __seek_closest(n, Xn, *(Ni+1), (axis+1)%_dim, d2, m); //left traversal
+//     __seek_closest(n, Xn, *(Ni+2), (axis+1)%_dim, d2, m); //right traversal
+//   }
+// }
+
+template <typename CoordArrayType>
+void K_SEARCH::KdTree<CoordArrayType>::__seek_closest(
+  size_type n, const E_Float *Xn, size_type root, size_type axis,
+  E_Float& d2, size_type& m) const
+{
+  if (root == IDX_NONE) return;
+
+  struct StackEntry
   {
-    if (D < 0)
-      __seek_closest(n, Xn, *(Ni+1), (axis+1)%_dim, d2, m); //left traversal
-    else
-      __seek_closest(n, Xn, *(Ni+2), (axis+1)%_dim, d2, m); //right traversal
-  }
-  else
+    size_type node;
+    size_type axis;
+  };
+
+  // KD-tree depth is log2(N), 64 is enough for all meshes
+  StackEntry stack[64];
+  E_Int top = 0;
+
+  stack[top++] = {root, axis};
+
+  while (top > 0)
   {
-    E_Float di2 = _posAcc.dist2(n, *Ni);
-    if ((di2 < d2) && ( n != *Ni))
+    StackEntry current = stack[--top];
+    size_type ci = current.node;
+    if (ci == IDX_NONE) continue;
+
+    const size_type* Ni = _tree.begin() + 3 * ci;
+    size_type ax = current.axis;
+    E_Float D = Xn[ax] - _posAcc.getVal(*Ni, ax);
+
+    size_type left  = *(Ni+1);
+    size_type right = *(Ni+2);
+    size_type nextAxis = ax+1 == _dim ? 0 : ax+1;
+
+    if (D*D >= d2)
     {
-		  d2 = di2;
-		  m = *Ni;
-	  }
-    __seek_closest(n, Xn, *(Ni+1), (axis+1)%_dim, d2, m); //left traversal
-    __seek_closest(n, Xn, *(Ni+2), (axis+1)%_dim, d2, m); //right traversal
+      // Only one branch can possibly contain a closer point
+      if (D < 0) stack[top++] = {left, nextAxis};
+      else stack[top++] = {right, nextAxis};
+    }
+    else
+    {
+      // Check current node
+      E_Float di2 = _posAcc.dist2(n, *Ni);
+      if ((di2 < d2) && (n != *Ni))
+      {
+        d2 = di2;
+        m = *Ni;
+      }
+
+      // Search both branches
+      stack[top++] = {right, nextAxis};
+      stack[top++] = {left, nextAxis};
+    }
   }
 }
 
@@ -736,34 +792,58 @@ void K_SEARCH::KdTree<CoordArrayType>::__seek_closest
 }
 
 template <typename CoordArrayType>
-void K_SEARCH::KdTree<CoordArrayType>::__getInBox
-(size_type ci, size_type axis, const E_Float* mBox, const E_Float* MBox, std::vector<size_type>& out) const
+void K_SEARCH::KdTree<CoordArrayType>::__getInBox(
+  size_type root, size_type axis, const E_Float* mBox, const E_Float* MBox,
+  std::vector<size_type>& out) const
 {
-  if (ci == IDX_NONE) return;
+  if (root == IDX_NONE) return;
 
-	const size_type* Ni = _tree.begin() + 3 * ci;// pointer to the ith _tree's node.
-
-  E_Float xi = _posAcc.getVal(*Ni, axis);
-
-  bool do_left = (mBox[axis] <= xi);
-  bool do_right = (xi <= MBox[axis]);
-
-  if (do_left && do_right) // might be in so do the complete checking
+  struct StackEntry
   {
-    bool is_in = true;
-    size_type ax = (axis+1)%_dim;
-    for (E_Int j = 0; j < _dim-1; ++j)
-    {
-      is_in &= ((mBox[ax] <= _posAcc.getVal(*Ni, ax)) && (_posAcc.getVal(*Ni, ax) <= MBox[ax]));
-      ax = (ax+1)%_dim;
-    }
-    if (is_in)
-      out.push_back(*Ni);
-  }
+    size_type node;
+    size_type axis;
+  };
 
-  if (do_left) // left search
-    __getInBox(*(Ni+1), (axis+1)%_dim, mBox, MBox, out);
-  if (do_right) //right search
-    __getInBox(*(Ni+2), (axis+1)%_dim, mBox, MBox, out);
+  StackEntry stack[64];
+  E_Int top = 0;
+
+  stack[top++] = {root, axis};
+
+  while (top > 0)
+  {
+    StackEntry current = stack[--top];
+    size_type ci = current.node;
+    if (ci == IDX_NONE) continue;
+
+    const size_type* Ni = _tree.begin() + 3 * ci;
+    size_type ax = current.axis;
+    E_Float xi = _posAcc.getVal(*Ni, ax);
+
+    E_Bool do_left = mBox[ax] <= xi;
+    E_Bool do_right = xi <= MBox[ax];
+
+    if (do_left && do_right)
+    {
+      E_Bool is_in = true;
+      size_type ax2 = ax + 1;
+      if (ax2 == _dim) ax2 = 0;
+
+      for (E_Int j = 0; j < _dim-1; j++)
+      {
+        E_Float v = _posAcc.getVal(*Ni, ax2);
+        if (v < mBox[ax2] || v > MBox[ax2]) { is_in = false; break; }
+        ax2++;
+        if (ax2 == _dim) ax2 = 0;
+      }
+
+      if (is_in) out.push_back(*Ni);
+    }
+
+    size_type nextAxis = ax+1;
+    if (nextAxis == _dim) nextAxis = 0;
+
+    if (do_right) stack[top++] = {*(Ni+2), nextAxis};
+    if (do_left) stack[top++] = {*(Ni+1), nextAxis};
+  }
 }
 #endif


### PR DESCRIPTION
No regressions

I will let you delete the recursive functions.

__getInBox called in getInSphere, thus closeMesh/rmOverlappingPts

No noticeable perf. improvement

```py
import Converter.PyTree as C
import Converter.Internal as Internal
import Generator.PyTree as G
import time

N = 300

a = G.cartNGon((0., 0., 0.), (0.1, 0.1, 0.1), (N, N, N), api=3)
t0 = time.perf_counter()
G._close(a, rmOverlappingPts=True, rmOrphanPts=False,
         rmDuplicatedFaces=False, rmDuplicatedElts=False,
         rmDegeneratedFaces=False, rmDegeneratedElts=False,)
t1 = time.perf_counter()
print(f"Elapsed time {t1-t0:.3f}")

# Elapsed time 39.726 - recursive
# Elapsed time 40.088 - non recursive
```

Future work: make __insert non recursive