### PR TITLE
CPlot: validCassiopee: CFDBase: change test name and timeout

### DIFF
--- a/Cassiopee/CPlot/apps/validCassiopee.py
+++ b/Cassiopee/CPlot/apps/validCassiopee.py
@@ -275,14 +275,17 @@ def checkOutput(cmd, path='.', env=None, stderr=None):
                                    stderr=subprocess.PIPE, cwd=path,
                                    env=env, preexec_fn=ossid)
 
-        # max accepted time is between 2 to 6 minutes
+        # Max accepted time is between 2 to 6 minutes for unit tests and 1 hour
+        # for validation tests
         nthreads = float(Threads.get())
-        timeout = (100. + 120.*Dist.DEBUG)*(1. + 4.8/nthreads)
+        if PREFS["validType"] == "regression":
+            timeout = (100. + 120.*Dist.DEBUG)*(1. + 4.8/nthreads)
+        else: timeout = 3600.
         stdout, stderr = PROCESS.communicate(None, timeout=timeout)
 
         if PROCESS.wait() != 0:
             stderr += b'\nError: process FAILED (Segmentation Fault or floating point exception).'
-        PROCESS = None # fini!
+        PROCESS = None # done!
         return stdout+stderr
     else:
         raise ValueError(f"validCassiopee: checkOutput: mode {mode} not supported")

--- a/Cassiopee/CPlot/apps/validCassiopee.py
+++ b/Cassiopee/CPlot/apps/validCassiopee.py
@@ -460,7 +460,7 @@ def getCFDBaseTests(module):
     tests = []
     for r in reps:
         if (
-            os.access(os.path.join(path, r, "test.py"), os.F_OK)
+            os.access(os.path.join(path, r, f"{r}.py"), os.F_OK)
             and not os.access(os.path.join(path, r, ".validignore"), os.F_OK)
         ): tests.append(r)
     return sorted(tests)
@@ -540,7 +540,7 @@ def runSingleTest(no, module, test, update=False):
     testr = os.path.splitext(test)
     if PREFS["validType"] == "validation":
         path = os.path.join(modulesDir, testr[0])
-        test = "test.py"
+        test = f"{testr[0]}.py"
         ncpus, nthreads = getCPUAndThreadFromUsageLine(os.path.join(path, test), 1)
         seq = True if ncpus == 1 else False
     else:
@@ -1133,7 +1133,7 @@ def viewTest(event=None):
         modulesDir = MODULESDIR[BASE4COMPARE][module]
         if PREFS["validType"] == "validation":
             pathl = os.path.join(modulesDir, test)
-            testFile = 'test.py'
+            testFile = f"{test}.py"
         else:
             pathl = os.path.join(modulesDir, module, 'test')
             testFile = test


### PR DESCRIPTION
CPlot: validCassiopee: CFDBase:
- test name should be that of the working folder
- change timeout to 1h

For example: Validation/CFDBase/IBM/naca/naca.py
-> module name: IBM
-> test name: naca (I could add .py if you want)

Careful with the capitalization @antjost 