### PR TITLE
Converter: fix bug in updateElementRange for BCs

### DIFF
--- a/Cassiopee/Converter/Converter/Internal.py
+++ b/Cassiopee/Converter/Converter/Internal.py
@@ -4325,7 +4325,7 @@ def setElementConnectivity2(z, array):
       i = numpy.empty((2), E_NpyInt); i[0] = 1; i[1] = gc.shape[0]
       info[2].append(['ElementRange', i, [], 'IndexRange_t'])
       info[2].append(['ElementConnectivity', gc.ravel("k"), [], 'DataArray_t'])
-      _updateElementRange(z)
+    _updateElementRange(z)
   else: # Faces->Nodes and Elements->Faces connectivities (NGON or NFACE)
     i = numpy.empty((2), E_NpyInt); i[0] = etype0; i[1] = 0
     #i = numpy.empty((2), numpy.int32); i[0] = etype0; i[1] = 0 # force I4
@@ -4503,7 +4503,7 @@ def _updateElementRange(z):
         rbc[1] = numpy.copy(rbc[1]); abc = rbc[1]
         abc = abc.ravel('k')
         if abc[0] == a[0] and abc[1] == a[1]:
-          abc[0] = c+1; abc[1] = c+1+size
+          abc[0] = c+1; abc[1] = c+size
           break
 
     a[0] = c+1; c += size; a[1] = c


### PR DESCRIPTION
- Fix upper bound of the element range for BCs
- No nested call to updateElementRange in setElementConnectivity2

Regressions:
- Connector/prepAMRFull_m1
- Connector/prepAMRFull_t1

```
[0] Reading Data_juno/prepAMRFull_m1.ref1 (bin_pickle)...done.
[0] DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/QuadNQuad/ElementRange.
[0] DIFF: reference: [[37851 45250]]
[0] DIFF: courant: [[37851 45249]]
[0] DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCFarfield.3/ElementRange.
[0] DIFF: reference: [[45250 45254]]
[0] DIFF: courant: [[45250 45253]]
[0] DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCFarfield.4/ElementRange.
[0] DIFF: reference: [[45254 45258]]
[0] DIFF: courant: [[45254 45257]]
[0] DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCFarfield.5/ElementRange.
[0] DIFF: reference: [[45258 45266]]
[0] DIFF: courant: [[45258 45265]]
[0] DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCSymmetryPlane.1/ElementRange.
[0] DIFF: reference: [[45266 83116]]
[0] DIFF: courant: [[45266 83115]]
[0] DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCSymmetryPlane.2/ElementRange.
[0] DIFF: reference: [[ 83116 120966]]
[0] DIFF: courant: [[ 83116 120965]]
[0] DIFF: valeurs differentes pour le noeud: Proc1/Proc1/ZoneBC/QuadNQuad/ElementRange.
[0] DIFF: reference: [[37857 45260]]
[0] DIFF: courant: [[37857 45259]]
[0] DIFF: valeurs differentes pour le noeud: Proc1/Proc1/ZoneBC/BCFarfield.3/ElementRange.
[0] DIFF: reference: [[45260 45264]]
[0] DIFF: courant: [[45260 45263]]
[0] DIFF: valeurs differentes pour le noeud: Proc1/Proc1/ZoneBC/BCFarfield.4/ElementRange.
[0] DIFF: reference: [[45264 45268]]
[0] DIFF: courant: [[45264 45267]]
[0] DIFF: valeurs differentes pour le noeud: Proc1/Proc1/ZoneBC/BCFarfield.5/ElementRange.
[0] DIFF: reference: [[45268 45276]]
[0] DIFF: courant: [[45268 45275]]
[0] DIFF: valeurs differentes pour le noeud: Proc1/Proc1/ZoneBC/BCSymmetryPlane.1/ElementRange.
[0] DIFF: reference: [[45276 83132]]
[0] DIFF: courant: [[45276 83131]]
[0] DIFF: valeurs differentes pour le noeud: Proc1/Proc1/ZoneBC/BCSymmetryPlane.2/ElementRange.
[0] DIFF: reference: [[ 83132 120988]]
[0] DIFF: courant: [[ 83132 120987]]
[0] Reading Data_juno/prepAMRFull_m1.ref2 (bin_pickle)...done.

Reading Data_juno/prepAMRFull_t1.ref1 (bin_pickle)...done.
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/QuadNQuad/ElementRange.
DIFF: reference: [[75707 90509]]
DIFF: courant: [[75707 90508]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCFarfield.3/ElementRange.
DIFF: reference: [[90509 90517]]
DIFF: courant: [[90509 90516]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCFarfield.4/ElementRange.
DIFF: reference: [[90517 90525]]
DIFF: courant: [[90517 90524]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCFarfield.5/ElementRange.
DIFF: reference: [[90525 90533]]
DIFF: courant: [[90525 90532]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCFarfield.6/ElementRange.
DIFF: reference: [[90533 90541]]
DIFF: courant: [[90533 90540]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCSymmetryPlane.1/ElementRange.
DIFF: reference: [[ 90541 166247]]
DIFF: courant: [[ 90541 166246]]
DIFF: valeurs differentes pour le noeud: Proc0/Proc0/ZoneBC/BCSymmetryPlane.2/ElementRange.
DIFF: reference: [[166247 241953]]
DIFF: courant: [[166247 241952]]
Reading Data_juno/prepAMRFull_t1.ref2 (bin_pickle)...done.
```