### PR TITLE
Converter: corrections in selectConnectivity

### DIFF
--- a/Cassiopee/Converter/Converter/Check.py
+++ b/Cassiopee/Converter/Converter/Check.py
@@ -1174,7 +1174,7 @@ def checkElementNodes(t):
 # Applies abs(index) for NFaces
 #==============================================================================
 def _correctElementNodes(t):
-    _correctBCElementNodes(t)
+    _correctElementBoundaryNodes(t)
     _cleanBEConnect(t)
     errors = checkElementNodes(t)
     le = len(errors)//3
@@ -1198,7 +1198,7 @@ def _correctElementNodes(t):
 #===============================================================================
 # Corrects boundary connectivity that are at zero (GE[1][1])
 #===============================================================================
-def _correctBCElementNodes(t):
+def _correctElementBoundaryNodes(t):
     #_correctBCPL2ER(t)
 
     zones = Internal.getZones(t)

--- a/Cassiopee/Converter/Converter/Internal.py
+++ b/Cassiopee/Converter/Converter/Internal.py
@@ -3884,11 +3884,11 @@ def checkSize(t, sizeMax=100000000):
   from . import Check
   return Check.checkSize(t, sizeMax)
 
-# -- correctBCElementNodes
-def _correctBCElementNodes(t):
+# -- correctElementBoundaryNodes
+def _correctElementBoundaryNodes(t):
   """Correct element nodes to tag them as BC."""
   from . import Check
-  return Check._correctBCElementNodes(t)
+  return Check._correctElementBoundaryNodes(t)
 
 # -- correctBaseZonesDim
 def _correctBaseZonesDim(t, splitBases=False):
@@ -4464,6 +4464,11 @@ def getElementBoundaryNodes(z):
     if dimElt < dim: out.append(GE)
   return out
 
+def _rmElementBoundaryNodes(z):
+  bcConnects = getElementBoundaryNodes(z)
+  for n in bcConnects: _rmNode(z, n)
+  return None
+
 # -- Retourne le noeud Element_t NGon si il existe
 def getNGonNode(z):
   GEl = getNodesFromType1(z, 'Elements_t')
@@ -4478,13 +4483,15 @@ def getNFaceNode(z):
     if GE[1][0] == 23: return GE
   return None
 
-# -- Update la numerotation des ElementRanges :
-#     - connectivites volumiques puis connectivites surfaciques
-#     - update les ElementRanges des BCs correspondantes
+# -- Update ElementRange numbering:
+#     - volume connectivities followed by surface connectivities
+#     - update the ElementRanges of the corresponding BCs
+#     - update the number of volume elements of BE/ME meshes in zoneDim
 def _updateElementRange(z):
   _setElementDim(z)
   GEl = getNodesFromType1(z, 'Elements_t')
   BCs = getNodesFromType2(z, 'BC_t')
+  dim = getZoneDim(z)
 
   iGEv = []; iGEs = []
   for i, GE in enumerate(GEl):
@@ -4492,7 +4499,16 @@ def _updateElementRange(z):
     else: iGEs.append(i)
 
   c = 0
-  for i in iGEv + iGEs:
+  for i in iGEv:
+    r = getNodeFromName1(GEl[i], 'ElementRange')
+    r[1] = numpy.copy(r[1]); a = r[1]
+    size = a[1]-a[0]+1
+    a[0] = c+1; c += size; a[1] = c
+  if dim[0] == "Unstructured" and dim[3] != "NGON":
+    z[1] = numpy.copy(z[1])
+    z[1][0][1] = c  # Update the number of volume elements
+
+  for i in iGEs:
     r = getNodeFromName1(GEl[i], 'ElementRange')
     r[1] = numpy.copy(r[1]); a = r[1]
     size = a[1]-a[0]+1
@@ -5071,8 +5087,7 @@ def _fixNGon(t, remove=False, breakBE=True, convertMIXED=True, addNFace=True, ap
           for c in connects:
             if c[1][0] != 22 and c[1][0] != 23:
               _rmNode(z, c)
-          connects = getElementBoundaryNodes(z)
-          for c in connects: _rmNode(z, c)
+          _rmElementBoundaryNodes(z)
         else: # swap
           if NGON != -1 and NGON > BE: # swap BE and NGON
             # swap un BE et NGON

--- a/Cassiopee/Converter/Converter/PyTree.py
+++ b/Cassiopee/Converter/Converter/PyTree.py
@@ -847,8 +847,7 @@ def _deleteZoneBC__(a, type='None'):
             bcs = Internal.getNodesFromType1(z, 'ZoneBC_t')
             for bc in bcs: Internal._rmNodeByPath(z, bc[0])
             # remove associated Elements_t corresponding to BCs
-            elts = Internal.getElementBoundaryNodes(z)
-            for e in elts: Internal._rmNodeByPath(z, e[0])
+            Internal._rmElementBoundaryNodes(z)
     else: _rmBCOfType(a, type)
     return None
 
@@ -965,7 +964,7 @@ def _upgradeTree(t, uncompress=True, upgradeNGon=True):
     Internal._correctPyTree(t, level=2) # force unique name
     Internal._correctPyTree(t, level=7) # create familyNames
 
-    #Internal._correctBCElementNodes(t) # boundary connectivity
+    #Internal._correctElementBoundaryNodes(t) # boundary connectivity
     #Internal._correctPyTree(t, level=9) # boundary connectivity, addNFace
     #Converter.Check._shiftParentElements(t, shift=-1) # shift -nface in PE
 
@@ -3642,8 +3641,7 @@ def _convertArray2NGon(t, recoverBC=True, api=1, method="geometric"):
                 else: _recoverBCs(z, gbcs[c], indices=indices[c])
 
             # Delete BC Element connectivities
-            bcConnects = Internal.getElementBoundaryNodes(z)
-            for n in bcConnects: Internal._rmNode(z, n)
+            Internal._rmElementBoundaryNodes(z)
     return None
 
 # -- convertPenta2Strand
@@ -4541,15 +4539,16 @@ def _recoverBCsGeometric(t, BCInfo, tol=1.e-11, removeBC=True, missingBCInfo=Non
                 ids = identifyElements(hook, b, tol)
                 # Check if some faces were not found
                 validIds = ids > -1
-                invalidIds = numpy.nonzero(~validIds)[0]
-                if invalidIds.size > 0:
+                invalidPos = numpy.nonzero(~validIds)[0]
+                ninvalidPos = invalidPos.size
+                if ninvalidPos > 0:
                     print(
-                        "Warning: _recoverBCsGeometric: face indices "
-                        f"{invalidIds} were not found in BC {b[0]}"
+                        f"Warning: _recoverBCsGeometric: {ninvalidPos} face "
+                        f"indices were not found in BC {b[0]}"
                     )
                     if storeMissing:
-                        invalidIds = invalidIds.astype(Internal.E_NpyInt)
-                        zu = T.subzone(b, invalidIds, type='elements')
+                        invalidPos = invalidPos.astype(Internal.E_NpyInt)
+                        zu = T.subzone(b, invalidPos, type='elements')
                         missingBCInfo[0].append(zu)
                         missingBCInfo[1].append(BCNames[c])
                         missingBCInfo[2].append(BCTypes[c])
@@ -4650,15 +4649,16 @@ def _recoverBCsTopologic(t, BCInfo, removeBC=True, indices=None, missingBCInfo=N
                         )
                         # Check if some faces were not found
                         validIds = fmap > -1
-                        invalidIds = numpy.nonzero(~validIds)[0]
-                        if invalidIds.size > 0:
+                        invalidPos = numpy.nonzero(~validIds)[0]
+                        ninvalidPos = invalidPos.size
+                        if ninvalidPos > 0:
                             print(
-                                "Warning:_recoverBCsTopologic: face indices "
-                                f"{invalidIds} were not found in BC {z[0]}"
+                                f"Warning:_recoverBCsTopologic: {ninvalidPos} "
+                                f"face indices were not found in BC {z[0]}"
                             )
                             if storeMissing:
-                                invalidIds = invalidIds.astype(Internal.E_NpyInt)
-                                zu = T.subzone(z, invalidIds, type='elements')
+                                invalidPos = invalidPos.astype(Internal.E_NpyInt)
+                                zu = T.subzone(z, invalidPos, type='elements')
                                 missingBCInfo[0].append(zu)
                                 missingBCInfo[1].append(BCNames[c])
                                 missingBCInfo[2].append(BCTypes[c])
@@ -8132,22 +8132,6 @@ def breakConnectivity(t):
     if typen == 1: typen = 2 # une zone renvoie une liste de zones
     return Internal.pyTree2Node(tp, typen)
 
-#==============================================================================
-# renumbers ElementRanges so they are in contiguous order
-# including for BCCs
-#==============================================================================
-def _renumberElementConnectivity(t):
-    zones = Internal.getZones(t)
-    for z in zones:
-        elts = Internal.getNodesFromType1(z, 'Elements_t')
-        c = 1
-        for e in elts:
-            r = Internal.getNodeFromName1(e, 'ElementRange')
-            r[1] = numpy.copy(r[1]); r = r[1]
-            delta = r[1]-r[0]+1
-            r[0] = c; r[1] = c+delta-1; c += delta
-    return None
-
 # -- selectOneConnectivity
 # Returns a new zone with only one of its connectivities
 # (passed as volumetric connectivity)
@@ -8164,13 +8148,17 @@ def _selectOneConnectivity(zp, name=None, number=None, irange=None):
     if name is not None:
         for e in elts:
             if e[0] != name: Internal._rmNodesByName(zp, e[0])
-            else: e[1] = numpy.copy(e[1]); e[1][1] = 0 # force volumetric
+            else:
+                e[1] = numpy.copy(e[1])
+                if e[1][1] == 0: _deleteZoneBC__(zp)
+                else: e[1][1] = 0 # force volumetric
     elif number is not None:
-        c = 0
-        for e in elts:
+        for c, e in enumerate(elts):
             if c != number: Internal._rmNodesByName(zp, e[0])
-            else: e[1] = numpy.copy(e[1]); e[1][1] = 0 # force volumetric
-            c += 1
+            else:
+                e[1] = numpy.copy(e[1])
+                if e[1][1] == 0: _deleteZoneBC__(zp)
+                else: e[1][1] = 0 # force volumetric
     elif irange is not None:
         for e in elts:
             r = Internal.getNodeFromName1(e, 'ElementRange')
@@ -8180,18 +8168,25 @@ def _selectOneConnectivity(zp, name=None, number=None, irange=None):
                     Internal._rmNodesByName(zp, e[0])
                 else:
                     if r[0] == irange[0] and r[1] == irange[1]: # full
-                        e[1] = numpy.copy(e[1]); e[1][1] = 0 # force volumetric
+                        e[1] = numpy.copy(e[1])
+                        if e[1][1] == 0: _deleteZoneBC__(zp)
+                        else: e[1][1] = 0 # force volumetric
                     else: # slice
                         (name, nnodes) = Internal.eltNo2EltName(e[1][0])
                         if name != 'NGON' and name != 'NFACE' and name != 'MIXED':
-                            e[1] = numpy.copy(e[1]); e[1][1] = 0 # force volumetric
+                            e[1] = numpy.copy(e[1])
+                            if e[1][1] == 0: _deleteZoneBC__(zp)
+                            else: e[1][1] = 0 # force volumetric
                             r = Internal.getNodeFromName1(e, 'ElementRange')
-                            r[1] = numpy.copy(r[1]); r[1][0] = 1; r[1][1] = irange[1]-irange[0]+1
+                            r[1] = numpy.copy(r[1])
+                            r[1][0] = 1; r[1][1] = irange[1]-irange[0]+1
                             c = Internal.getNodeFromName1(e, 'ElementConnectivity')
                             c[1] = c[1][nnodes*(irange[0]-1):nnodes*(irange[1])+1]
                         else: print ('Warning: selectOneConnectivity: slice impossible.')
             else: Internal._rmNodesByName(zp, e[0])
-    _renumberElementConnectivity(zp)
+
+    _deleteFlowSolutions__(zp, loc='centers')
+    Internal._updateElementRange(zp)
     return None
 
 # -- selectConnectivity
@@ -8203,17 +8198,20 @@ def _selectOneConnectivity(zp, name=None, number=None, irange=None):
 def selectConnectivity(z, name=None, number=None, irange=None):
     zp = Internal.copyRef(z)
     elts = Internal.getNodesFromType1(zp, 'Elements_t')
-
     if name is not None:
         for e in elts:
             if e[0] != name: Internal._rmNodesByName(zp, e[0])
-            else: e[1] = numpy.copy(e[1]); e[1][1] = 0 # force volumetric
+            else:
+                e[1] = numpy.copy(e[1])
+                if e[1][1] == 0: _deleteZoneBC__(zp)
+                else: e[1][1] = 0 # force volumetric
     elif number is not None:
-        c = 0
-        for e in elts:
+        for c, e in enumerate(elts):
             if c != number: Internal._rmNodesByName(zp, e[0])
-            else: e[1] = numpy.copy(e[1]); e[1][1] = 0 # force volumetric
-            c += 1
+            else:
+                e[1] = numpy.copy(e[1])
+                if e[1][1] == 0: _deleteZoneBC__(zp)
+                else: e[1][1] = 0 # force volumetric
     elif irange is not None:
         for e in elts:
             r = Internal.getNodeFromName1(e, 'ElementRange')
@@ -8222,11 +8220,15 @@ def selectConnectivity(z, name=None, number=None, irange=None):
                 if r[0] != irange[0] and r[1] != irange[1]:
                     Internal._rmNodesByName(zp, e[0])
                 if r[0] == irange[0] and r[1] == irange[1]: # full
-                    e[1] = numpy.copy(e[1]); e[1][1] = 0 # force volumetric
+                    e[1] = numpy.copy(e[1])
+                    if e[1][1] == 0: _deleteZoneBC__(zp)
+                    else: e[1][1] = 0 # force volumetric
                 if r[0] == irange[0] and r[1] < irange[1]: # full
                     (name, nnodes) = Internal.eltNo2EltName(e[1][0])
                     if name != 'NGON' and name != 'NFACE' and name != 'MIXED':
-                        e[1] = numpy.copy(e[1]); e[1][1] = 0 # force volumetric
+                        e[1] = numpy.copy(e[1])
+                        if e[1][1] == 0: _deleteZoneBC__(zp)
+                        else: e[1][1] = 0 # force volumetric
                         r0 = r[0]; r1 = r[1]
                         r = Internal.getNodeFromName1(e, 'ElementRange')
                         r[1] = numpy.copy(r[1]); r[1][0] = 1; r[1][1] = r1-r0+1
@@ -8237,7 +8239,9 @@ def selectConnectivity(z, name=None, number=None, irange=None):
                 if r[0] > irange[0] and r[1] == irange[1]: # full
                     (name, nnodes) = Internal.eltNo2EltName(e[1][0])
                     if name != 'NGON' and name != 'NFACE' and name != 'MIXED':
-                        e[1] = numpy.copy(e[1]); e[1][1] = 0 # force volumetric
+                        e[1] = numpy.copy(e[1])
+                        if e[1][1] == 0: _deleteZoneBC__(zp)
+                        else: e[1][1] = 0 # force volumetric
                         r0 = r[0]; r1 = r[1]
                         r = Internal.getNodeFromName1(e, 'ElementRange')
                         r[1] = numpy.copy(r[1]); r[1][0] = 1; r[1][1] = r1-r0+1
@@ -8246,7 +8250,9 @@ def selectConnectivity(z, name=None, number=None, irange=None):
                         c[1] = c[1][nnodes*(r[0]-1):nnodes*(r[1])+1]
                     else: print('Warning: selectConnectivity: slice impossible.')
             else: Internal._rmNodesByName(zp, e[0])
-    _renumberElementConnectivity(zp)
+
+    _deleteFlowSolutions__(zp, loc='centers')
+    Internal._updateElementRange(zp)
     return zp
 
 #=============================================================================


### PR DESCRIPTION
### Devs

1. update the number of volume elements of BE/ME meshes in Internal._updateElementRange
2. C.selectConnectivity / C.selectOneConnectivity: delete cell-center flow solutions (to prevent inconsistencies) and update the number of volume elements of the zone using Internal._updateElementRange. Delete ZoneBC_t node if the connectivity that is kept is a volume  connectivity. Could be further improved and one of the two functions should be deleted. New tests should be added.
3. delete C._renumberElementConnectivity (duplicate of Internal._updateElementRange)
4. rename Check._correctBCElementNodes to  Check._correctElementBoundaryNodes

### Regressions / Corrections
Converter/selectOneConnectivityPT_t1.py
Converter/recoverBCsPT_t3.py 

- Converter/selectOneConnectivityPT_t1.py: connectivity selected has 81 elements only, this is now reflected in the zone dimensions:
```py
b = C.selectOneConnectivity(a, irange=[730,810])
```

```
Reading Data_ubuntu/selectOneConnectivityPT_t1.ref1 (bin_pickle)...done.
DIFF: valeurs differentes pour le noeud: Base/cartHexa.
DIFF: reference: [[1000  729    0]]
DIFF: courant: [[1000   81    0]]
```

- Converter/recoverBCsPT_t3.py: refs 2 and 3 were wrong (and still are to some extent). Each BC and boundary conns should have 16 faces / elements (see ElementRanges below). The reference had 64 (number of volume elements) because of C.selectConnectivity (see points 1. and 2. above)

```
- Reading Data_ubuntu/recoverBCsPT_t3.ref21 (bin_pickle)...done.
DIFF: valeurs differentes pour le noeud: Base/cartHexa/cartHexa\wall1.
DIFF: reference: [ 7 64]
DIFF: courant: [ 7 16]
DIFF: valeurs differentes pour le noeud: Base/cartHexa/cartHexa\wall1/ElementRange.
DIFF: reference: [ 65 128]
DIFF: courant: [65 80]
DIFF: valeurs differentes pour le noeud: Base/cartHexa/ZoneBC/wall1.1/ElementRange.
DIFF: reference: [[ 65 128]]
DIFF: courant: [[65 80]]
DIFF: valeurs differentes pour le noeud: Base/cartHexa/ZoneBC/wall2.1/ElementRange.
DIFF: reference: [[129 192]]
DIFF: courant: [[81 96]]
DIFF: valeurs differentes pour le noeud: Base/cartHexa/cartHexa\wall2.
DIFF: reference: [ 7 64]
DIFF: courant: [ 7 16]
DIFF: valeurs differentes pour le noeud: Base/cartHexa/cartHexa\wall2/ElementRange.
DIFF: reference: [129 192]
DIFF: courant: [81 96]
```

The new BC ElementRanges, [[65 80]] and [[81 96]] are not accounting for corrupted BC faces yet. This will be done in the next commit.