### PR TITLE
Post: Correct bugs in selectExteriorFaces

### DIFF
--- a/Cassiopee/Converter/test/convFsdmPT_t1.py
+++ b/Cassiopee/Converter/test/convFsdmPT_t1.py
@@ -78,11 +78,9 @@ t = C.convertFile2PyTree(LOCAL+'/out.h5')
 test.testT(t, 1)
 
 # passage en NGON
-bcs = C.getBCs(m)
-m = C.breakConnectivity(m)
-m = C.convertArray2NGon(m, recoverBC=0)
-m = T.join(m)
-C._recoverBCs(m, bcs)
+zones = Internal.getZones(m)
+for z in zones:
+    C._convertArray2NGon(z, recoverBC=True, api=3)
 C._signNGonFaces(m)
 Internal._adaptNGon32NGon4(m)
 #C.convertPyTree2File(m, 'mesh.cgns')

--- a/Cassiopee/Intersector/Intersector/PyTree.py
+++ b/Cassiopee/Intersector/Intersector/PyTree.py
@@ -1662,7 +1662,7 @@ def _triangulateSpecifiedFaces(t, pgs, improve_qual=1):
     for z in zones:
         m = C.getFields(Internal.__GridCoordinates__, z)[0]
         if m == []: continue
-        m = Converter.convertArray2NGon(m)
+        m = Converter.convertArray2NGon(m, api=1)
         m = XOR.triangulateSpecifiedFaces(m, pgs[i], improve_qual)
         mesh = m[0]
         pg_oids= m[1]
@@ -1748,15 +1748,15 @@ def _triangulateBC(t, bctype):
 
     for z in zones:
 
-        coords = C.getFields(Internal.__GridCoordinates__, z)[0]
+        coords = C.getFields(Internal.__GridCoordinates__, z, api=1)[0]
         if coords == []: continue
 
-        coords = Converter.convertArray2NGon(coords)
+        coords = Converter.convertArray2NGon(coords, api=1)
 
         bnds = Internal.getNodesFromType2(z, 'BC_t')
 
         bcpgs = []
-        for bb in bnds :
+        for bb in bnds:
             if Internal.isValue(bb, bctype) == False: continue
             bcpgs.append(bb[2][1][1][0]) # POINTLIST NUMPY
 

--- a/Cassiopee/Intersector/test/syncPerioFacesPT_t1.py
+++ b/Cassiopee/Intersector/test/syncPerioFacesPT_t1.py
@@ -14,7 +14,7 @@ import Converter.Internal as I
 # ----------------------------------------------------------------
 # Maillages
 a = G.cartHexa((0.,0.,0.), (1.,1.,1.), (10,10,10))
-a = C.convertArray2NGon(a)
+a = C.convertArray2NGon(a, api=1)
 
 XOR._reorient(a)
 

--- a/Cassiopee/Post/Post/PyTree.py
+++ b/Cassiopee/Post/Post/PyTree.py
@@ -678,7 +678,7 @@ def exteriorFaces(t, indices=None):
 def _exteriorFaces(t, indices=None):
     C._deleteZoneBC__(t)
     C._deleteFlowSolutions__(t, 'centers')
-    C._TZA1(t, 'nodes', 'nodes', True, Post.exteriorFaces, indices)
+    C._TZA3(t, 'nodes', 'nodes', True, Post.exteriorFaces, indices)
     return None
 
 def exteriorElts(t):

--- a/Cassiopee/Post/Post/selectExteriorFaces.cpp
+++ b/Cassiopee/Post/Post/selectExteriorFaces.cpp
@@ -813,6 +813,7 @@ PyObject* K_POST::selectExteriorFacesNGon3D(char* varString, FldArrayF& f,
   E_Int npts = f.getSize(), nfld = f.getNfld(), api = f.getApi();
   E_Int ngonType = cn.getNGonType();
   E_Int shift = 1; if (ngonType == 3) shift = 0;
+  E_Bool hasCnOffsets = (ngonType == 2 || ngonType == 3);
 
   // cFE: connectivite face/elements.
   // Si une face n'a pas d'element gauche ou droit, retourne 0 pour 
@@ -915,9 +916,10 @@ PyObject* K_POST::selectExteriorFacesNGon3D(char* varString, FldArrayF& f,
   E_Int* nface2 = cn2->getNFace();
   E_Int *indPG2 = NULL, *indPH2 = NULL;
   
-  if (ngonType == 2 || ngonType == 3) // set offsets
+  if (hasCnOffsets) // set offsets
   {
     indPG2 = cn2->getIndPG(); indPH2 = cn2->getIndPH();
+    indPH2[0] = 0;
   }
 
   E_Int c1 = 0, c2 = 0; // positions in ngon2 and nface2
@@ -928,12 +930,16 @@ PyObject* K_POST::selectExteriorFacesNGon3D(char* varString, FldArrayF& f,
     if (boolIndir) indirp[i] = fidx;
     
     nface2[c2] = nbnodes;
-    if (ngonType == 2 || ngonType == 3) indPH2[i] = nbnodes;
+    if (hasCnOffsets && i < nfacesExt-1) 
+    {
+      indPH2[i+1] = indPH2[i] + nbnodes + shift;
+    }
     
     for (E_Int p = 0; p < nbnodes; p++)
     {
-      edge[0] = face[p]-1; 
-      edge[1] = face[(p+1)%nbnodes]-1;
+      edge[0] = face[p]-1;
+      if (p == nbnodes-1) edge[1] = face[0]-1;
+      else edge[1] = face[p+1]-1;
     
       //E.set(edge); // version with Topology
       E.set(edge.data(), 2); // version with TopologyOpt
@@ -958,10 +964,10 @@ PyObject* K_POST::selectExteriorFacesNGon3D(char* varString, FldArrayF& f,
   #pragma omp parallel
   {
     E_Int indf;
-    if (ngonType == 2 || ngonType == 3)
+    if (hasCnOffsets)
     {
       #pragma omp for nowait
-      for(E_Int i = 0; i < nedgesExt; i++) indPG2[i] = 2;
+      for(E_Int i = 0; i < nedgesExt; i++) indPG2[i] = i*(2+shift);
     }
   
     for(E_Int eq = 1; eq <= nfld; eq++)
@@ -1007,6 +1013,7 @@ PyObject* K_POST::selectExteriorFacesNGon2D(char* varString, FldArrayF& f,
   E_Int npts = f.getSize(), nfld = f.getNfld(), api = f.getApi();
   E_Int ngonType = cn.getNGonType();
   E_Int shift = 1; if (ngonType == 3) shift = 0;
+  E_Bool hasCnOffsets = (ngonType == 2 || ngonType == 3);
 
   // cFE: connectivite face/elements.
   // Si une face n'a pas d'element gauche ou droit, retourne 0 pour 
@@ -1033,7 +1040,6 @@ PyObject* K_POST::selectExteriorFacesNGon2D(char* varString, FldArrayF& f,
   vector<E_Int> exteriorEdges;
   TopologyOpt E;
   std::unordered_map<TopologyOpt, E_Int, BernsteinHash<TopologyOpt> > edgeMap;
-
 
   for (E_Int i = 0; i < nfaces; i++)
   {
@@ -1107,7 +1113,7 @@ PyObject* K_POST::selectExteriorFacesNGon2D(char* varString, FldArrayF& f,
   E_Int* ngon2 = cn2->getNGon();
   E_Int* nface2 = cn2->getNFace();
   E_Int *indPG2 = NULL, *indPH2 = NULL;
-  if (ngonType == 2 || ngonType == 3) // set offsets
+  if (hasCnOffsets) // set offsets
   {
     indPG2 = cn2->getIndPG(); indPH2 = cn2->getIndPH();
   }
@@ -1137,12 +1143,12 @@ PyObject* K_POST::selectExteriorFacesNGon2D(char* varString, FldArrayF& f,
       nface2[ind+1+shift] = indirVertices[v2];
     }
 
-    if (ngonType == 2 || ngonType == 3)
+    if (hasCnOffsets)
     {
       #pragma omp for nowait
-      for(E_Int i = 0; i < nptsExt; i++) indPG2[i] = 1;
+      for(E_Int i = 0; i < nptsExt; i++) indPG2[i] = i*(1+shift);
       #pragma omp for nowait
-      for(E_Int i = 0; i < nedgesExt; i++) indPH2[i] = 2;
+      for(E_Int i = 0; i < nedgesExt; i++) indPH2[i] = i*(2+shift);
     }
   
     for(E_Int eq = 1; eq <= nfld; eq++)
@@ -1788,7 +1794,9 @@ PyObject* K_POST::selectExteriorFacesME(char* varString, FldArrayF& f,
   {
     if (tmp_nfpc2[ic] > 0)
     {
-      nfpc2[nc2] = tmp_nfpc2[ic]; nc2++;
+      if (ic == 0) nfpc2[nc2] = 0;  // NODE
+      else nfpc2[nc2] = tmp_nfpc2[ic];
+      nc2++;
       ntotUniqueFaces += tmp_nfpc2[ic];
     }
   }

--- a/Cassiopee/Post/test/exteriorFacesPT_t3.py
+++ b/Cassiopee/Post/test/exteriorFacesPT_t3.py
@@ -3,21 +3,23 @@ import KCore.test as test
 import Post.PyTree as P
 import Generator.PyTree as G
 
+# -- STRUCT
 # 1D
 a = G.cart((0,0,0), (1,1,1), (10,1,1))
 b = P.exteriorFaces(a)
 test.testT(b, 1)
 
-# 2D array
+# 2D
 a = G.cart((0,0,0), (1,1,1), (10,6,1))
 b = P.exteriorFaces(a)
 test.testT(b, 2)
 
-# 3D array
+# 3D
 a = G.cart((0,0,0), (1,1,1), (4,4,6))
 b = P.exteriorFaces(a)
 test.testT(b, 3)
 
+# -- BE
 # TRI
 a = G.cartTetra((0,0,0), (1,1,1), (20,3,1))
 b = P.exteriorFaces(a)
@@ -43,12 +45,43 @@ a = G.cartTetra((0,0,0), (1,1,1), (5,1,1))
 b = P.exteriorFaces(a)
 test.testT(b, 8)
 
-# NGON3D
-a = G.cartNGon((0,0,0), (1,1,1), (5,5,5))
+# -- NGON
+# NGON3D, api1
+a = G.cartNGon((0,0,0), (1,1,1), (5,5,5), api=1)
 b = P.exteriorFaces(a)
 test.testT(b, 9)
 
-# NGON2D
-a = G.cartNGon((0,0,0), (1,1,1), (5,5,1))
+# NGON2D, api1
+a = G.cartNGon((0,0,0), (1,1,1), (5,5,1), api=1)
 b = P.exteriorFaces(a)
 test.testT(b, 10)
+
+# NGON3D, api3
+a = G.cartNGon((0,0,0), (1,1,1), (5,5,5), api=3)
+b = P.exteriorFaces(a)
+test.testT(b, 11)
+
+# NGON2D, api3
+a = G.cartNGon((0,0,0), (1,1,1), (5,5,1), api=3)
+b = P.exteriorFaces(a)
+test.testT(b, 12)
+
+# -- ME
+# 2D: tri-quad-tri
+#          |
+#         tri
+a = G.cartTetra((0.,0.,0.), (0.1,0.1,0.2), (5,10,1))
+b = G.cartHexa((0.4,0.,0.), (0.1,0.1,0.2), (5,10,1))
+c = G.cartTetra((0.8,0.,0.), (0.1,0.1,0.2), (5,10,1))
+d = G.cartTetra((0.4,-0.9,0.), (0.1,0.1,0.2), (5,10,1))
+a = C.mergeConnectivity([a, b, c, d], None)
+b = P.exteriorFaces(a)
+test.testT(b, 13)
+
+# 3D: pyra - penta - hexa
+a = G.cartPyra((0.,0.,0.), (0.1,0.1,0.1), (5,5,5))
+b = G.cartPenta((0.4,0.,0.), (0.1,0.1,0.1), (5,5,5))
+c = G.cartHexa((0.8,0.,0.), (0.1,0.1,0.1), (5,5,5))
+a = C.mergeConnectivity([a, b, c], None)
+b = P.exteriorFaces(a)
+test.testT(b, 14)


### PR DESCRIPTION
### Devs
- Correct ElementStartOffsets in P.selectExteriorFaces 2D and 3D
- Switch P._exteriorFaces to api 3
- Add tests (incl. NGON api 3 and ME)

### Regressions / Corrections

- Post/exteriorFacesPT_t3 refs 8 and 9
- Post/exteriorFaces_t1 ref 29

ref8 / ref 29: zoneDim of NODE conn is supposed to be [[npts, 0, 0]]. Fixed in `current`
ref9: new ElementStartOffset nodes resulting from the switch to NGONv3 non compact

```
Reading Data_juno/exteriorFacesPT_t3.ref8 (bin_pickle)...done.
DIFF: valeurs differentes pour le noeud: Base/cartTetra.1.
DIFF: reference: [[2 2 0]]
DIFF: courant: [[2 0 0]]
DIFF: valeurs differentes pour le noeud: Base/cartTetra.1/GridElements/ElementRange.
DIFF: reference: [1 2]
DIFF: courant: [1 0]
DIFF: shape differentes pour le noeud: Base/cartTetra.1/GridElements/ElementConnectivity.
DIFF: reference: (2,)
DIFF: courant: (0,)
DIFF: reference: [1 2]
DIFF: courant: []

Reading Data_juno/exteriorFacesPT_t3.ref9 (bin_pickle)...done.
DIFF: longueur des fils differente pour le noeud: Base/cartNGon/NGonElements.
DIFF: longueur des fils differente pour le noeud: Base/cartNGon/NFaceElements.
DIFF: node Base/cartNGon/NGonElements/FaceIndex exists in current but not in reference.
DIFF: node Base/cartNGon/NFaceElements/ElementIndex exists in current but not in reference.
Reading Data_juno/exteriorFacesPT_t3.ref10 (bin_pickle)...done.
DIFF: longueur des fils differente pour le noeud: Base/cartNGon.0/NGonElements.
DIFF: longueur des fils differente pour le noeud: Base/cartNGon.0/NFaceElements.
DIFF: node Base/cartNGon.0/NGonElements/FaceIndex exists in current but not in reference.
DIFF: node Base/cartNGon.0/NFaceElements/ElementIndex exists in current but not in reference.

Reading Data_juno/exteriorFaces_t1.ref29... done.
DIFF: object shape differs from Data_juno/exteriorFaces_t1.ref29. current: (1, 0), ref: (1, 2).
```

@benoit128, @antjost, @BconstantMMK: if you see anything wrong when loading a mesh with `cassiopee`  after the integration of this commit, let me know asap.