### PR TITLE
Converter: convertUnstruct2NGon: remove degenerated faces

### DIFF
--- a/Cassiopee/Converter/Converter/convertUnstruct2NGon.cpp
+++ b/Cassiopee/Converter/Converter/convertUnstruct2NGon.cpp
@@ -391,7 +391,7 @@ PyObject* K_CONVERTER::convertUnstruct2NGon(PyObject* self, PyObject* args)
   E_Float tol = 1.e-12;
   E_Bool rmOverlappingPts = true; E_Bool rmOrphanPts = false;
   E_Bool rmDuplicatedFaces = true; E_Bool rmDuplicatedElts = false;
-  E_Bool rmDegeneratedFaces = false; E_Bool rmDegeneratedElts = false;
+  E_Bool rmDegeneratedFaces = true; E_Bool rmDegeneratedElts = false;
   PyObject* tplClean = K_CONNECT::V_cleanConnectivity(
     varString, *f2, *cn2, "NGON", tol,
     rmOverlappingPts, rmOrphanPts,


### PR DESCRIPTION
No regressions

Needed when converting PENTA elements with all faces stored as QUADs -> 2 degenerated QUAD faces.

Example: Intersector/adaptCellsPT_t6.py