### PR TITLE
Transform: join: bug fixes and switch to new cleanConn

### DIFF
--- a/Cassiopee/Transform/Transform/join.cpp
+++ b/Cassiopee/Transform/Transform/join.cpp
@@ -804,6 +804,7 @@ PyObject* K_TRANSFORM::joinNGON(FldArrayF& f1, FldArrayI& cn1,
 
   E_Int api = f1.getApi();
   E_Int ngonType = cn1.getNGonType();
+  E_Int shift = 1; if (ngonType == 3) shift = 0;
   PyObject* tpl = K_ARRAY::buildArray3(nfld, varString, npts, nelts,
                                        nfaces, "NGON", sizeFN, sizeEF,
                                        ngonType, false, api);
@@ -863,7 +864,7 @@ PyObject* K_TRANSFORM::joinNGON(FldArrayF& f1, FldArrayI& cn1,
 
   // Correction for number of vertices per face and number of faces per element
   // for the second connectivity
-  if (api != 3)
+  if (shift == 1)
   {
     E_Int ind = 0;
     for (E_Int i = 0; i < nfaces2; i++)

--- a/Cassiopee/Transform/Transform/joinAll.cpp
+++ b/Cassiopee/Transform/Transform/joinAll.cpp
@@ -88,21 +88,10 @@ PyObject* K_TRANSFORM::joinAll(PyObject* self, PyObject* args)
       {
         char* eltTypConn = eltTypesk[ic];
         // Check dimensionality: allow merge if identical
-        if (dimRef == -1)
-        {
-          if (strcmp(eltTypesk[ic], "NODE") == 0) dimRef = 0;
-          else if (strcmp(eltTypesk[ic], "BAR") == 0) dimRef = 1;
-          else if (strcmp(eltTypesk[ic], "TRI") == 0 or
-                   strcmp(eltTypesk[ic], "QUAD") == 0) dimRef = 2;
-          else dimRef = 3;
-        }
+        if (dimRef == -1) dimRef = K_CONNECT::getDimME(eltTypConn);
         else
         {
-          if (strcmp(eltTypesk[ic], "NODE") == 0) dim = 0;
-          else if (strcmp(eltTypesk[ic], "BAR") == 0) dim = 1;
-          else if (strcmp(eltTypesk[ic], "TRI") == 0 or
-                   strcmp(eltTypesk[ic], "QUAD") == 0) dim = 2;
-          else dim = 3;
+          dim = K_CONNECT::getDimME(eltTypConn);
           if (dim != dimRef) { indir[k].push_back(-2); missed++; continue; }
         }
         // Add default value in mapping table
@@ -115,8 +104,7 @@ PyObject* K_TRANSFORM::joinAll(PyObject* self, PyObject* args)
         }
       }
 
-      for (size_t ic = 0; ic < eltTypesk.size(); ic++)
-        delete [] eltTypesk[ic];
+      for (size_t ic = 0; ic < eltTypesk.size(); ic++) delete [] eltTypesk[ic];
     }
     else missed++;
   }
@@ -128,12 +116,15 @@ PyObject* K_TRANSFORM::joinAll(PyObject* self, PyObject* args)
   // Build unstructured connectivity
   E_Int nfld = unstructF[0]->getNfld();
   E_Int api = unstructF[0]->getApi();
+  E_Int ngonType = -1;
+  E_Int shift = 1;
   vector<E_Int> neltsME;
 
   if (strcmp(eltRef, "NGON") == 0)
   {
     strcat(newEltType, "NGON");
-    E_Int ngonType = cn[0]->getNGonType();
+    ngonType = cn[0]->getNGonType();
+    if (ngonType == 3) shift = 0;
     tpl = K_ARRAY::buildArray3(nfld, unstructVarString[0], npts, neltsNGON,
                                nfaces, newEltType, sizeFN, sizeEF,
                                ngonType, false, api);
@@ -190,12 +181,12 @@ PyObject* K_TRANSFORM::joinAll(PyObject* self, PyObject* args)
     tpl = K_ARRAY::buildArray3(nfld, unstructVarString[0], npts, neltsME,
                                newEltType, false, api);
   }
+
   FldArrayF* f; FldArrayI* cno;
   K_ARRAY::getFromArray3(tpl, f, cno);
 
   // Acces non universel sur les ptrs NGON
   E_Int *ngon = NULL, *nface = NULL, *indPG = NULL, *indPH = NULL;
-  E_Int ngonType = cno->getNGonType();
   if (strcmp(eltRef, "NGON") == 0)
   {
     ngon = cno->getNGon(); nface = cno->getNFace();
@@ -249,10 +240,10 @@ PyObject* K_TRANSFORM::joinAll(PyObject* self, PyObject* args)
           indPGk = cn[k]->getIndPG(); indPHk = cn[k]->getIndPH();
           #pragma omp for
           for (E_Int i = 0; i < nfacesk; i++)
-            indPG[i+offsetFaces] = indPGk[i] + offsetFaces;
+            indPG[i+offsetFaces] = indPGk[i] + offsetSizeFN;
           #pragma omp for
           for (E_Int i = 0; i < neltsk; i++)
-            indPH[i+offsetElts] = indPHk[i] + offsetElts;
+            indPH[i+offsetElts] = indPHk[i] + offsetSizeEF;
         }
 
         // Increment NGON offsets
@@ -288,7 +279,7 @@ PyObject* K_TRANSFORM::joinAll(PyObject* self, PyObject* args)
 
   // NGON: Correction for number of vertices per face and number of faces per
   // element for all but the first array
-  if (strcmp(eltRef, "NGON") == 0 and api != 3)
+  if (strcmp(eltRef, "NGON") == 0 and shift == 1)
   {
     E_Int offsetSizeFN = cn[0]->getSizeNGon();
     E_Int offsetSizeEF = cn[0]->getSizeNFace();
@@ -322,11 +313,10 @@ PyObject* K_TRANSFORM::joinAll(PyObject* self, PyObject* args)
   E_Int posz = K_ARRAY::isCoordinateZPresent(unstructVarString[0])+1;
   if (posx > 0 && posy > 0 && posz > 0)
   {
-    K_CONNECT::cleanConnectivity(posx, posy, posz, tol, newEltType,
-                                 *f, *cno);
-    PyObject* tpl2 = K_ARRAY::buildArray3(*f, unstructVarString[0], *cno, newEltType, api);
-    // PyObject* tpl2 = K_CONNECT::V_cleanConnectivity(
-    //   unstructVarString[0], *f, *cno, newEltType, tol);
+    // Do not remove degenerated nor duplicated elements - AMR
+    PyObject* tpl2 = K_CONNECT::V_cleanConnectivity(
+      unstructVarString[0], *f, *cno, newEltType, tol,
+      true, true, true, false, true, false);
     RELEASESHAREDU(tpl, f, cno); Py_DECREF(tpl);
     return tpl2;
   }
@@ -393,6 +383,7 @@ PyObject* K_TRANSFORM::joinAllBoth(PyObject* self, PyObject* args)
   // Counters for all arrays
   E_Int npts = 0;
   E_Int nfaces = 0, neltsNGON = 0, sizeFN = 0, sizeEF = 0;
+  E_Int shift = 1;
   // Table d'indirection des connectivites ME
   vector<vector<E_Int> > indir(nu);
 
@@ -411,6 +402,7 @@ PyObject* K_TRANSFORM::joinAllBoth(PyObject* self, PyObject* args)
         sizeEF += cn[k]->getSizeNFace();
       }
       else missed++;
+      if (cn[k]->getNGonType() == 3) shift = 0;
     }
     else if (strcmp(eltRef, "NGON") != 0)
     {
@@ -424,21 +416,10 @@ PyObject* K_TRANSFORM::joinAllBoth(PyObject* self, PyObject* args)
       {
         char* eltTypConn = eltTypesk[ic];
         // Check dimensionality: allow merge if identical
-        if (dimRef == -1)
-        {
-          if (strcmp(eltTypesk[ic], "NODE") == 0) dimRef = 0;
-          else if (strcmp(eltTypesk[ic], "BAR") == 0) dimRef = 1;
-          else if (strcmp(eltTypesk[ic], "TRI") == 0 or
-                   strcmp(eltTypesk[ic], "QUAD") == 0) dimRef = 2;
-          else dimRef = 3;
-        }
+        if (dimRef == -1) dimRef = K_CONNECT::getDimME(eltTypConn);
         else
         {
-          if (strcmp(eltTypesk[ic], "NODE") == 0) dim = 0;
-          else if (strcmp(eltTypesk[ic], "BAR") == 0) dim = 1;
-          else if (strcmp(eltTypesk[ic], "TRI") == 0 or
-                   strcmp(eltTypesk[ic], "QUAD") == 0) dim = 2;
-          else dim = 3;
+          dim = K_CONNECT::getDimME(eltTypConn);
           if (dim != dimRef) { indir[k].push_back(-2); missed++; continue; }
         }
         // Add default value in mapping table
@@ -589,10 +570,10 @@ PyObject* K_TRANSFORM::joinAllBoth(PyObject* self, PyObject* args)
           indPGk = cn[k]->getIndPG(); indPHk = cn[k]->getIndPH();
           #pragma omp for nowait
           for (E_Int i = 0; i < nfacesk; i++)
-            indPG[i+offsetFaces] = indPGk[i] + offsetFaces;
+            indPG[i+offsetFaces] = indPGk[i] + offsetSizeFN;
           #pragma omp for
           for (E_Int i = 0; i < neltsk; i++)
-            indPH[i+offsetElts] = indPHk[i] + offsetElts;
+            indPH[i+offsetElts] = indPHk[i] + offsetSizeEF;
         }
 
         // Increment NGON offsets
@@ -628,7 +609,7 @@ PyObject* K_TRANSFORM::joinAllBoth(PyObject* self, PyObject* args)
 
   // NGON: Correction for number of vertices per face and number of faces per
   // element for all but the first array
-  if (strcmp(eltRef, "NGON") == 0 and api != 3)
+  if (strcmp(eltRef, "NGON") == 0 and shift == 1)
   {
     E_Int offsetSizeFN = cn[0]->getSizeNGon();
     E_Int offsetSizeEF = cn[0]->getSizeNFace();
@@ -665,25 +646,29 @@ PyObject* K_TRANSFORM::joinAllBoth(PyObject* self, PyObject* args)
   E_Int posz = K_ARRAY::isCoordinateZPresent(unstructVarString[0])+1;
 
   PyObject* l = PyList_New(0);
-  if (posx > 0 && posy > 0 && posz > 0)
-  {
-    K_CONNECT::cleanConnectivity(posx, posy, posz, tol, newEltType, *f, *cno);
-    // PyObject* tpln2 = K_CONNECT::V_cleanConnectivity(
-    //  unstructVarString[0], *f, *cno, newEltType, tol);
-    // PyList_Append(l, tpln2); Py_DECREF(tpln2);
-  }
-  // else
-  // {
-  //  PyList_Append(l, tpln);
-  // }
-  PyObject* tpln2 = K_ARRAY::buildArray3(*f, unstructVarString[0], *cno, newEltType, api);
-  PyList_Append(l, tpln2); Py_DECREF(tpln2);
-
+  PyObject* tplc = NULL;
   char newEltTypec[K_ARRAY::VARSTRINGLENGTH];
   K_ARRAY::starVarString(newEltType, newEltTypec);
-  PyObject* tplc = K_ARRAY::buildArray3(*fc, unstructVarStringc[0],
-                                        *cno, newEltTypec, api);
-  PyList_Append(l, tplc); Py_DECREF(tplc); delete fc;
+
+  if (posx > 0 && posy > 0 && posz > 0)
+  {
+    PyObject* tpln2 = K_CONNECT::V_cleanConnectivity(
+      unstructVarString[0], *f, *cno, newEltType, tol
+    );
+    FldArrayF* fout; FldArrayI* cnout;
+    K_ARRAY::getFromArray3(tpln2, fout, cnout);
+    tplc = K_ARRAY::buildArray3(*fc, unstructVarStringc[0],
+                                *cnout, newEltTypec, api);
+    PyList_Append(l, tpln2); PyList_Append(l, tplc);
+    RELEASESHAREDU(tpln2, fout, cnout); Py_DECREF(tpln2);
+  }
+  else
+  {
+    tplc = K_ARRAY::buildArray3(*fc, unstructVarStringc[0],
+                                *cno, newEltTypec, api);
+    PyList_Append(l, tpln); PyList_Append(l, tplc);
+  }
   RELEASESHAREDU(tpln, f, cno);
+  Py_DECREF(tpln); Py_DECREF(tplc); delete fc;
   return l;
 }

--- a/Cassiopee/Transform/Transform/joinBoth.cpp
+++ b/Cassiopee/Transform/Transform/joinBoth.cpp
@@ -873,7 +873,7 @@ PyObject* K_TRANSFORM::joinBothUnstructured(
     {
       FldArrayI& cm1 = *(cn1.getConnect(ic));
       nelts[ic] += cm1.getSize();
-      neltstot += nelts[ic];
+      neltstot += cm1.getSize();
     }
 
     for (E_Int ic2 = 0; ic2 < nc2; ic2++)
@@ -883,7 +883,7 @@ PyObject* K_TRANSFORM::joinBothUnstructured(
       {
         FldArrayI& cm2 = *(cn2.getConnect(ic2));
         nelts[ic] += cm2.getSize();
-        neltstot += nelts[ic];
+        neltstot += cm2.getSize();
         indir2[ic2] = ic;
       }
     }
@@ -957,23 +957,27 @@ PyObject* K_TRANSFORM::joinBothUnstructured(
   for (size_t ic = 0; ic < eltTypes2.size(); ic++) delete [] eltTypes2[ic];
 
   PyObject* l = PyList_New(0);
+  PyObject* tplc = NULL;
+  char eltTypec[K_ARRAY::VARSTRINGLENGTH];
+  K_ARRAY::starVarString(eltType, eltTypec);
+
   // Clean connectivity
   if (posx > 0 && posy > 0 && posz > 0)
   {
-    K_CONNECT::cleanConnectivity(posx, posy, posz, tol, eltType, *f, *cn);
-    PyObject* tpln2 = K_ARRAY::buildArray3(*f, varString, *cn, eltType, api);
-    PyList_Append(l, tpln2); Py_DECREF(tpln2);
+    PyObject* tpln2 = K_CONNECT::V_cleanConnectivity(varString, *f, *cn, eltType, tol);
+    FldArrayF* fout; FldArrayI* cnout;
+    K_ARRAY::getFromArray3(tpln2, fout, cnout);
+    tplc = K_ARRAY::buildArray3(*fc, varStringc, *cnout, eltTypec, api);
+    PyList_Append(l, tpln2); PyList_Append(l, tplc);
+    RELEASESHAREDU(tpln2, fout, cnout); Py_DECREF(tpln2);
   }
   else
   {
-    PyList_Append(l, tpln); Py_DECREF(tpln);
+    tplc = K_ARRAY::buildArray3(*fc, varStringc, *cn, eltTypec, api);
+    PyList_Append(l, tpln); PyList_Append(l, tplc);
   }
-
-  char eltTypec[K_ARRAY::VARSTRINGLENGTH];
-  K_ARRAY::starVarString(eltType, eltTypec);
-  PyObject* tplc = K_ARRAY::buildArray3(*fc, varStringc, *cn, eltTypec, api);
-  PyList_Append(l, tplc); Py_DECREF(tplc); delete fc;
   RELEASESHAREDU(tpln, f, cn);
+  Py_DECREF(tpln); Py_DECREF(tplc); delete fc;
   return l;
 }
 //=============================================================================
@@ -1006,6 +1010,7 @@ PyObject* K_TRANSFORM::joinBothNGON(FldArrayF& f1, FldArrayF& fc1,
 
   E_Int api = f1.getApi();
   E_Int ngonType = cn1.getNGonType();
+  E_Int shift = 1; if (ngonType == 3) shift = 0;
   PyObject* tpln = K_ARRAY::buildArray3(nfld, varString, npts, nelts,
                                         nfaces, "NGON", sizeFN, sizeEF,
                                         ngonType, false, api);
@@ -1082,7 +1087,7 @@ PyObject* K_TRANSFORM::joinBothNGON(FldArrayF& f1, FldArrayF& fc1,
 
   // Correction for number of vertices per face and number of faces per element
   // for the second connectivity
-  if (api != 3)
+  if (shift == 1)
   {
     E_Int ind = 0;
     for (E_Int i = 0; i < nfaces2; i++)
@@ -1098,18 +1103,23 @@ PyObject* K_TRANSFORM::joinBothNGON(FldArrayF& f1, FldArrayF& fc1,
     }
   }
 
-  //Py_DECREF(tpln); // to fix
-  // TODO VINCENT: connectivity not cleaned in the original code
-  // if (posx > 0 && posy > 0 && posz > 0)
-  // {
-  //   K_CONNECT::cleanConnectivityNGon(posx, posy, posz, tol, *f, *cn);
-  //   tpln = K_ARRAY::buildArray3(*f, varString, *cn, "NGON");
-  // }
-
   PyObject* l = PyList_New(0);
-  PyList_Append(l, tpln); Py_DECREF(tpln);
-  PyObject* tplc = K_ARRAY::buildArray3(*fc, varStringc, *cn, "NGON*", api);
-  PyList_Append(l, tplc); Py_DECREF(tplc); delete fc;
+  PyObject* tplc = NULL;
+  if (posx > 0 && posy > 0 && posz > 0)
+  {
+    PyObject* tpln2 = K_CONNECT::V_cleanConnectivity(varString, *f, *cn, "NGON", tol);
+    FldArrayF* fout; FldArrayI* cnout;
+    K_ARRAY::getFromArray3(tpln2, fout, cnout);
+    tplc = K_ARRAY::buildArray3(*fc, varStringc, *cnout, "NGON*", api);
+    PyList_Append(l, tpln2); PyList_Append(l, tplc);
+    RELEASESHAREDU(tpln2, fout, cnout); Py_DECREF(tpln2);
+  }
+  else
+  {
+    tplc = K_ARRAY::buildArray3(*fc, varStringc, *cn, "NGON*", api);
+    PyList_Append(l, tpln); PyList_Append(l, tplc);
+  }
   RELEASESHAREDU(tpln, f, cn);
+  Py_DECREF(tpln); Py_DECREF(tplc); delete fc;
   return l;
 }


### PR DESCRIPTION
### Devs - T.join
1. Fix a few bugs: connectivity offsets and/or size for NGON and ME which would show up if the api were 3 
2. Switch from cleanConnectivity to V_cleanConnectivity
3. Add V_cleanConnectivity to joinBothNGON (previously missing)
4. Fix connectivity of arrays containing cell-center fields. This connectivity must be that that was cleaned post-join (`cnout` here), and not the one filled during join (`cno` here).

```py
    PyObject* tpln2 = K_CONNECT::V_cleanConnectivity(
      unstructVarString[0], *f, *cno, newEltType, tol
    );
    FldArrayF* fout; FldArrayI* cnout;
    K_ARRAY::getFromArray3(tpln2, fout, cnout);
    tplc = K_ARRAY::buildArray3(*fc, unstructVarStringc[0],
                                *cnout, newEltTypec, api);
```

NB: Because of AMR (QuadNQuad conn), duplicated and degenerated elements are not removed in joinAll

<br>

### Topologic regressions

```
Apps            : createDragonMesh_t1.py      
Generator       : getSmoothNormalMapPT_t1.py    
Intersector     : adaptCellsPT_t6.py
Intersector     : xcellnSph6PT_t1.py
Transform       : breakElementsPT_t1.py
Transform       : joinPT_t2.py
Transform       : reorderPT_t1.py  
```

<br>

### Geometric regressions

```   
Generator       : getSmoothNormalMap_t1.py    
Transform       : joinPT_t1.py  
Transform       : join_t1.py
Transform       : join_t6.py
```

#### - Generator/getSmoothNormalMap_t1.py
This is an array test and a similar NGON test in Generator/getSmoothNormalMapPT_t1.py was shown to be geometrically identical. Thus the ref just needs to be updated.

#### - Transform/joinPT_t1.py, ref4

_1 STRUCT et 1 NON-STRUCT QUAD avec champs en centres_
```
Reading Data_ubuntu/joinPT_t1.ref4 (bin_pickle)...done.
DIFF: valeurs differentes pour le noeud: Base/join.4.
DIFF: reference: [[161 181   0]]
DIFF: courant: [[161 136   0]]
DIFF: valeurs differentes pour le noeud: Base/join.4/GridElements/ElementRange.
DIFF: reference: [  1 181]
DIFF: courant: [  1 136]
```

Wrong number of elements in REF (should be 10x10 + 9x4 = 136) – connectivity was not cleaned (see point 3.).
Left and right blocks are overlapping. The overlap was not removed.

<table>
<tr>
<th> Left </th>
<th> Right </th>
<th> Joined </th>
</tr>
<tr>
<td>
<img width="1065" height="763" alt="image" src="https://github.com/user-attachments/assets/9e1f10a8-51f5-42a2-8bfd-c7aeb863036b" />
</td>
<td>
<img width="1065" height="763" alt="image" src="https://github.com/user-attachments/assets/e78bc7fc-dae8-4ea8-9c3f-2b75e468671b" />
</td>
<td>
<img width="1065" height="763" alt="image" src="https://github.com/user-attachments/assets/175f3ecd-ec61-43c9-85e7-465aeef4a4a9" />
</td>
</tr>
</table>

#### - Transform/join_t1.py, ref42

Same as above.

```
Reading 'Data_ubuntu/join_t1.ref42'...done.
Traceback (most recent call last):
  File "/home/vince/git/Cassiopee/Cassiopee/Transform/test/join_t1.py", line 93, in <module>
    test.testA(res,42)
  File "/home/vince/git/Cassiopee/Dist/bin/ubuntu/local/lib/python3.12/dist-packages/KCore/test.py", line 75, in testA
    ret = C.diffArrays(arrays, old,
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vince/git/Cassiopee/Dist/bin/ubuntu/local/lib/python3.12/dist-packages/Converter/Converter.py", line 942, in diffArrays
    return converter.diffArrays(arrays1, arrays2, atol, rtol)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: diff2: grid sizes are different.
```

#### - Transform/join_t6.py, ref21

```
Reading 'Data_ubuntu/join_t6.ref21'...done.
Traceback (most recent call last):
  File "/home/vince/git/Cassiopee/Cassiopee/Transform/test/join_t6.py", line 27, in <module>
    test.testA(res, 21)
  File "/home/vince/git/Cassiopee/Dist/bin/ubuntu/local/lib/python3.12/dist-packages/KCore/test.py", line 75, in testA
    ret = C.diffArrays(arrays, old,
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vince/git/Cassiopee/Dist/bin/ubuntu/local/lib/python3.12/dist-packages/Converter/Converter.py", line 942, in diffArrays
    return converter.diffArrays(arrays1, arrays2, atol, rtol)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: diff2: grid sizes are different.
```

G is not displayed correctly (see point 4.) and there are two zones in the PyTree in REF because of this inconsistency.
```py
ac1 = C.initVars(ac1,'G',2.); ac1 = C.extractVars(ac1,['G'])
ac2 = C.initVars(ac2,'G',1.); ac2 = C.extractVars(ac2,['G'])
```

<table>
<tr>
<th> Ref </th>
<th> Current </th>
</tr>
<tr>
<td>
<img width="1387" height="896" alt="image" src="https://github.com/user-attachments/assets/2e21088a-6192-4383-b17a-f9d11d60abd7" />
</td>
<td>
<img width="1257" height="889" alt="image" src="https://github.com/user-attachments/assets/fd815044-6fe9-45a4-aa53-37e67f3b0f27" />
</td>
</tr>
</table>